### PR TITLE
feat: Add npx support for MCP server usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ const result = streamText({
 
 ## Using as an MCP server
 
-For convenience, we already include a function that initializes an MCP Server with all the tools available:
+You can run the MCP server directly with npx:
+
+```bash
+npx @doist/todoist-ai
+```
+
+For convenience, we also include a function that initializes an MCP Server with all the tools available:
 
 ```js
 import { getMcpServer } from "@doist/todoist-ai";

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -2,6 +2,18 @@
 
 This document outlines the steps necessary to run this MCP server and connect to an MCP host application, such as Claude Desktop or Cursor.
 
+## Quick Setup
+
+The easiest way to use this MCP server is with npx:
+
+```bash
+npx @doist/todoist-ai
+```
+
+You'll need to set your Todoist API key as an environment variable `TODOIST_API_KEY`.
+
+## Local Development Setup
+
 Start by cloning this repository and setting it up locally, if you haven't done so yet.
 
 ```sh
@@ -20,6 +32,27 @@ This will build the project and run the MCP inspector for manual testing.
 Then, proceed depending on the MCP protocol transport you'll use.
 
 ## Using Standard I/O Transport
+
+### Quick Setup with npx
+
+Add this section to your `mcp.json` config in Claude, Cursor, etc.:
+
+```json
+{
+    "mcpServers": {
+        "todoist-ai": {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["@doist/todoist-ai"],
+            "env": {
+                "TODOIST_API_KEY": "your-todoist-token-here"
+            }
+        }
+    }
+}
+```
+
+### Using local installation
 
 Add this `todoist-ai-tools` section to your `mcp.json` config in Cursor, Claude, Raycast, etc.
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
+    "bin": "./dist/main.js",
     "files": [
         "dist",
         "scripts",
@@ -25,6 +26,7 @@
     "scripts": {
         "test": "jest",
         "build": "rimraf dist && npx tsc --project tsconfig.json",
+        "postbuild": "chmod +x dist/main.js",
         "start": "npm run build && npx @modelcontextprotocol/inspector node dist/main.js",
         "dev": "concurrently \"npx tsc --watch\" \"nodemon --watch dist --ext js --exec 'npx @modelcontextprotocol/inspector node dist/main.js'\"",
         "setup": "cp .env.example .env && npm install && npm run build",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import dotenv from 'dotenv'
 import { getMcpServer } from './mcp-server.js'


### PR DESCRIPTION
First I want to say thanks for making this! I am a long time Todoist user and using this today with Claude Code was awesome.

## Short description

This just makes it a little easier to run the MCP server. You can just do `npx @doist/todoist-ai` and it should all work.

It was hard to fully test this locally, but it works with `npx .`

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [ ] Added tests for bugs / new features 
-   [x] Updated docs (README, etc.)