### PR TITLE
chore: configure dependabot to use conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary
Configure dependabot to use conventional commit format for dependency updates.

This ensures that dependabot PRs follow the same commit message format as the rest of the project, which is required for release-please to properly categorize changes.

## Changes
- Added `.github/dependabot.yml` configuration
- Set commit message prefix to "chore" for dependency updates
- Configured weekly schedule for npm updates

## Test plan
- After merging, new dependabot PRs should use format like "chore: bump package-name from x.y.z to a.b.c"

🤖 Generated with [Claude Code](https://claude.ai/code)