### PR TITLE
feat: add support for task duration when adding or updating tasks

### DIFF
--- a/src/tool-helpers.test.ts
+++ b/src/tool-helpers.test.ts
@@ -39,6 +39,7 @@ describe('shared utilities', () => {
                 sectionId: null,
                 parentId: null,
                 labels: ['work'],
+                duration: null,
             })
         })
 
@@ -64,6 +65,28 @@ describe('shared utilities', () => {
             const result = mapTask(mockTask)
 
             expect(result.recurring).toBe('every day')
+            expect(result.duration).toBe(null)
+        })
+
+        it('should handle task with duration', () => {
+            const mockTask = {
+                id: '789',
+                content: 'Task with duration',
+                description: '',
+                projectId: 'proj-1',
+                sectionId: null,
+                parentId: null,
+                labels: [],
+                priority: 1,
+                duration: {
+                    amount: 150,
+                    unit: 'minute',
+                },
+            } as unknown as Task
+
+            const result = mapTask(mockTask)
+
+            expect(result.duration).toBe('2h30m')
         })
     })
 

--- a/src/tool-helpers.ts
+++ b/src/tool-helpers.ts
@@ -7,6 +7,7 @@ import {
     getSanitizedContent,
 } from '@doist/todoist-api-typescript'
 import z from 'zod'
+import { formatDuration } from './utils/duration-parser.js'
 
 export type Project = PersonalProject | WorkspaceProject
 
@@ -73,6 +74,7 @@ function mapTask(task: Task) {
         sectionId: task.sectionId,
         parentId: task.parentId,
         labels: task.labels,
+        duration: task.duration ? formatDuration(task.duration.amount) : null,
     }
 }
 

--- a/src/tools/tasks-add-multiple.ts
+++ b/src/tools/tasks-add-multiple.ts
@@ -1,13 +1,20 @@
-import type { Task } from '@doist/todoist-api-typescript'
+import type { AddTaskArgs, Task } from '@doist/todoist-api-typescript'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
 import { mapTask } from '../tool-helpers.js'
+import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
 
 const TaskSchema = z.object({
     content: z.string().min(1).describe('The content of the task to create.'),
     description: z.string().optional().describe('The description of the task.'),
     priority: z.number().int().min(1).max(4).optional().describe('The priority of the task (1-4).'),
     dueString: z.string().optional().describe('The due date for the task, in natural language.'),
+    duration: z
+        .string()
+        .optional()
+        .describe(
+            'The duration of the task. Use format: "2h" (hours), "90m" (minutes), "2h30m" (combined), or "1.5h" (decimal hours). Max 24h.',
+        ),
 })
 
 const ArgsSchema = {
@@ -25,7 +32,27 @@ const tasksAddMultiple = {
         const { projectId, sectionId, parentId, tasks } = args
         const newTasks: Task[] = []
         for (const task of tasks) {
-            const taskArgs = { ...task, projectId, sectionId, parentId }
+            const { duration: durationStr, ...otherTaskArgs } = task
+
+            let taskArgs: AddTaskArgs = { ...otherTaskArgs, projectId, sectionId, parentId }
+
+            // Parse duration if provided
+            if (durationStr) {
+                try {
+                    const { minutes } = parseDuration(durationStr)
+                    taskArgs = {
+                        ...taskArgs,
+                        duration: minutes,
+                        durationUnit: 'minute',
+                    }
+                } catch (error) {
+                    if (error instanceof DurationParseError) {
+                        throw new Error(`Task "${task.content}": ${error.message}`)
+                    }
+                    throw error
+                }
+            }
+
             newTasks.push(await client.addTask(taskArgs))
         }
         return newTasks.map(mapTask)

--- a/src/tools/tasks-update-one.ts
+++ b/src/tools/tasks-update-one.ts
@@ -1,6 +1,8 @@
+import { UpdateTaskArgs } from '@doist/todoist-api-typescript'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
 import { createMoveTaskArgs } from '../tool-helpers.js'
+import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
 
 const ArgsSchema = {
     id: z.string().min(1).describe('The ID of the task to update.'),
@@ -20,6 +22,12 @@ const ArgsSchema = {
         .string()
         .optional()
         .describe("The new due date for the task, in natural language (e.g., 'tomorrow at 5pm')."),
+    duration: z
+        .string()
+        .optional()
+        .describe(
+            'The duration of the task. Use format: "2h" (hours), "90m" (minutes), "2h30m" (combined), or "1.5h" (decimal hours). Max 24h.',
+        ),
 }
 
 const tasksUpdateOne = {
@@ -27,7 +35,33 @@ const tasksUpdateOne = {
     description: 'Update an existing task with new values.',
     parameters: ArgsSchema,
     async execute(args, client) {
-        const { id, projectId, sectionId, parentId, ...updateArgs } = args
+        const {
+            id,
+            projectId,
+            sectionId,
+            parentId,
+            duration: durationStr,
+            ...otherUpdateArgs
+        } = args
+
+        let updateArgs: UpdateTaskArgs = { ...otherUpdateArgs }
+
+        // Parse duration if provided
+        if (durationStr) {
+            try {
+                const { minutes } = parseDuration(durationStr)
+                updateArgs = {
+                    ...updateArgs,
+                    duration: minutes,
+                    durationUnit: 'minute',
+                }
+            } catch (error) {
+                if (error instanceof DurationParseError) {
+                    throw new Error(`Task ${id}: ${error.message}`)
+                }
+                throw error
+            }
+        }
 
         // If no move parameters are provided, use updateTask without moveTasks
         if (!projectId && !sectionId && !parentId) {

--- a/src/tools/test-helpers.ts
+++ b/src/tools/test-helpers.ts
@@ -15,6 +15,7 @@ export type MappedTask = {
     sectionId: string | null
     parentId: string | null
     labels: string[]
+    duration: string | null
 }
 
 /**
@@ -134,6 +135,7 @@ export function createMappedTask(overrides: Partial<MappedTask> = {}): MappedTas
         sectionId: null,
         parentId: null,
         labels: [],
+        duration: null,
         ...overrides,
     }
 }

--- a/src/utils/duration-parser.test.ts
+++ b/src/utils/duration-parser.test.ts
@@ -1,0 +1,174 @@
+import { DurationParseError, formatDuration, parseDuration } from './duration-parser.js'
+
+describe('parseDuration', () => {
+    describe('valid formats', () => {
+        it('should parse hours only', () => {
+            expect(parseDuration('2h')).toEqual({ minutes: 120 })
+            expect(parseDuration('1h')).toEqual({ minutes: 60 })
+            expect(parseDuration('24h')).toEqual({ minutes: 1440 })
+        })
+
+        it('should parse minutes only', () => {
+            expect(parseDuration('90m')).toEqual({ minutes: 90 })
+            expect(parseDuration('45m')).toEqual({ minutes: 45 })
+            expect(parseDuration('1m')).toEqual({ minutes: 1 })
+            expect(parseDuration('1440m')).toEqual({ minutes: 1440 })
+        })
+
+        it('should parse hours and minutes combined', () => {
+            expect(parseDuration('2h30m')).toEqual({ minutes: 150 })
+            expect(parseDuration('1h45m')).toEqual({ minutes: 105 })
+            expect(parseDuration('0h30m')).toEqual({ minutes: 30 })
+            expect(parseDuration('23h59m')).toEqual({ minutes: 1439 })
+        })
+
+        it('should parse decimal hours', () => {
+            expect(parseDuration('1.5h')).toEqual({ minutes: 90 })
+            expect(parseDuration('2.25h')).toEqual({ minutes: 135 })
+            expect(parseDuration('0.5h')).toEqual({ minutes: 30 })
+            expect(parseDuration('0.75h')).toEqual({ minutes: 45 })
+        })
+
+        it('should handle spaces in input', () => {
+            expect(parseDuration('2h 30m')).toEqual({ minutes: 150 })
+            expect(parseDuration(' 1h45m ')).toEqual({ minutes: 105 })
+            expect(parseDuration('  2h  ')).toEqual({ minutes: 120 })
+            expect(parseDuration(' 90m ')).toEqual({ minutes: 90 })
+        })
+
+        it('should handle case insensitive input', () => {
+            expect(parseDuration('2H')).toEqual({ minutes: 120 })
+            expect(parseDuration('90M')).toEqual({ minutes: 90 })
+            expect(parseDuration('2H30M')).toEqual({ minutes: 150 })
+            expect(parseDuration('1.5H')).toEqual({ minutes: 90 })
+        })
+
+        it('should round decimal minutes from decimal hours', () => {
+            expect(parseDuration('1.33h')).toEqual({ minutes: 80 }) // 1.33 * 60 = 79.8 -> 80
+            expect(parseDuration('1.67h')).toEqual({ minutes: 100 }) // 1.67 * 60 = 100.2 -> 100
+        })
+    })
+
+    describe('invalid formats', () => {
+        it('should throw error for empty or null input', () => {
+            expect(() => parseDuration('')).toThrow(DurationParseError)
+            expect(() => parseDuration('   ')).toThrow('Duration must be a non-empty string')
+            // biome-ignore lint/suspicious/noExplicitAny: Testing error cases with invalid types
+            expect(() => parseDuration(null as any)).toThrow('Duration must be a non-empty string')
+            // biome-ignore lint/suspicious/noExplicitAny: Testing error cases with invalid types
+            expect(() => parseDuration(undefined as any)).toThrow(
+                'Duration must be a non-empty string',
+            )
+        })
+
+        it('should throw error for invalid format', () => {
+            expect(() => parseDuration('2')).toThrow(
+                'Use format like "2h", "30m", "2h30m", or "1.5h"',
+            )
+            expect(() => parseDuration('2hours')).toThrow('Use format like')
+            expect(() => parseDuration('2h30')).toThrow('Use format like')
+            expect(() => parseDuration('h30m')).toThrow('Use format like')
+            expect(() => parseDuration('2x30m')).toThrow('Use format like')
+            expect(() => parseDuration('2h30s')).toThrow('Use format like')
+        })
+
+        it('should throw error for decimal minutes', () => {
+            expect(() => parseDuration('90.5m')).toThrow('Minutes must be a whole number')
+            expect(() => parseDuration('1h30.5m')).toThrow('Minutes must be a whole number')
+        })
+
+        it('should throw error for negative values', () => {
+            expect(() => parseDuration('-2h')).toThrow('Use format like')
+            expect(() => parseDuration('-30m')).toThrow('Use format like')
+            expect(() => parseDuration('2h-30m')).toThrow('Use format like')
+        })
+
+        it('should throw error for zero duration', () => {
+            expect(() => parseDuration('0h')).toThrow('Duration must be greater than 0 minutes')
+            expect(() => parseDuration('0m')).toThrow('Duration must be greater than 0 minutes')
+            expect(() => parseDuration('0h0m')).toThrow('Duration must be greater than 0 minutes')
+        })
+
+        it('should throw error for duration exceeding 24 hours', () => {
+            expect(() => parseDuration('25h')).toThrow(
+                'Duration cannot exceed 24 hours (1440 minutes)',
+            )
+            expect(() => parseDuration('1441m')).toThrow(
+                'Duration cannot exceed 24 hours (1440 minutes)',
+            )
+            expect(() => parseDuration('24h1m')).toThrow(
+                'Duration cannot exceed 24 hours (1440 minutes)',
+            )
+            expect(() => parseDuration('24.1h')).toThrow(
+                'Duration cannot exceed 24 hours (1440 minutes)',
+            )
+        })
+
+        it('should throw error for malformed numbers', () => {
+            expect(() => parseDuration('2.h')).toThrow('Hours must be a positive number')
+            expect(() => parseDuration('2h.m')).toThrow('Minutes must be a positive number')
+            expect(() => parseDuration('2..5h')).toThrow('Hours must be a positive number')
+        })
+
+        it('should throw error for duplicate units', () => {
+            expect(() => parseDuration('2h3h')).toThrow('Use format like')
+            expect(() => parseDuration('30m45m')).toThrow('Use format like')
+        })
+    })
+
+    describe('edge cases', () => {
+        it('should handle maximum allowed duration', () => {
+            expect(parseDuration('24h')).toEqual({ minutes: 1440 })
+            expect(parseDuration('1440m')).toEqual({ minutes: 1440 })
+            expect(parseDuration('23h60m')).toEqual({ minutes: 1440 })
+        })
+
+        it('should handle minimum allowed duration', () => {
+            expect(parseDuration('1m')).toEqual({ minutes: 1 })
+            expect(parseDuration('0.017h')).toEqual({ minutes: 1 }) // 0.017 * 60 = 1.02 -> 1
+        })
+    })
+})
+
+describe('formatDuration', () => {
+    it('should format minutes only', () => {
+        expect(formatDuration(45)).toBe('45m')
+        expect(formatDuration(1)).toBe('1m')
+        expect(formatDuration(59)).toBe('59m')
+    })
+
+    it('should format hours only', () => {
+        expect(formatDuration(60)).toBe('1h')
+        expect(formatDuration(120)).toBe('2h')
+        expect(formatDuration(1440)).toBe('24h')
+    })
+
+    it('should format hours and minutes combined', () => {
+        expect(formatDuration(90)).toBe('1h30m')
+        expect(formatDuration(150)).toBe('2h30m')
+        expect(formatDuration(105)).toBe('1h45m')
+        expect(formatDuration(1439)).toBe('23h59m')
+    })
+
+    it('should handle edge cases', () => {
+        expect(formatDuration(0)).toBe('0m')
+        expect(formatDuration(-5)).toBe('0m')
+    })
+})
+
+describe('round trip parsing and formatting', () => {
+    const testCases = [
+        { input: '2h', expectedMinutes: 120, expectedFormat: '2h' },
+        { input: '45m', expectedMinutes: 45, expectedFormat: '45m' },
+        { input: '2h30m', expectedMinutes: 150, expectedFormat: '2h30m' },
+        { input: '1.5h', expectedMinutes: 90, expectedFormat: '1h30m' },
+    ]
+
+    for (const { input, expectedMinutes, expectedFormat } of testCases) {
+        it(`should parse "${input}" and format back consistently`, () => {
+            const parsed = parseDuration(input)
+            expect(parsed.minutes).toBe(expectedMinutes)
+            expect(formatDuration(parsed.minutes)).toBe(expectedFormat)
+        })
+    }
+})

--- a/src/utils/duration-parser.test.ts
+++ b/src/utils/duration-parser.test.ts
@@ -105,14 +105,24 @@ describe('parseDuration', () => {
         })
 
         it('should throw error for malformed numbers', () => {
-            expect(() => parseDuration('2.h')).toThrow('Hours must be a positive number')
-            expect(() => parseDuration('2h.m')).toThrow('Minutes must be a positive number')
-            expect(() => parseDuration('2..5h')).toThrow('Hours must be a positive number')
+            expect(() => parseDuration('2.h')).toThrow('Use format like')
+            expect(() => parseDuration('2h.m')).toThrow('Use format like')
+            expect(() => parseDuration('2..5h')).toThrow('Use format like')
         })
 
         it('should throw error for duplicate units', () => {
             expect(() => parseDuration('2h3h')).toThrow('Use format like')
             expect(() => parseDuration('30m45m')).toThrow('Use format like')
+        })
+
+        it('should throw error for wrong order (minutes before hours)', () => {
+            expect(() => parseDuration('30m2h')).toThrow('Use format like')
+            expect(() => parseDuration('45m1h')).toThrow('Use format like')
+        })
+
+        it('should throw error for invalid mixed formats with correct order', () => {
+            expect(() => parseDuration('2h30m15h')).toThrow('Use format like')
+            expect(() => parseDuration('1h2h30m')).toThrow('Use format like')
         })
     })
 

--- a/src/utils/duration-parser.ts
+++ b/src/utils/duration-parser.ts
@@ -1,0 +1,143 @@
+/**
+ * Duration parser utility for converting human-readable duration strings
+ * to minutes using a restricted, language-neutral syntax.
+ *
+ * Supported formats:
+ * - "2h" (hours only)
+ * - "90m" (minutes only)
+ * - "2h30m" (hours + minutes)
+ * - "1.5h" (decimal hours)
+ * - Supports optional spaces: "2h 30m"
+ */
+
+interface ParsedDuration {
+    minutes: number
+}
+
+export class DurationParseError extends Error {
+    constructor(input: string, reason: string) {
+        super(`Invalid duration format "${input}": ${reason}`)
+        this.name = 'DurationParseError'
+    }
+}
+
+/**
+ * Parses duration string in restricted syntax to minutes.
+ * Max duration: 1440 minutes (24 hours)
+ *
+ * @param durationStr - Duration string like "2h30m", "45m", "1.5h"
+ * @returns Parsed duration in minutes
+ * @throws DurationParseError for invalid formats
+ */
+export function parseDuration(durationStr: string): ParsedDuration {
+    if (!durationStr || typeof durationStr !== 'string') {
+        throw new DurationParseError(durationStr, 'Duration must be a non-empty string')
+    }
+
+    // Remove all spaces and convert to lowercase
+    const normalized = durationStr.trim().toLowerCase().replace(/\s+/g, '')
+
+    // Check for empty string after trimming
+    if (!normalized) {
+        throw new DurationParseError(durationStr, 'Duration must be a non-empty string')
+    }
+
+    // Validate format - must contain only numbers, dots, h, and m
+    if (!/^[\d.]+[hm](?:[\d.]+[hm])?$/.test(normalized)) {
+        throw new DurationParseError(durationStr, 'Use format like "2h", "30m", "2h30m", or "1.5h"')
+    }
+
+    // Check for duplicate units
+    const hCount = (normalized.match(/h/g) || []).length
+    const mCount = (normalized.match(/m/g) || []).length
+    if (hCount > 1 || mCount > 1) {
+        throw new DurationParseError(durationStr, 'Use format like "2h", "30m", "2h30m", or "1.5h"')
+    }
+
+    let totalMinutes = 0
+    let hasHours = false
+    let hasMinutes = false
+
+    // Extract hours if present
+    const hoursMatch = normalized.match(/([\d.]+)h/)
+    if (hoursMatch?.[1]) {
+        const hoursStr = hoursMatch[1]
+        // Check for malformed numbers like "2.", "2..5", or empty
+        if (hoursStr.endsWith('.') || hoursStr === '' || hoursStr.includes('..')) {
+            throw new DurationParseError(durationStr, 'Hours must be a positive number')
+        }
+        const hours = Number.parseFloat(hoursStr)
+        if (Number.isNaN(hours) || hours < 0) {
+            throw new DurationParseError(durationStr, 'Hours must be a positive number')
+        }
+        totalMinutes += hours * 60
+        hasHours = true
+    }
+
+    // Extract minutes if present
+    const minutesMatch = normalized.match(/([\d.]+)m/)
+    if (minutesMatch?.[1]) {
+        const minutesStr = minutesMatch[1]
+        // Check for malformed numbers like "2.", "2..5", or empty
+        if (minutesStr.endsWith('.') || minutesStr === '' || minutesStr.includes('..')) {
+            throw new DurationParseError(durationStr, 'Minutes must be a positive number')
+        }
+        const minutes = Number.parseFloat(minutesStr)
+        if (Number.isNaN(minutes) || minutes < 0) {
+            throw new DurationParseError(durationStr, 'Minutes must be a positive number')
+        }
+        // Don't allow decimal minutes
+        if (minutes % 1 !== 0) {
+            throw new DurationParseError(
+                durationStr,
+                'Minutes must be a whole number (use decimal hours instead)',
+            )
+        }
+        totalMinutes += minutes
+        hasMinutes = true
+    }
+
+    // Must have at least hours or minutes
+    if (!hasHours && !hasMinutes) {
+        throw new DurationParseError(durationStr, 'Must specify at least hours (h) or minutes (m)')
+    }
+
+    // Round to nearest minute (handles decimal hours)
+    totalMinutes = Math.round(totalMinutes)
+
+    // Validate minimum duration
+    if (totalMinutes === 0) {
+        throw new DurationParseError(durationStr, 'Duration must be greater than 0 minutes')
+    }
+
+    // Validate maximum duration (24 hours = 1440 minutes)
+    if (totalMinutes > 1440) {
+        throw new DurationParseError(durationStr, 'Duration cannot exceed 24 hours (1440 minutes)')
+    }
+
+    return { minutes: totalMinutes }
+}
+
+/**
+ * Formats minutes back to a human-readable duration string.
+ * Used when returning task data to LLMs.
+ *
+ * @param minutes - Duration in minutes
+ * @returns Formatted duration string like "2h30m" or "45m"
+ */
+export function formatDuration(minutes: number): string {
+    if (minutes <= 0) return '0m'
+
+    const hours = Math.floor(minutes / 60)
+    const remainingMinutes = minutes % 60
+
+    if (hours === 0) {
+        return `${remainingMinutes}m`
+    }
+
+    if (remainingMinutes === 0) {
+        return `${hours}h`
+    }
+
+    return `${hours}h${remainingMinutes}m`
+}


### PR DESCRIPTION
Closes #27 

## Short description

It follows a similar approach to the proposed solution in https://github.com/Doist/todoist-ai/issues/27#issuecomment-3190219489, but with an improvement on top of it that allows the LLM to pass a more LLM/human readable duration in string form (e.g. `2h30`, `1h`, `1.5h`, `45m`, etc.) and this value is parsed internally and converted to a raw minutes number to be passed to the API.

## PR Checklist

-   [x] Added tests for bugs / new features
-   [ ] Updated docs (README, etc.)
