### PR TITLE
fix: implement workflow_dispatch trigger for reliable publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*"
+  # triggered by `release-please.yml`
+  workflow_dispatch:
 
 permissions:
   # Enable the use of OIDC for npm provenance
@@ -12,8 +14,8 @@ permissions:
 
 jobs:
   publish:
-    # Only run if release-please created a release
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    # Allow both tag pushes and workflow_dispatch events
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     # Based on historical data
     timeout-minutes: 60

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,10 +9,13 @@ permissions:
     contents: write
     pull-requests: write
     issues: write
+    actions: write
 
 jobs:
     release-please:
         runs-on: ubuntu-latest
+        outputs:
+            release_created: ${{ steps.release.outputs.release_created }}
         steps:
             - uses: googleapis/release-please-action@v4
               id: release
@@ -21,3 +24,17 @@ jobs:
                   release-type: node
                   config-file: .github/release-please-config.json
                   manifest-file: .github/release-please-manifest.json
+
+            - name: Trigger publish workflow
+              if: ${{ steps.release.outputs.release_created }}
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      console.log('Release created, triggering publish workflow');
+                      await github.rest.actions.createWorkflowDispatch({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          workflow_id: 'publish.yml',
+                          ref: 'main'
+                      });
+                      console.log('Successfully triggered publish.yml');


### PR DESCRIPTION
## Summary
- Implement Reactist-style workflow dispatch triggering to eliminate manual re-tagging requirement
- Add direct workflow triggering when Release-Please creates releases
- Use `workflow_dispatch` instead of unreliable tag webhook events

## Problem Solved
Fixes the systematic issue where Release-Please creates releases but the publish workflow fails to trigger automatically, requiring manual re-tagging of every release (as documented in issue #35).

## Key Changes
- **release-please.yml**: Add `workflow_dispatch` triggering when `release_created` is true
- **publish.yml**: Support both tag pushes and `workflow_dispatch` events
- **Eliminates webhook timing issues**: Direct API call within same workflow context

## Approach Based on Doist/reactist
This implementation mirrors the proven approach used in the Reactist repository, which doesn't experience the same publishing failures.

## Testing
- [x] Workflow files updated with proper syntax
- [x] Permissions added for `actions: write`
- [x] Conditional triggering only when releases are actually created
- [ ] End-to-end test with actual release creation

## References
- Fixes #35
- Based on successful implementation in Doist/reactist repository

🤖 Generated with [Claude Code](https://claude.ai/code)