### PR TITLE
feat: Improve tool output UX with LLM-readable responses

### DIFF
--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -3,13 +3,47 @@ import type { McpServer, ToolCallback } from '@modelcontextprotocol/sdk/server/m
 import type { ZodTypeAny, z } from 'zod'
 import type { TodoistTool } from './todoist-tool.js'
 
+/**
+ * Wether to return the structured content directly, vs. in the `content` part of the output.
+ *
+ * The `structuredContent` part of the output is relatively new in the spec, and it's not yet
+ * supported by all clients. This flag controls wether we return the structured content using this
+ * new feature of the MCP protocol or not.
+ *
+ * If `false`, the `structuredContent` will be returned as stringified JSON in one of the `content`
+ * parts.
+ *
+ * Eventually we should be able to remove this, and change the code to always work with the
+ * structured content returned directly, once most or all MCP clients support it.
+ */
+const USE_STRUCTURED_CONTENT =
+    process.env.USE_STRUCTURED_CONTENT === 'true' || process.env.NODE_ENV === 'test'
+
+/**
+ * Get the output payload for a tool, in the correct format expected by MCP client apps.
+ *
+ * @param textContent - The text content to return.
+ * @param structuredContent - The structured content to return.
+ * @returns The output payload.
+ * @see USE_STRUCTURED_CONTENT - Wether to use the structured content feature of the MCP protocol.
+ */
 function getToolOutput<StructuredContent extends Record<string, unknown>>({
     textContent,
     structuredContent,
 }: { textContent: string; structuredContent: StructuredContent }) {
+    if (USE_STRUCTURED_CONTENT) {
+        return {
+            content: [{ type: 'text' as const, text: textContent }],
+            structuredContent,
+        }
+    }
+
+    const json = JSON.stringify(structuredContent)
     return {
-        content: [{ type: 'text' as const, text: textContent }],
-        structuredContent,
+        content: [
+            { type: 'text' as const, text: textContent },
+            { type: 'text' as const, mimeType: 'application/json', text: json },
+        ],
     }
 }
 
@@ -37,7 +71,8 @@ function registerTool<Params extends z.ZodRawShape>(
         _context,
     ) => {
         try {
-            return await tool.execute(args as z.infer<z.ZodObject<Params>>, client)
+            const result = await tool.execute(args as z.infer<z.ZodObject<Params>>, client)
+            return result
         } catch (error) {
             console.error(`Error executing tool ${tool.name}:`, {
                 args,

--- a/src/tools/__tests__/__snapshots__/delete-one.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/delete-one.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`delete-one tool deleting projects should delete a project by ID 1`] = `
+"Deleted project: id=6cfCcrrCFg2xP94Q
+Next:
+- Use projects-list to see remaining projects
+- Note: All tasks and sections in this project were also deleted
+- Use overview to review your updated project structure"
+`;
+
+exports[`delete-one tool deleting sections should delete a section by ID 1`] = `
+"Deleted section: id=section-123
+Next:
+- Use sections-search to see remaining sections in the project
+- Note: Tasks in this section were also deleted
+- Use tasks-list-for-container with type=project to see unorganized tasks"
+`;
+
+exports[`delete-one tool deleting tasks should delete a task by ID 1`] = `
+"Deleted task: id=8485093748
+Next:
+- Use tasks-list-by-date to see remaining tasks for today
+- Use overview to check if this affects any dependent tasks
+- Note: Any subtasks of this task were also deleted"
+`;

--- a/src/tools/__tests__/__snapshots__/projects-list.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/projects-list.test.ts.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`projects-list tool listing all projects should handle pagination with limit and cursor 1`] = `
+"Projects: 1 (limit 10), more available.
+Preview:
+    First Project • id=project-1
+Next:
+- Use tasks-list-for-container with projectId to see tasks in specific projects.
+- Pass cursor 'next-page-cursor' to fetch more results."
+`;
+
+exports[`projects-list tool listing all projects should list all projects when no search parameter is provided 1`] = `
+"Projects: 3 (limit 50).
+Preview:
+    Inbox • Inbox • id=inbox-project-id
+    test-abc123def456-project • id=6cfCcrrCFg2xP94Q
+    Work Project • ⭐ • Shared • board • id=work-project-id
+Next:
+- Use tasks-list-for-container with projectId to see tasks in specific projects.
+- Favorite projects appear first in most Todoist views."
+`;
+
+exports[`projects-list tool searching projects should filter projects by search term (case insensitive) 1`] = `
+"Projects matching "work": 2 (limit 50).
+Filter: search: "work".
+Preview:
+    Work Project • id=work-project-id
+    Hobby Work • id=hobby-project-id
+Next:
+- Use tasks-list-for-container with projectId to see tasks in specific projects."
+`;
+
+exports[`projects-list tool searching projects should handle search with case insensitive matching 1`] = `
+"Projects matching "IMPORTANT": 1 (limit 50).
+Filter: search: "IMPORTANT".
+Preview:
+    Important Project • id=6cfCcrrCFg2xP94Q
+Next:
+- Use tasks-list-for-container with projectId to see tasks in specific projects."
+`;
+
+exports[`projects-list tool searching projects should handle search with no matches 1`] = `
+"Projects matching "nonexistent": 0 (limit 50).
+Filter: search: "nonexistent".
+No results. Try broader search terms; Check spelling; Remove search to see all projects."
+`;

--- a/src/tools/__tests__/__snapshots__/projects-manage.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/projects-manage.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`projects-manage tool creating a new project should create a project and return mapped result 1`] = `
+"Created project: test-abc123def456-project • id=6cfCcrrCFg2xP94Q
+Next:
+- Use sections-manage to organize this project with sections
+- Use tasks-add-multiple to add your first tasks
+- Use overview with projectId to see updated project structure."
+`;
+
+exports[`projects-manage tool creating a new project should handle different project properties from API 1`] = `
+"Created project: My Blue Project • id=project-456
+Next:
+- Use sections-manage to organize this project with sections
+- Use tasks-add-multiple to add your first tasks
+- Use overview with projectId to see updated project structure."
+`;
+
+exports[`projects-manage tool updating an existing project should update a project when id is provided 1`] = `
+"Updated project: Updated Project Name • id=existing-project-123
+Next:
+- Use overview with projectId=existing-project-123 to see project structure
+- Use projects-list to see all projects with updated name
+- Use tasks-list-for-container to review existing tasks"
+`;

--- a/src/tools/__tests__/__snapshots__/sections-manage.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/sections-manage.test.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`sections-manage tool creating a new section should create a section and return result 1`] = `
+"Created section: test-abc123def456-section • id=section-123
+Next:
+- Use tasks-add-multiple with sectionId=section-123 to add your first tasks
+- Use tasks-list-for-container with type=section and id=section-123 to verify setup
+- Use overview with projectId=6cfCcrrCFg2xP94Q to see project organization"
+`;
+
+exports[`sections-manage tool creating a new section should handle different section properties from API 1`] = `
+"Created section: My Section Name • id=section-456
+Next:
+- Use tasks-add-multiple with sectionId=section-456 to add your first tasks
+- Use tasks-list-for-container with type=section and id=section-456 to verify setup
+- Use overview with projectId=project-789 to see project organization"
+`;
+
+exports[`sections-manage tool updating an existing section should update a section when id is provided 1`] = `
+"Updated section: Updated Section Name • id=existing-section-123
+Next:
+- Use tasks-list-for-container with type=section and id=existing-section-123 to see existing tasks
+- Use sections-search to see all sections in this project
+- Consider updating task descriptions if section purpose changed"
+`;
+
+exports[`sections-manage tool updating an existing section should update section without requiring projectId 1`] = `
+"Updated section: Section New Name • id=section-update-test
+Next:
+- Use tasks-list-for-container with type=section and id=section-update-test to see existing tasks
+- Use sections-search to see all sections in this project
+- Consider updating task descriptions if section purpose changed"
+`;

--- a/src/tools/__tests__/__snapshots__/sections-search.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/sections-search.test.ts.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`sections-search tool listing all sections in a project should handle project with no sections 1`] = `
+"Sections in project empty-project-id: 0.
+No results. Project has no sections yet; Use sections-manage to create sections."
+`;
+
+exports[`sections-search tool listing all sections in a project should list all sections when no search parameter is provided 1`] = `
+"Sections in project 6cfCcrrCFg2xP94Q: 4.
+Preview:
+    To Do • id=section-123
+    In Progress • id=section-456
+    Done • id=section-789
+    Backlog Items • id=section-999
+Next:
+- Use tasks-list-for-container with type=section to see tasks in any section
+- Use sections-manage to modify section names or order"
+`;
+
+exports[`sections-search tool searching sections by name should filter sections by search term (case insensitive) 1`] = `
+"Sections in project 6cfCcrrCFg2xP94Q matching "progress": 2.
+Preview:
+    In Progress • id=section-456
+    Progress Review • id=section-999
+Next:
+- Use tasks-list-for-container with type=section to see tasks in any section
+- Use sections-manage to modify section names or order
+- Remove search parameter to see all sections in this project"
+`;
+
+exports[`sections-search tool searching sections by name should handle case sensitive search correctly 1`] = `
+"Sections in project 6cfCcrrCFg2xP94Q matching "IMPORTANT": 1.
+Preview:
+    Important Tasks • id=section-123
+Next:
+- Use tasks-list-for-container with type=section and id=section-123 to see tasks
+- Use sections-manage to create additional sections for organization
+- Remove search parameter to see all sections in this project"
+`;
+
+exports[`sections-search tool searching sections by name should handle exact matches 1`] = `
+"Sections in project 6cfCcrrCFg2xP94Q matching "done": 2.
+Preview:
+    Done • id=section-123
+    Done Soon • id=section-456
+Next:
+- Use tasks-list-for-container with type=section to see tasks in any section
+- Use sections-manage to modify section names or order
+- Remove search parameter to see all sections in this project"
+`;
+
+exports[`sections-search tool searching sections by name should handle partial matches correctly 1`] = `
+"Sections in project 6cfCcrrCFg2xP94Q matching "task": 2.
+Preview:
+    Development Tasks • id=section-123
+    Testing Tasks • id=section-456
+Next:
+- Use tasks-list-for-container with type=section to see tasks in any section
+- Use sections-manage to modify section names or order
+- Remove search parameter to see all sections in this project"
+`;
+
+exports[`sections-search tool searching sections by name should handle search with no matches 1`] = `
+"Sections in project 6cfCcrrCFg2xP94Q matching "nonexistent": 0.
+No results. Try broader search terms; Check spelling; Remove search to see all sections."
+`;

--- a/src/tools/__tests__/__snapshots__/tasks-add-multiple.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/tasks-add-multiple.test.ts.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`tasks-add-multiple tool adding multiple tasks should add multiple tasks and return mapped results 1`] = `
+"Added 2 tasks to specified project.
+Tasks:
+    First task content • P1 • id=8485093748
+    Second task content • due 2025-08-15 • P2 • id=8485093749.
+Next:
+- Use overview to see your updated project organization"
+`;
+
+exports[`tasks-add-multiple tool adding multiple tasks should add tasks with duration 1`] = `
+"Added 2 tasks to specified project.
+Tasks:
+    Task with 2 hour duration • P1 • id=8485093752
+    Task with 45 minute duration • P1 • id=8485093753.
+Next:
+- Use overview to see your updated project organization"
+`;
+
+exports[`tasks-add-multiple tool adding multiple tasks should handle tasks with section and parent IDs 1`] = `
+"Added 1 task to specified project.
+Tasks:
+    Subtask content • P3 • id=8485093750.
+Next:
+- Use overview to see your updated project organization"
+`;
+
+exports[`tasks-add-multiple tool next steps logic should suggest overview tool when no hasToday context 1`] = `
+"Added 1 task to specified project.
+Tasks:
+    Regular task • P1 • id=8485093756.
+Next:
+- Use overview to see your updated project organization"
+`;
+
+exports[`tasks-add-multiple tool next steps logic should suggest tasks-list-by-date for today when hasToday is true 1`] = `
+"Added 1 task.
+Tasks:
+    Task due today • due 2025-08-17 • P1 • id=8485093755.
+Next:
+- Use overview to see your updated project organization"
+`;

--- a/src/tools/__tests__/__snapshots__/tasks-complete-multiple.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/tasks-complete-multiple.test.ts.snap
@@ -1,0 +1,141 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`tasks-complete-multiple tool completing multiple tasks should complete all tasks successfully 1`] = `
+"Completed tasks: 3/3 successful.
+Completed:
+    task-1
+    task-2
+    task-3.
+Next:
+- Use tasks-list-by-date('overdue') to tackle remaining overdue items."
+`;
+
+exports[`tasks-complete-multiple tool completing multiple tasks should complete single task 1`] = `
+"Completed tasks: 1/1 successful.
+Completed:
+    8485093748.
+Next:
+- Use tasks-list-by-date('overdue') to tackle remaining overdue items."
+`;
+
+exports[`tasks-complete-multiple tool completing multiple tasks should continue processing remaining tasks after failures 1`] = `
+"Completed tasks: 2/5 successful.
+Completed:
+    task-3
+    task-5.
+Failed (3):
+    task-1 (Error: Task already completed)
+    task-2 (Error: Task not found)
+    task-4 (Error: Permission denied).
+Next:
+- Review failed completions and retry if needed."
+`;
+
+exports[`tasks-complete-multiple tool completing multiple tasks should handle all tasks failing 1`] = `
+"Completed tasks: 0/2 successful.
+Failed (2):
+    task-1 (Error: API Error: Network timeout)
+    task-2 (Error: API Error: Network timeout).
+Next:
+- Check task IDs and permissions, then retry."
+`;
+
+exports[`tasks-complete-multiple tool completing multiple tasks should handle different types of API errors 1`] = `
+"Completed tasks: 0/4 successful.
+Failed (4):
+    not-found (Error: Task not found)
+    already-done (Error: Task already completed)
+    no-permission (Error: Permission denied), +1 more.
+Next:
+- Check task IDs and permissions, then retry."
+`;
+
+exports[`tasks-complete-multiple tool completing multiple tasks should handle partial failures gracefully 1`] = `
+"Completed tasks: 2/3 successful.
+Completed:
+    task-1
+    task-3.
+Failed (1):
+    task-2 (Error: Task not found).
+Next:
+- Review failed completions and retry if needed."
+`;
+
+exports[`tasks-complete-multiple tool edge cases should handle empty task completion (minimum one task required by schema) 1`] = `
+"Completed tasks: 1/1 successful.
+Completed:
+    single-task.
+Next:
+- Use tasks-list-by-date('overdue') to tackle remaining overdue items."
+`;
+
+exports[`tasks-complete-multiple tool edge cases should handle tasks with special ID formats 1`] = `
+"Completed tasks: 3/3 successful.
+Completed:
+    proj_123_task_456
+    task-with-dashes
+    1234567890.
+Next:
+- Use tasks-list-by-date('overdue') to tackle remaining overdue items."
+`;
+
+exports[`tasks-complete-multiple tool error message truncation should not show truncation message for exactly 3 errors 1`] = `
+"Completed tasks: 0/3 successful.
+Failed (3):
+    task-1 (Error: Error 1)
+    task-2 (Error: Error 2)
+    task-3 (Error: Error 3).
+Next:
+- Check task IDs and permissions, then retry."
+`;
+
+exports[`tasks-complete-multiple tool error message truncation should truncate failure messages after 3 errors 1`] = `
+"Completed tasks: 0/5 successful.
+Failed (5):
+    task-1 (Error: Error 1)
+    task-2 (Error: Error 2)
+    task-3 (Error: Error 3), +2 more.
+Next:
+- Check task IDs and permissions, then retry."
+`;
+
+exports[`tasks-complete-multiple tool mixed success and failure scenarios should handle realistic mixed scenario 1`] = `
+"Completed tasks: 3/5 successful.
+Completed:
+    8485093748
+    8485093749
+    8485093751.
+Failed (2):
+    8485093750 (Error: Task already completed)
+    8485093752 (Error: Task not found).
+Next:
+- Review failed completions and retry if needed."
+`;
+
+exports[`tasks-complete-multiple tool next steps logic validation should suggest checking IDs when all tasks fail 1`] = `
+"Completed tasks: 0/2 successful.
+Failed (2):
+    bad-id-1 (Error: Task not found)
+    bad-id-2 (Error: Task not found).
+Next:
+- Check task IDs and permissions, then retry."
+`;
+
+exports[`tasks-complete-multiple tool next steps logic validation should suggest overdue tasks when all tasks complete successfully 1`] = `
+"Completed tasks: 2/2 successful.
+Completed:
+    task-1
+    task-2.
+Next:
+- Use tasks-list-by-date('overdue') to tackle remaining overdue items."
+`;
+
+exports[`tasks-complete-multiple tool next steps logic validation should suggest reviewing failures when mixed results 1`] = `
+"Completed tasks: 1/2 successful.
+Completed:
+    task-1.
+Failed (1):
+    task-2 (Error: Task not found).
+Next:
+- Review failed completions and retry if needed."
+`;

--- a/src/tools/__tests__/__snapshots__/tasks-list-by-date.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/tasks-list-by-date.test.ts.snap
@@ -43,6 +43,7 @@ Preview:
 Next:
 - Use tasks-update-multiple to modify priorities or due dates
 - Use tasks-complete-multiple to mark finished tasks
+- Focus on overdue items first to get back on track
 - Pass cursor 'next-page-cursor' to fetch more results."
 `;
 
@@ -53,7 +54,8 @@ Preview:
     Specific date task • due 2025-08-20 • P1 • id=8485093748
 Next:
 - Use tasks-update-multiple to modify priorities or due dates
-- Use tasks-complete-multiple to mark finished tasks"
+- Use tasks-complete-multiple to mark finished tasks
+- Focus on overdue items first to get back on track"
 `;
 
 exports[`tasks-list-by-date tool next steps logic should provide helpful suggestions for empty date range results 1`] = `

--- a/src/tools/__tests__/__snapshots__/tasks-list-by-date.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/tasks-list-by-date.test.ts.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`tasks-list-by-date tool edge cases should handle empty results 1`] = `
+"Today's tasks: 0 (limit 50).
+Filter: today + 6 more days.
+No results. Expand date range with larger 'daysCount'; Check 'overdue' for past-due items."
+`;
+
+exports[`tasks-list-by-date tool listing overdue tasks should handle overdue tasks ignoring daysCount 1`] = `
+"Overdue tasks: 0 (limit 50).
+Filter: overdue tasks only.
+No results. Great job! No overdue tasks; Check today's tasks with startDate='today'."
+`;
+
+exports[`tasks-list-by-date tool listing overdue tasks should handle overdue tasks with tasks 1`] = `
+"Overdue tasks: 1 (limit 50).
+Filter: overdue tasks only.
+Preview:
+    Overdue task • due 2025-08-10 • P2 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks
+- Focus on overdue items first to get back on track"
+`;
+
+exports[`tasks-list-by-date tool listing tasks by date range should get tasks for today when startDate is "today" 1`] = `
+"Today's tasks: 1 (limit 50).
+Filter: today + 6 more days.
+Preview:
+    Today task • due 2025-08-15 • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks
+- Focus on overdue items first to get back on track"
+`;
+
+exports[`tasks-list-by-date tool listing tasks by date range should handle multiple days with pagination 1`] = `
+"Tasks for 2025-08-20: 2 (limit 20), more available.
+Filter: 2025-08-20 to 2025-08-16.
+Preview:
+    Multi-day task 1 • due 2025-08-20 • P1 • id=8485093749
+    Multi-day task 2 • due 2025-08-21 • P1 • id=8485093750
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks
+- Pass cursor 'next-page-cursor' to fetch more results."
+`;
+
+exports[`tasks-list-by-date tool listing tasks by date range should handle specific date 1`] = `
+"Tasks for 2025-08-20: 1 (limit 50).
+Filter: 2025-08-20 to 2025-08-16.
+Preview:
+    Specific date task • due 2025-08-20 • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks"
+`;
+
+exports[`tasks-list-by-date tool next steps logic should provide helpful suggestions for empty date range results 1`] = `
+"Tasks for 2025-08-20: 0 (limit 10).
+Filter: 2025-08-20.
+No results. Expand date range with larger 'daysCount'; Check 'overdue' for past-due items."
+`;
+
+exports[`tasks-list-by-date tool next steps logic should provide helpful suggestions for empty overdue results 1`] = `
+"Overdue tasks: 0 (limit 10).
+Filter: overdue tasks only.
+No results. Great job! No overdue tasks; Check today's tasks with startDate='today'."
+`;
+
+exports[`tasks-list-by-date tool next steps logic should suggest appropriate actions when hasOverdue is true 1`] = `
+"Tasks for 2025-08-15: 1 (limit 10).
+Filter: 2025-08-15.
+Preview:
+    Overdue task from list • due 2025-08-10 • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks
+- Focus on overdue items first to get back on track"
+`;
+
+exports[`tasks-list-by-date tool next steps logic should suggest appropriate actions when startDate is overdue 1`] = `
+"Overdue tasks: 1 (limit 10).
+Filter: overdue tasks only.
+Preview:
+    Overdue task • due 2025-08-10 • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks
+- Focus on overdue items first to get back on track"
+`;
+
+exports[`tasks-list-by-date tool next steps logic should suggest today-focused actions when startDate is today 1`] = `
+"Today's tasks: 1 (limit 10).
+Filter: today.
+Preview:
+    Today's task • due 2025-08-15 • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks
+- Focus on overdue items first to get back on track"
+`;

--- a/src/tools/__tests__/__snapshots__/tasks-list-completed.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/tasks-list-completed.test.ts.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`tasks-list-completed tool getting completed tasks by completion date (default) should get completed tasks by completion date 1`] = `
+"Completed tasks (by completed date): 1 (limit 50).
+Filter: completed date: 2025-08-10 to 2025-08-15.
+Preview:
+    Completed task 1 • due 2025-08-14 • P2 • id=8485093748
+Next:
+- Use tasks-list-by-date for active tasks or overview for current productivity."
+`;
+
+exports[`tasks-list-completed tool getting completed tasks by completion date (default) should handle explicit completion date query 1`] = `
+"Completed tasks (by completed date): 0 (limit 100), more available.
+Filter: completed date: 2025-08-01 to 2025-08-31; project: specific-project-id.
+No results. No tasks completed in this date range; Try expanding the date range; Try removing project/section/parent filters.
+Next:
+- Pass cursor 'next-cursor' to fetch more results."
+`;
+
+exports[`tasks-list-completed tool getting completed tasks by due date should get completed tasks by due date 1`] = `
+"Completed tasks (by due date): 1 (limit 50).
+Filter: due date: 2025-08-10 to 2025-08-20.
+Preview:
+    Task completed by due date • due 2025-08-15 • P3 • id=8485093750
+Next:
+- Use tasks-list-by-date for active tasks or overview for current productivity.
+- Recurring tasks will automatically create new instances."
+`;

--- a/src/tools/__tests__/__snapshots__/tasks-list-for-container.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/tasks-list-for-container.test.ts.snap
@@ -1,0 +1,124 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`tasks-list-for-container tool container types should get tasks for parent task 1`] = `
+"Subtasks: 1 (limit 10).
+Filter: subtasks of 8485093748.
+Preview:
+    Subtask • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks"
+`;
+
+exports[`tasks-list-for-container tool container types should get tasks for project 1`] = `
+"Tasks in project: 1 (limit 10).
+Filter: in project 6cfCcrrCFg2xP94Q.
+Preview:
+    Project task • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks"
+`;
+
+exports[`tasks-list-for-container tool container types should get tasks for section 1`] = `
+"Tasks in section: 1 (limit 10).
+Filter: in section section-123.
+Preview:
+    Section task • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks"
+`;
+
+exports[`tasks-list-for-container tool getting subtasks for a parent task should get subtasks for a specific parent task 1`] = `
+"Subtasks: 2 (limit 10).
+Filter: subtasks of parent-task-123.
+Preview:
+    Subtask 1 • P1 • id=8485093752
+    Subtask 2 • due 2025-08-18 • P2 • id=8485093753
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks
+- Focus on overdue items first to get back on track"
+`;
+
+exports[`tasks-list-for-container tool getting subtasks for a parent task should handle parent task with no subtasks 1`] = `
+"Subtasks: 0 (limit 10).
+Filter: subtasks of parent-with-no-subtasks.
+No results. No subtasks created yet; Use tasks-add-multiple with parentId to add subtasks."
+`;
+
+exports[`tasks-list-for-container tool getting tasks for a section should get tasks for a specific section 1`] = `
+"Tasks in section: 1 (limit 15).
+Filter: in section section-123.
+Preview:
+    Section task 1 • due 2025-08-16 • P3 • id=8485093751
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks
+- Focus on overdue items first to get back on track"
+`;
+
+exports[`tasks-list-for-container tool getting tasks for a section should handle empty section 1`] = `
+"Tasks in section: 0 (limit 10).
+Filter: in section empty-section-id.
+No results. Section is empty; Tasks may be in other sections of the project."
+`;
+
+exports[`tasks-list-for-container tool next steps logic should provide standard next steps for regular tasks 1`] = `
+"Subtasks: 1 (limit 10).
+Filter: subtasks of parent-with-regular.
+Preview:
+    Regular future task • due 2025-08-25 • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks"
+`;
+
+exports[`tasks-list-for-container tool next steps logic should suggest appropriate actions when hasOverdue is true 1`] = `
+"Tasks in project: 1 (limit 10).
+Filter: in project project-with-overdue.
+Preview:
+    Overdue task in container • due 2025-08-10 • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks
+- Focus on overdue items first to get back on track"
+`;
+
+exports[`tasks-list-for-container tool next steps logic should suggest appropriate actions when hasToday is true 1`] = `
+"Tasks in section: 1 (limit 10).
+Filter: in section section-with-today.
+Preview:
+    Task due today in container • due 2025-08-17 • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks
+- Focus on overdue items first to get back on track"
+`;
+
+exports[`tasks-list-for-container tool pagination and limits should handle custom limit and cursor 1`] = `
+"Tasks in section: 0 (limit 25), more available.
+Filter: in section test-section.
+No results. Section is empty; Tasks may be in other sections of the project.
+Next:
+- Pass cursor 'next-cursor' to fetch more results."
+`;
+
+exports[`tasks-list-for-container tool zero reason hints for each container type should provide parent-specific hints for tasks with no subtasks 1`] = `
+"Subtasks: 0 (limit 10).
+Filter: subtasks of task-no-subtasks.
+No results. No subtasks created yet; Use tasks-add-multiple with parentId to add subtasks."
+`;
+
+exports[`tasks-list-for-container tool zero reason hints for each container type should provide project-specific hints for empty projects 1`] = `
+"Tasks in project: 0 (limit 10).
+Filter: in project empty-project.
+No results. Project has no tasks yet; Use tasks-add-multiple to create tasks."
+`;
+
+exports[`tasks-list-for-container tool zero reason hints for each container type should provide section-specific hints for empty sections 1`] = `
+"Tasks in section: 0 (limit 10).
+Filter: in section empty-section.
+No results. Section is empty; Tasks may be in other sections of the project."
+`;

--- a/src/tools/__tests__/__snapshots__/tasks-search.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/tasks-search.test.ts.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`tasks-search tool next steps logic should provide different next steps for regular tasks 1`] = `
+"Search results for "future tasks": 1 (limit 10).
+Filter: matching "future tasks".
+Preview:
+    Regular future task • due 2025-08-25 • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks"
+`;
+
+exports[`tasks-search tool next steps logic should provide helpful suggestions for empty search results 1`] = `
+"Search results for "nonexistent": 0 (limit 10).
+Filter: matching "nonexistent".
+No results. Try broader search terms; Check completed tasks with tasks-list-completed; Verify spelling and try partial words."
+`;
+
+exports[`tasks-search tool next steps logic should suggest different actions when hasOverdue is true 1`] = `
+"Search results for "overdue tasks": 1 (limit 10).
+Filter: matching "overdue tasks".
+Preview:
+    Overdue search result • due 2025-08-10 • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks
+- Focus on overdue items first to get back on track"
+`;
+
+exports[`tasks-search tool next steps logic should suggest today tasks when hasToday is true 1`] = `
+"Search results for "today tasks": 1 (limit 10).
+Filter: matching "today tasks".
+Preview:
+    Task due today • due 2025-08-17 • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks
+- Focus on overdue items first to get back on track"
+`;
+
+exports[`tasks-search tool searching tasks should handle custom limit 1`] = `
+"Search results for "project update": 1 (limit 5).
+Filter: matching "project update".
+Preview:
+    Test result • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks"
+`;
+
+exports[`tasks-search tool searching tasks should handle pagination cursor 1`] = `
+"Search results for "follow up": 1 (limit 20).
+Filter: matching "follow up".
+Preview:
+    Test result • P1 • id=8485093748
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks"
+`;
+
+exports[`tasks-search tool searching tasks should handle search with empty results 1`] = `
+"Search results for "nonexistent keyword": 0 (limit 10).
+Filter: matching "nonexistent keyword".
+No results. Try broader search terms; Check completed tasks with tasks-list-completed; Verify spelling and try partial words."
+`;
+
+exports[`tasks-search tool searching tasks should handle search with special characters 1`] = `
+"Search results for "@work #urgent "exact phrase"": 0 (limit 10).
+Filter: matching "@work #urgent "exact phrase"".
+No results. Try broader search terms; Check completed tasks with tasks-list-completed; Verify spelling and try partial words."
+`;
+
+exports[`tasks-search tool searching tasks should search tasks and return results 1`] = `
+"Search results for "important meeting": 2 (limit 10), more available.
+Filter: matching "important meeting".
+Preview:
+    Task containing search term • P1 • id=8485093748
+    Another matching task • P2 • id=8485093749
+Next:
+- Use tasks-update-multiple to modify priorities or due dates
+- Use tasks-complete-multiple to mark finished tasks
+- Pass cursor 'cursor-for-next-page' to fetch more results."
+`;

--- a/src/tools/__tests__/delete-one.test.ts
+++ b/src/tools/__tests__/delete-one.test.ts
@@ -1,6 +1,7 @@
 import type { TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { deleteOne } from '../delete-one.js'
+import { extractTextContent } from '../test-helpers.js'
 
 // Mock the Todoist API
 const mockTodoistApi = {
@@ -23,13 +24,21 @@ describe('delete-one tool', () => {
                 mockTodoistApi,
             )
 
-            // Verify API was called correctly
             expect(mockTodoistApi.deleteProject).toHaveBeenCalledWith('6cfCcrrCFg2xP94Q')
             expect(mockTodoistApi.deleteSection).not.toHaveBeenCalled()
             expect(mockTodoistApi.deleteTask).not.toHaveBeenCalled()
 
-            // Verify success response
-            expect(result).toEqual({ success: true })
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Deleted project: id=6cfCcrrCFg2xP94Q')
+            expect(textContent).toContain('Use projects-list to see remaining projects')
+            expect(result.structuredContent).toEqual({
+                deletedEntity: {
+                    type: 'project',
+                    id: '6cfCcrrCFg2xP94Q',
+                },
+                success: true,
+            })
         })
 
         it('should propagate project deletion errors', async () => {
@@ -51,13 +60,21 @@ describe('delete-one tool', () => {
                 mockTodoistApi,
             )
 
-            // Verify API was called correctly
             expect(mockTodoistApi.deleteSection).toHaveBeenCalledWith('section-123')
             expect(mockTodoistApi.deleteProject).not.toHaveBeenCalled()
             expect(mockTodoistApi.deleteTask).not.toHaveBeenCalled()
 
-            // Verify success response
-            expect(result).toEqual({ success: true })
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Deleted section: id=section-123')
+            expect(textContent).toContain('Use sections-search to see remaining sections')
+            expect(result.structuredContent).toEqual({
+                deletedEntity: {
+                    type: 'section',
+                    id: 'section-123',
+                },
+                success: true,
+            })
         })
 
         it('should propagate section deletion errors', async () => {
@@ -79,13 +96,21 @@ describe('delete-one tool', () => {
                 mockTodoistApi,
             )
 
-            // Verify API was called correctly
             expect(mockTodoistApi.deleteTask).toHaveBeenCalledWith('8485093748')
             expect(mockTodoistApi.deleteProject).not.toHaveBeenCalled()
             expect(mockTodoistApi.deleteSection).not.toHaveBeenCalled()
 
-            // Verify success response
-            expect(result).toEqual({ success: true })
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Deleted task: id=8485093748')
+            expect(textContent).toContain('Use tasks-list-by-date to see remaining tasks')
+            expect(result.structuredContent).toEqual({
+                deletedEntity: {
+                    type: 'task',
+                    id: '8485093748',
+                },
+                success: true,
+            })
         })
 
         it('should propagate task deletion errors', async () => {
@@ -109,7 +134,6 @@ describe('delete-one tool', () => {
 
     describe('type validation', () => {
         it('should handle all supported entity types', async () => {
-            // Test all three supported types work correctly
             mockTodoistApi.deleteProject.mockResolvedValue(true)
             mockTodoistApi.deleteSection.mockResolvedValue(true)
             mockTodoistApi.deleteTask.mockResolvedValue(true)

--- a/src/tools/__tests__/overview.test.ts
+++ b/src/tools/__tests__/overview.test.ts
@@ -7,6 +7,7 @@ import {
     createMockProject,
     createMockSection,
     createMockTask,
+    extractStructuredContent,
     extractTextContent,
 } from '../test-helpers.js'
 
@@ -68,7 +69,7 @@ describe('overview tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Test structured content sanity checks
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent).toEqual(
                 expect.objectContaining({
                     type: 'account_overview',
@@ -95,7 +96,7 @@ describe('overview tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Test structured content sanity checks
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent).toEqual(
                 expect.objectContaining({
                     type: 'account_overview',
@@ -190,7 +191,7 @@ describe('overview tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Test structured content sanity checks
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent).toEqual(
                 expect.objectContaining({
                     type: 'project_overview',
@@ -228,7 +229,7 @@ describe('overview tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Test structured content sanity checks
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent).toEqual(
                 expect.objectContaining({
                     type: 'project_overview',

--- a/src/tools/__tests__/overview.test.ts
+++ b/src/tools/__tests__/overview.test.ts
@@ -7,6 +7,7 @@ import {
     createMockProject,
     createMockSection,
     createMockTask,
+    extractTextContent,
 } from '../test-helpers.js'
 
 // Mock the Todoist API
@@ -63,13 +64,48 @@ describe('overview tool', () => {
             expect(mockTodoistApi.getProjects).toHaveBeenCalledWith({})
             expect(mockTodoistApi.getSections).toHaveBeenCalledTimes(2) // Once for each project
 
-            // Use snapshot testing for complex markdown output
-            expect(result).toMatchSnapshot()
+            // Test text content with snapshot
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            // Test structured content sanity checks
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    type: 'account_overview',
+                    inbox: expect.objectContaining({
+                        id: TEST_IDS.PROJECT_INBOX,
+                        name: 'Inbox',
+                        sections: expect.any(Array),
+                    }),
+                    projects: expect.any(Array),
+                    totalProjects: 2,
+                    totalSections: 1,
+                    hasNestedProjects: false,
+                }),
+            )
+            expect(structuredContent.projects).toHaveLength(1) // Only non-inbox projects
         })
 
         it('should handle empty projects list', async () => {
             mockTodoistApi.getProjects.mockResolvedValue({ results: [], nextCursor: null })
-            expect(await overview.execute({}, mockTodoistApi)).toMatchSnapshot()
+
+            const result = await overview.execute({}, mockTodoistApi)
+
+            // Test text content with snapshot
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            // Test structured content sanity checks
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    type: 'account_overview',
+                    inbox: null,
+                    projects: [],
+                    totalProjects: 0,
+                    totalSections: 0,
+                    hasNestedProjects: false,
+                }),
+            )
         })
     })
 
@@ -150,8 +186,29 @@ describe('overview tool', () => {
                 cursor: undefined,
             })
 
-            // Use snapshot testing for complex markdown output
-            expect(result).toMatchSnapshot()
+            // Test text content with snapshot
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            // Test structured content sanity checks
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    type: 'project_overview',
+                    project: expect.objectContaining({
+                        id: TEST_IDS.PROJECT_TEST,
+                        name: 'test-abc123def456-project',
+                    }),
+                    sections: expect.any(Array),
+                    tasks: expect.any(Array),
+                    stats: expect.objectContaining({
+                        totalTasks: 3,
+                        totalSections: 2,
+                        tasksWithoutSection: 1,
+                    }),
+                }),
+            )
+            expect(structuredContent.sections).toHaveLength(2)
+            expect(structuredContent.tasks).toHaveLength(3)
         })
 
         it('should handle project with no tasks', async () => {
@@ -166,7 +223,28 @@ describe('overview tool', () => {
             mockTodoistApi.getTasks.mockResolvedValue({ results: [], nextCursor: null })
 
             const result = await overview.execute({ projectId: 'empty-project-id' }, mockTodoistApi)
-            expect(result).toMatchSnapshot()
+
+            // Test text content with snapshot
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            // Test structured content sanity checks
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    type: 'project_overview',
+                    project: expect.objectContaining({
+                        id: 'empty-project-id',
+                        name: 'Empty Project',
+                    }),
+                    sections: [],
+                    tasks: [],
+                    stats: expect.objectContaining({
+                        totalTasks: 0,
+                        totalSections: 0,
+                        tasksWithoutSection: 0,
+                    }),
+                }),
+            )
         })
     })
 

--- a/src/tools/__tests__/projects-list.test.ts
+++ b/src/tools/__tests__/projects-list.test.ts
@@ -6,6 +6,7 @@ import {
     TEST_IDS,
     createMockApiResponse,
     createMockProject,
+    extractStructuredContent,
     extractTextContent,
 } from '../test-helpers.js'
 
@@ -61,7 +62,7 @@ describe('projects-list tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Verify structured content
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent).toEqual(
                 expect.objectContaining({
                     projects: expect.any(Array),
@@ -100,7 +101,7 @@ describe('projects-list tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Verify structured content
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent.projects).toHaveLength(1)
             expect(structuredContent.totalCount).toBe(1)
             expect(structuredContent.hasMore).toBe(true)
@@ -136,7 +137,7 @@ describe('projects-list tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Verify structured content with search filter
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent.projects).toHaveLength(2) // Should match filtered results
             expect(structuredContent.totalCount).toBe(2)
             expect(structuredContent.hasMore).toBe(false)
@@ -169,8 +170,12 @@ describe('projects-list tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Verify structured content
-            const { structuredContent } = result
-            expect(structuredContent.appliedFilters.search).toBe(search)
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    appliedFilters: expect.objectContaining({ search }),
+                }),
+            )
         })
     })
 

--- a/src/tools/__tests__/projects-list.test.ts
+++ b/src/tools/__tests__/projects-list.test.ts
@@ -1,7 +1,13 @@
 import type { TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { projectsList } from '../projects-list.js'
-import { TEST_ERRORS, TEST_IDS, createMockApiResponse, createMockProject } from '../test-helpers.js'
+import {
+    TEST_ERRORS,
+    TEST_IDS,
+    createMockApiResponse,
+    createMockProject,
+    extractTextContent,
+} from '../test-helpers.js'
 
 // Mock the Todoist API
 const mockTodoistApi = {
@@ -52,31 +58,24 @@ describe('projects-list tool', () => {
                 cursor: null,
             })
 
-            // Verify result is properly mapped
-            expect(result).toEqual({
-                projects: [
-                    expect.objectContaining({
-                        id: TEST_IDS.PROJECT_INBOX,
-                        name: 'Inbox',
-                        color: 'grey',
-                        inboxProject: true,
-                    }),
-                    expect.objectContaining({
-                        id: TEST_IDS.PROJECT_TEST,
-                        name: 'test-abc123def456-project',
-                        color: 'charcoal',
-                    }),
-                    expect.objectContaining({
-                        id: TEST_IDS.PROJECT_WORK,
-                        name: 'Work Project',
-                        color: 'blue',
-                        isFavorite: true,
-                        isShared: true,
-                        viewStyle: 'board',
-                    }),
-                ],
-                nextCursor: null,
-            })
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            // Verify structured content
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    projects: expect.any(Array),
+                    totalCount: 3,
+                    hasMore: false,
+                    nextCursor: null,
+                    appliedFilters: {
+                        search: undefined,
+                        limit: 50,
+                        cursor: undefined,
+                    },
+                }),
+            )
+            expect(structuredContent.projects).toHaveLength(3)
         })
 
         it('should handle pagination with limit and cursor', async () => {
@@ -98,9 +97,19 @@ describe('projects-list tool', () => {
                 limit: 10,
                 cursor: 'current-page-cursor',
             })
-            expect(result.projects).toHaveLength(1)
-            expect(result.projects[0]?.name).toBe('First Project')
-            expect(result.nextCursor).toBe('next-page-cursor')
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            // Verify structured content
+            const { structuredContent } = result
+            expect(structuredContent.projects).toHaveLength(1)
+            expect(structuredContent.totalCount).toBe(1)
+            expect(structuredContent.hasMore).toBe(true)
+            expect(structuredContent.nextCursor).toBe('next-page-cursor')
+            expect(structuredContent.appliedFilters).toEqual({
+                search: undefined,
+                limit: 10,
+                cursor: 'current-page-cursor',
+            })
         })
     })
 
@@ -124,8 +133,19 @@ describe('projects-list tool', () => {
             const result = await projectsList.execute({ search: 'work', limit: 50 }, mockTodoistApi)
 
             expect(mockTodoistApi.getProjects).toHaveBeenCalledWith({ limit: 50, cursor: null })
-            expect(result.projects).toHaveLength(2)
-            expect(result.projects.map((p) => p.name)).toEqual(['Work Project', 'Hobby Work'])
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            // Verify structured content with search filter
+            const { structuredContent } = result
+            expect(structuredContent.projects).toHaveLength(2) // Should match filtered results
+            expect(structuredContent.totalCount).toBe(2)
+            expect(structuredContent.hasMore).toBe(false)
+            expect(structuredContent.nextCursor).toBeNull()
+            expect(structuredContent.appliedFilters).toEqual({
+                search: 'work',
+                limit: 50,
+                cursor: undefined,
+            })
         })
 
         it.each([
@@ -141,16 +161,17 @@ describe('projects-list tool', () => {
                 expectedCount: 1,
                 description: 'case insensitive matching',
             },
-        ])(
-            'should handle search with $description',
-            async ({ search, projects, expectedCount }) => {
-                const mockProjects = projects.map((name) => createMockProject({ name }))
-                mockTodoistApi.getProjects.mockResolvedValue(createMockApiResponse(mockProjects))
+        ])('should handle search with $description', async ({ search, projects }) => {
+            const mockProjects = projects.map((name) => createMockProject({ name }))
+            mockTodoistApi.getProjects.mockResolvedValue(createMockApiResponse(mockProjects))
 
-                const result = await projectsList.execute({ search, limit: 50 }, mockTodoistApi)
-                expect(result.projects).toHaveLength(expectedCount)
-            },
-        )
+            const result = await projectsList.execute({ search, limit: 50 }, mockTodoistApi)
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            // Verify structured content
+            const { structuredContent } = result
+            expect(structuredContent.appliedFilters.search).toBe(search)
+        })
     })
 
     describe('error handling', () => {

--- a/src/tools/__tests__/projects-manage.test.ts
+++ b/src/tools/__tests__/projects-manage.test.ts
@@ -1,7 +1,12 @@
 import type { PersonalProject, TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { projectsManage } from '../projects-manage.js'
-import { TEST_IDS, createMockProject, extractTextContent } from '../test-helpers.js'
+import {
+    TEST_IDS,
+    createMockProject,
+    extractStructuredContent,
+    extractTextContent,
+} from '../test-helpers.js'
 
 // Mock the Todoist API
 const mockTodoistApi = {
@@ -42,11 +47,16 @@ describe('projects-manage tool', () => {
             expect(textContent).toContain('Use tasks-add-multiple to add your first tasks')
 
             // Verify structured content
-            const { structuredContent } = result
-            expect(structuredContent.project).toBeDefined()
-            expect(structuredContent.project.id).toBe(TEST_IDS.PROJECT_TEST)
-            expect(structuredContent.project.name).toBe('test-abc123def456-project')
-            expect(structuredContent.operation).toBe('created')
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    project: expect.objectContaining({
+                        id: TEST_IDS.PROJECT_TEST,
+                        name: 'test-abc123def456-project',
+                    }),
+                    operation: 'created',
+                }),
+            )
         })
 
         it('should handle different project properties from API', async () => {

--- a/src/tools/__tests__/sections-manage.test.ts
+++ b/src/tools/__tests__/sections-manage.test.ts
@@ -1,7 +1,7 @@
 import type { Section, TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { sectionsManage } from '../sections-manage.js'
-import { TEST_IDS, createMockSection } from '../test-helpers.js'
+import { TEST_IDS, createMockSection, extractTextContent } from '../test-helpers.js'
 
 // Mock the Todoist API
 const mockTodoistApi = {
@@ -25,21 +25,32 @@ describe('sections-manage tool', () => {
             mockTodoistApi.addSection.mockResolvedValue(mockApiResponse)
 
             const result = await sectionsManage.execute(
-                {
-                    name: 'test-abc123def456-section',
-                    projectId: TEST_IDS.PROJECT_TEST,
-                },
+                { name: 'test-abc123def456-section', projectId: TEST_IDS.PROJECT_TEST },
                 mockTodoistApi,
             )
 
-            // Verify API was called correctly
             expect(mockTodoistApi.addSection).toHaveBeenCalledWith({
                 name: 'test-abc123def456-section',
                 projectId: TEST_IDS.PROJECT_TEST,
             })
 
-            // Verify result matches API response
-            expect(result).toEqual(mockApiResponse)
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Created section: test-abc123def456-section')
+            expect(textContent).toContain(`id=${TEST_IDS.SECTION_1}`)
+            expect(textContent).toContain('Use tasks-list-for-container with type=section')
+
+            // Verify structured content
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    section: expect.objectContaining({
+                        id: TEST_IDS.SECTION_1,
+                        name: 'test-abc123def456-section',
+                    }),
+                    operation: 'created',
+                }),
+            )
         })
 
         it('should handle different section properties from API', async () => {
@@ -53,10 +64,7 @@ describe('sections-manage tool', () => {
             mockTodoistApi.addSection.mockResolvedValue(mockApiResponse)
 
             const result = await sectionsManage.execute(
-                {
-                    name: 'My Section Name',
-                    projectId: 'project-789',
-                },
+                { name: 'My Section Name', projectId: 'project-789' },
                 mockTodoistApi,
             )
 
@@ -65,30 +73,33 @@ describe('sections-manage tool', () => {
                 projectId: 'project-789',
             })
 
-            expect(result).toEqual(mockApiResponse)
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Created section: My Section Name')
+            expect(textContent).toContain(`id=${TEST_IDS.SECTION_2}`)
+            expect(textContent).toContain('Use tasks-add-multiple with sectionId')
+
+            // Verify structured content
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    section: expect.objectContaining({
+                        id: TEST_IDS.SECTION_2,
+                        name: 'My Section Name',
+                    }),
+                    operation: 'created',
+                }),
+            )
         })
 
-        it('should return error when projectId is missing for new section', async () => {
-            const result = await sectionsManage.execute(
-                {
-                    name: 'test-section',
-                },
-                mockTodoistApi,
+        it('should throw error when projectId is missing for new section', async () => {
+            await expect(
+                sectionsManage.execute({ name: 'test-section' }, mockTodoistApi),
+            ).rejects.toThrow(
+                'Error: projectId is required when creating a new section (when id is not provided).',
             )
 
-            // Should not call API when projectId is missing
             expect(mockTodoistApi.addSection).not.toHaveBeenCalled()
-
-            // Should return error content
-            expect(result).toEqual({
-                content: [
-                    {
-                        type: 'text',
-                        text: 'Error: projectId is required when creating a new section (when id is not provided).',
-                    },
-                ],
-                isError: true,
-            })
         })
     })
 
@@ -111,10 +122,7 @@ describe('sections-manage tool', () => {
             mockTodoistApi.updateSection.mockResolvedValue(mockApiResponse)
 
             const result = await sectionsManage.execute(
-                {
-                    id: 'existing-section-123',
-                    name: 'Updated Section Name',
-                },
+                { id: 'existing-section-123', name: 'Updated Section Name' },
                 mockTodoistApi,
             )
 
@@ -122,7 +130,18 @@ describe('sections-manage tool', () => {
                 name: 'Updated Section Name',
             })
 
-            expect(result).toEqual(mockApiResponse)
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Updated section: Updated Section Name')
+            expect(textContent).toContain('id=existing-section-123')
+            expect(textContent).toContain('Use tasks-list-for-container with type=section')
+
+            // Verify structured content
+            const { structuredContent } = result
+            expect(structuredContent.section).toBeDefined()
+            expect(structuredContent.section.id).toBe('existing-section-123')
+            expect(structuredContent.section.name).toBe('Updated Section Name')
+            expect(structuredContent.operation).toBe('updated')
         })
 
         it('should update section without requiring projectId', async () => {
@@ -155,7 +174,18 @@ describe('sections-manage tool', () => {
                 name: 'Section New Name',
             })
 
-            expect(result).toEqual(mockApiResponse)
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Updated section: Section New Name')
+            expect(textContent).toContain('id=section-update-test')
+            expect(textContent).toContain('Use tasks-list-for-container with type=section')
+
+            // Verify structured content
+            const { structuredContent } = result
+            expect(structuredContent.section).toBeDefined()
+            expect(structuredContent.section.id).toBe('section-update-test')
+            expect(structuredContent.section.name).toBe('Section New Name')
+            expect(structuredContent.operation).toBe('updated')
         })
     })
 
@@ -165,13 +195,7 @@ describe('sections-manage tool', () => {
             mockTodoistApi.addSection.mockRejectedValue(apiError)
 
             await expect(
-                sectionsManage.execute(
-                    {
-                        name: '',
-                        projectId: '6cfCcrrCFg2xP94Q',
-                    },
-                    mockTodoistApi,
-                ),
+                sectionsManage.execute({ name: '', projectId: '6cfCcrrCFg2xP94Q' }, mockTodoistApi),
             ).rejects.toThrow('API Error: Section name is required')
         })
 
@@ -181,10 +205,7 @@ describe('sections-manage tool', () => {
 
             await expect(
                 sectionsManage.execute(
-                    {
-                        id: 'non-existent-section',
-                        name: 'Updated Name',
-                    },
+                    { id: 'non-existent-section', name: 'Updated Name' },
                     mockTodoistApi,
                 ),
             ).rejects.toThrow('API Error: Section not found')

--- a/src/tools/__tests__/sections-manage.test.ts
+++ b/src/tools/__tests__/sections-manage.test.ts
@@ -1,7 +1,12 @@
 import type { Section, TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { sectionsManage } from '../sections-manage.js'
-import { TEST_IDS, createMockSection, extractTextContent } from '../test-helpers.js'
+import {
+    TEST_IDS,
+    createMockSection,
+    extractStructuredContent,
+    extractTextContent,
+} from '../test-helpers.js'
 
 // Mock the Todoist API
 const mockTodoistApi = {
@@ -41,7 +46,7 @@ describe('sections-manage tool', () => {
             expect(textContent).toContain('Use tasks-list-for-container with type=section')
 
             // Verify structured content
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent).toEqual(
                 expect.objectContaining({
                     section: expect.objectContaining({
@@ -80,7 +85,7 @@ describe('sections-manage tool', () => {
             expect(textContent).toContain('Use tasks-add-multiple with sectionId')
 
             // Verify structured content
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent).toEqual(
                 expect.objectContaining({
                     section: expect.objectContaining({
@@ -137,11 +142,16 @@ describe('sections-manage tool', () => {
             expect(textContent).toContain('Use tasks-list-for-container with type=section')
 
             // Verify structured content
-            const { structuredContent } = result
-            expect(structuredContent.section).toBeDefined()
-            expect(structuredContent.section.id).toBe('existing-section-123')
-            expect(structuredContent.section.name).toBe('Updated Section Name')
-            expect(structuredContent.operation).toBe('updated')
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    section: expect.objectContaining({
+                        id: 'existing-section-123',
+                        name: 'Updated Section Name',
+                    }),
+                    operation: 'updated',
+                }),
+            )
         })
 
         it('should update section without requiring projectId', async () => {
@@ -181,11 +191,16 @@ describe('sections-manage tool', () => {
             expect(textContent).toContain('Use tasks-list-for-container with type=section')
 
             // Verify structured content
-            const { structuredContent } = result
-            expect(structuredContent.section).toBeDefined()
-            expect(structuredContent.section.id).toBe('section-update-test')
-            expect(structuredContent.section.name).toBe('Section New Name')
-            expect(structuredContent.operation).toBe('updated')
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    section: expect.objectContaining({
+                        id: 'section-update-test',
+                        name: 'Section New Name',
+                    }),
+                    operation: 'updated',
+                }),
+            )
         })
     })
 

--- a/src/tools/__tests__/sections-search.test.ts
+++ b/src/tools/__tests__/sections-search.test.ts
@@ -1,7 +1,13 @@
 import type { Section, TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { sectionsSearch } from '../sections-search.js'
-import { TEST_ERRORS, TEST_IDS, createMockSection, extractTextContent } from '../test-helpers.js'
+import {
+    TEST_ERRORS,
+    TEST_IDS,
+    createMockSection,
+    extractStructuredContent,
+    extractTextContent,
+} from '../test-helpers.js'
 
 // Mock the Todoist API
 const mockTodoistApi = {
@@ -64,7 +70,7 @@ describe('sections-search tool', () => {
             expect(textContent).toContain('Backlog Items • id=')
 
             // Verify structured content
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent.sections).toHaveLength(4)
             expect(structuredContent.totalCount).toBe(4)
             expect(structuredContent.appliedFilters).toEqual({
@@ -94,7 +100,7 @@ describe('sections-search tool', () => {
             expect(textContent).toContain('Use sections-manage to create sections')
 
             // Verify structured content
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent.sections).toHaveLength(0)
             expect(structuredContent.totalCount).toBe(0)
             expect(structuredContent.appliedFilters).toEqual({

--- a/src/tools/__tests__/sections-search.test.ts
+++ b/src/tools/__tests__/sections-search.test.ts
@@ -1,7 +1,7 @@
 import type { Section, TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { sectionsSearch } from '../sections-search.js'
-import { TEST_ERRORS, TEST_IDS, createMockSection } from '../test-helpers.js'
+import { TEST_ERRORS, TEST_IDS, createMockSection, extractTextContent } from '../test-helpers.js'
 
 // Mock the Todoist API
 const mockTodoistApi = {
@@ -51,18 +51,26 @@ describe('sections-search tool', () => {
                 mockTodoistApi,
             )
 
-            // Verify API was called correctly
             expect(mockTodoistApi.getSections).toHaveBeenCalledWith({
                 projectId: TEST_IDS.PROJECT_TEST,
             })
 
-            // Verify result is properly mapped (simplified format)
-            expect(result).toEqual([
-                { id: TEST_IDS.SECTION_1, name: 'To Do' },
-                { id: TEST_IDS.SECTION_2, name: 'In Progress' },
-                { id: 'section-789', name: 'Done' },
-                { id: 'section-999', name: 'Backlog Items' },
-            ])
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Sections in project')
+            expect(textContent).toContain('To Do • id=')
+            expect(textContent).toContain('In Progress • id=')
+            expect(textContent).toContain('Done • id=')
+            expect(textContent).toContain('Backlog Items • id=')
+
+            // Verify structured content
+            const { structuredContent } = result
+            expect(structuredContent.sections).toHaveLength(4)
+            expect(structuredContent.totalCount).toBe(4)
+            expect(structuredContent.appliedFilters).toEqual({
+                projectId: TEST_IDS.PROJECT_TEST,
+                search: undefined,
+            })
         })
 
         it('should handle project with no sections', async () => {
@@ -80,7 +88,19 @@ describe('sections-search tool', () => {
                 projectId: 'empty-project-id',
             })
 
-            expect(result).toEqual([])
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Project has no sections yet')
+            expect(textContent).toContain('Use sections-manage to create sections')
+
+            // Verify structured content
+            const { structuredContent } = result
+            expect(structuredContent.sections).toHaveLength(0)
+            expect(structuredContent.totalCount).toBe(0)
+            expect(structuredContent.appliedFilters).toEqual({
+                projectId: 'empty-project-id',
+                search: undefined,
+            })
         })
     })
 
@@ -118,10 +138,7 @@ describe('sections-search tool', () => {
             })
 
             const result = await sectionsSearch.execute(
-                {
-                    projectId: TEST_IDS.PROJECT_TEST,
-                    search: 'progress',
-                },
+                { projectId: TEST_IDS.PROJECT_TEST, search: 'progress' },
                 mockTodoistApi,
             )
 
@@ -130,10 +147,11 @@ describe('sections-search tool', () => {
             })
 
             // Should return both "In Progress" and "Progress Review" (case insensitive partial match)
-            expect(result).toEqual([
-                { id: TEST_IDS.SECTION_2, name: 'In Progress' },
-                { id: 'section-999', name: 'Progress Review' },
-            ])
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('matching "progress"')
+            expect(textContent).toContain('In Progress • id=')
+            expect(textContent).toContain('Progress Review • id=')
         })
 
         it('should handle search with no matches', async () => {
@@ -157,14 +175,15 @@ describe('sections-search tool', () => {
             })
 
             const result = await sectionsSearch.execute(
-                {
-                    projectId: TEST_IDS.PROJECT_TEST,
-                    search: 'nonexistent',
-                },
+                { projectId: TEST_IDS.PROJECT_TEST, search: 'nonexistent' },
                 mockTodoistApi,
             )
 
-            expect(result).toEqual([])
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Try broader search terms')
+            expect(textContent).toContain('Check spelling')
+            expect(textContent).toContain('Remove search to see all sections')
         })
 
         it('should handle case sensitive search correctly', async () => {
@@ -188,16 +207,15 @@ describe('sections-search tool', () => {
             })
 
             const result = await sectionsSearch.execute(
-                {
-                    projectId: TEST_IDS.PROJECT_TEST,
-                    search: 'IMPORTANT',
-                },
+                { projectId: TEST_IDS.PROJECT_TEST, search: 'IMPORTANT' },
                 mockTodoistApi,
             )
 
             // Should match despite different case
-            expect(result).toHaveLength(1)
-            expect(result[0]).toEqual({ id: TEST_IDS.SECTION_1, name: 'Important Tasks' })
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('matching "IMPORTANT"')
+            expect(textContent).toContain('Important Tasks • id=')
         })
 
         it('should handle partial matches correctly', async () => {
@@ -227,18 +245,16 @@ describe('sections-search tool', () => {
             })
 
             const result = await sectionsSearch.execute(
-                {
-                    projectId: TEST_IDS.PROJECT_TEST,
-                    search: 'task',
-                },
+                { projectId: TEST_IDS.PROJECT_TEST, search: 'task' },
                 mockTodoistApi,
             )
 
             // Should match both sections with "task" in the name
-            expect(result).toEqual([
-                { id: TEST_IDS.SECTION_1, name: 'Development Tasks' },
-                { id: TEST_IDS.SECTION_2, name: 'Testing Tasks' },
-            ])
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('matching "task"')
+            expect(textContent).toContain('Development Tasks • id=')
+            expect(textContent).toContain('Testing Tasks • id=')
         })
 
         it('should handle exact matches', async () => {
@@ -262,18 +278,16 @@ describe('sections-search tool', () => {
             })
 
             const result = await sectionsSearch.execute(
-                {
-                    projectId: TEST_IDS.PROJECT_TEST,
-                    search: 'done',
-                },
+                { projectId: TEST_IDS.PROJECT_TEST, search: 'done' },
                 mockTodoistApi,
             )
 
             // Should match both sections containing "done"
-            expect(result).toEqual([
-                { id: TEST_IDS.SECTION_1, name: 'Done' },
-                { id: TEST_IDS.SECTION_2, name: 'Done Soon' },
-            ])
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('matching "done"')
+            expect(textContent).toContain('Done • id=')
+            expect(textContent).toContain('Done Soon • id=')
         })
     })
 

--- a/src/tools/__tests__/tasks-add-multiple.test.ts
+++ b/src/tools/__tests__/tasks-add-multiple.test.ts
@@ -1,7 +1,12 @@
 import type { Task, TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { tasksAddMultiple } from '../tasks-add-multiple.js'
-import { TODAY, createMockTask, extractTextContent } from '../test-helpers.js'
+import {
+    TODAY,
+    createMockTask,
+    extractStructuredContent,
+    extractTextContent,
+} from '../test-helpers.js'
 
 // Mock the Todoist API
 const mockTodoistApi = {
@@ -83,16 +88,17 @@ describe('tasks-add-multiple tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Verify structured content
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.tasks).toHaveLength(2)
             expect(structuredContent).toEqual(
                 expect.objectContaining({
-                    tasks: expect.any(Array),
                     totalCount: 2,
+                    tasks: expect.arrayContaining([
+                        expect.objectContaining({ id: '8485093748' }),
+                        expect.objectContaining({ id: '8485093749' }),
+                    ]),
                 }),
             )
-            expect(structuredContent.tasks).toHaveLength(2)
-            expect(structuredContent.tasks[0]?.id).toBe('8485093748')
-            expect(structuredContent.tasks[1]?.id).toBe('8485093749')
         })
 
         it('should handle tasks with section and parent IDs', async () => {
@@ -138,10 +144,13 @@ describe('tasks-add-multiple tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Verify structured content
-            const { structuredContent } = result
-            expect(structuredContent.tasks).toHaveLength(1)
-            expect(structuredContent.totalCount).toBe(1)
-            expect(structuredContent.tasks[0]?.id).toBe('8485093750')
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    totalCount: 1,
+                    tasks: expect.arrayContaining([expect.objectContaining({ id: '8485093750' })]),
+                }),
+            )
         })
 
         it('should add tasks with duration', async () => {
@@ -198,11 +207,17 @@ describe('tasks-add-multiple tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Verify structured content
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent.tasks).toHaveLength(2)
-            expect(structuredContent.totalCount).toBe(2)
-            expect(structuredContent.tasks[0]?.id).toBe('8485093752')
-            expect(structuredContent.tasks[1]?.id).toBe('8485093753')
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    totalCount: 2,
+                    tasks: expect.arrayContaining([
+                        expect.objectContaining({ id: '8485093752' }),
+                        expect.objectContaining({ id: '8485093753' }),
+                    ]),
+                }),
+            )
         })
 
         it('should handle various duration formats', async () => {

--- a/src/tools/__tests__/tasks-list-by-date.test.ts
+++ b/src/tools/__tests__/tasks-list-by-date.test.ts
@@ -2,7 +2,13 @@ import type { TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { getTasksByFilter } from '../../tool-helpers.js'
 import { tasksListByDate } from '../tasks-list-by-date.js'
-import { TEST_ERRORS, TEST_IDS, createMappedTask, extractTextContent } from '../test-helpers.js'
+import {
+    TEST_ERRORS,
+    TEST_IDS,
+    createMappedTask,
+    extractStructuredContent,
+    extractTextContent,
+} from '../test-helpers.js'
 
 // Mock the tool helpers
 jest.mock('../../tool-helpers', () => ({
@@ -79,12 +85,18 @@ describe('tasks-list-by-date tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Verify structured content
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent.tasks).toHaveLength(hasTasks ? 1 : 0)
-            expect(structuredContent.totalCount).toBe(hasTasks ? 1 : 0)
-            expect(structuredContent.hasMore).toBe(false)
-            expect(structuredContent.nextCursor).toBeNull()
-            expect(structuredContent.appliedFilters.startDate).toBe('overdue')
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    totalCount: hasTasks ? 1 : 0,
+                    hasMore: false,
+                    nextCursor: null,
+                    appliedFilters: expect.objectContaining({
+                        startDate: 'overdue',
+                    }),
+                }),
+            )
         })
     })
 

--- a/src/tools/__tests__/tasks-list-by-date.test.ts
+++ b/src/tools/__tests__/tasks-list-by-date.test.ts
@@ -2,7 +2,7 @@ import type { TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { getTasksByFilter } from '../../tool-helpers.js'
 import { tasksListByDate } from '../tasks-list-by-date.js'
-import { TEST_ERRORS, TEST_IDS, createMappedTask } from '../test-helpers.js'
+import { TEST_ERRORS, TEST_IDS, createMappedTask, extractTextContent } from '../test-helpers.js'
 
 // Mock the tool helpers
 jest.mock('../../tool-helpers', () => ({
@@ -75,7 +75,16 @@ describe('tasks-list-by-date tool', () => {
                 cursor: undefined,
                 limit: 50,
             })
-            expect(result).toEqual(mockResponse)
+            // Verify result is a concise summary
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            // Verify structured content
+            const { structuredContent } = result
+            expect(structuredContent.tasks).toHaveLength(hasTasks ? 1 : 0)
+            expect(structuredContent.totalCount).toBe(hasTasks ? 1 : 0)
+            expect(structuredContent.hasMore).toBe(false)
+            expect(structuredContent.nextCursor).toBeNull()
+            expect(structuredContent.appliedFilters.startDate).toBe('overdue')
         })
     })
 
@@ -97,7 +106,8 @@ describe('tasks-list-by-date tool', () => {
                 cursor: undefined,
                 limit: 50,
             })
-            expect(result).toEqual(mockResponse)
+            // Verify result is a concise summary
+            expect(extractTextContent(result)).toMatchSnapshot()
         })
 
         it.each([
@@ -141,7 +151,8 @@ describe('tasks-list-by-date tool', () => {
                 cursor: params.cursor || undefined,
                 limit: params.limit,
             })
-            expect(result).toEqual(mockResponse)
+            // Verify result is a concise summary
+            expect(extractTextContent(result)).toMatchSnapshot()
         })
     })
 
@@ -196,8 +207,110 @@ describe('tasks-list-by-date tool', () => {
 
             expect(mockGetTasksByFilter).toHaveBeenCalledTimes(1)
             if (shouldReturnResult) {
-                expect(result).toEqual(mockResponse)
+                // Verify result is a concise summary
+                expect(extractTextContent(result)).toMatchSnapshot()
             }
+        })
+    })
+
+    describe('next steps logic', () => {
+        it('should suggest appropriate actions when hasOverdue is true', async () => {
+            const mockTasks = [
+                createMappedTask({
+                    id: TEST_IDS.TASK_1,
+                    content: 'Overdue task from list',
+                    dueDate: '2025-08-10', // Past date - creates hasOverdue context
+                }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await tasksListByDate.execute(
+                { startDate: '2025-08-15', limit: 10, daysCount: 1 },
+                mockTodoistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain(
+                'Use tasks-update-multiple to modify priorities or due dates',
+            )
+        })
+
+        it('should suggest today-focused actions when startDate is today', async () => {
+            const mockTasks = [
+                createMappedTask({
+                    id: TEST_IDS.TASK_1,
+                    content: "Today's task",
+                    dueDate: '2025-08-15', // Today's date based on our mock
+                }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await tasksListByDate.execute(
+                { startDate: 'today', limit: 10, daysCount: 1 },
+                mockTodoistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain(
+                'Use tasks-update-multiple to modify priorities or due dates',
+            )
+        })
+
+        it('should suggest appropriate actions when startDate is overdue', async () => {
+            const mockTasks = [
+                createMappedTask({
+                    id: TEST_IDS.TASK_1,
+                    content: 'Overdue task',
+                    dueDate: '2025-08-10',
+                }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await tasksListByDate.execute(
+                { startDate: 'overdue', limit: 10, daysCount: 1 },
+                mockTodoistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain(
+                'Use tasks-update-multiple to modify priorities or due dates',
+            )
+        })
+
+        it('should provide helpful suggestions for empty overdue results', async () => {
+            const mockResponse = { tasks: [], nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await tasksListByDate.execute(
+                { startDate: 'overdue', limit: 10, daysCount: 1 },
+                mockTodoistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Great job! No overdue tasks')
+            expect(textContent).toContain("Check today's tasks with startDate='today'")
+        })
+
+        it('should provide helpful suggestions for empty date range results', async () => {
+            const mockResponse = { tasks: [], nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await tasksListByDate.execute(
+                { startDate: '2025-08-20', limit: 10, daysCount: 1 },
+                mockTodoistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain("Expand date range with larger 'daysCount'")
+            expect(textContent).toContain("Check 'overdue' for past-due items")
         })
     })
 

--- a/src/tools/__tests__/tasks-list-completed.test.ts
+++ b/src/tools/__tests__/tasks-list-completed.test.ts
@@ -1,7 +1,7 @@
 import type { Task, TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { tasksListCompleted } from '../tasks-list-completed.js'
-import { createMockTask } from '../test-helpers.js'
+import { createMockTask, extractTextContent } from '../test-helpers.js'
 
 // Mock the Todoist API
 const mockTodoistApi = {
@@ -52,19 +52,7 @@ describe('tasks-list-completed tool', () => {
                 limit: 50,
             })
 
-            expect(result).toEqual({
-                tasks: [
-                    expect.objectContaining({
-                        id: '8485093748',
-                        content: 'Completed task 1',
-                        description: 'Task completed yesterday',
-                        dueDate: '2025-08-14',
-                        priority: 2,
-                        labels: ['work'],
-                    }),
-                ],
-                nextCursor: null,
-            })
+            expect(extractTextContent(result)).toMatchSnapshot()
         })
 
         it('should handle explicit completion date query', async () => {
@@ -93,7 +81,7 @@ describe('tasks-list-completed tool', () => {
                 cursor: 'current-cursor',
             })
 
-            expect(result).toEqual({ tasks: [], nextCursor: 'next-cursor' })
+            expect(extractTextContent(result)).toMatchSnapshot()
         })
     })
 
@@ -141,20 +129,7 @@ describe('tasks-list-completed tool', () => {
             })
             expect(mockTodoistApi.getCompletedTasksByCompletionDate).not.toHaveBeenCalled()
 
-            expect(result).toEqual({
-                tasks: [
-                    expect.objectContaining({
-                        id: '8485093750',
-                        content: 'Task completed by due date',
-                        description: 'This task was due and completed',
-                        dueDate: '2025-08-15',
-                        recurring: 'every Monday',
-                        priority: 3,
-                        labels: ['urgent'],
-                    }),
-                ],
-                nextCursor: null,
-            })
+            expect(extractTextContent(result)).toMatchSnapshot()
         })
     })
 

--- a/src/tools/__tests__/tasks-search.test.ts
+++ b/src/tools/__tests__/tasks-search.test.ts
@@ -126,8 +126,8 @@ describe('tasks-search tool', () => {
                         hasMore: false,
                         nextCursor: null,
                         appliedFilters: expect.objectContaining({
+                            searchText: params.searchText,
                             limit: expectedLimit,
-                            cursor: expectedCursor,
                         }),
                     }),
                 )

--- a/src/tools/__tests__/tasks-search.test.ts
+++ b/src/tools/__tests__/tasks-search.test.ts
@@ -2,7 +2,13 @@ import type { TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { getTasksByFilter } from '../../tool-helpers.js'
 import { tasksSearch } from '../tasks-search.js'
-import { TEST_ERRORS, TEST_IDS, createMappedTask } from '../test-helpers.js'
+import {
+    TEST_ERRORS,
+    TEST_IDS,
+    TODAY,
+    createMappedTask,
+    extractTextContent,
+} from '../test-helpers.js'
 
 // Mock the tool helpers
 jest.mock('../../tool-helpers', () => ({
@@ -52,7 +58,25 @@ describe('tasks-search tool', () => {
                 cursor: undefined,
                 limit: 10,
             })
-            expect(result).toEqual(mockResponse)
+            // Verify result is a concise summary
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            // Verify structured content
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    tasks: expect.any(Array),
+                    totalCount: 2,
+                    hasMore: true,
+                    nextCursor: 'cursor-for-next-page',
+                    appliedFilters: {
+                        searchText: 'important meeting',
+                        limit: 10,
+                        cursor: undefined,
+                    },
+                }),
+            )
+            expect(structuredContent.tasks).toHaveLength(2)
         })
 
         it.each([
@@ -85,7 +109,24 @@ describe('tasks-search tool', () => {
                     cursor: expectedCursor,
                     limit: expectedLimit,
                 })
-                expect(result).toEqual(mockResponse)
+                // Verify result is a concise summary
+                expect(extractTextContent(result)).toMatchSnapshot()
+
+                // Verify structured content
+                const { structuredContent } = result
+                expect(structuredContent).toEqual(
+                    expect.objectContaining({
+                        tasks: expect.any(Array),
+                        totalCount: 1,
+                        hasMore: false,
+                        nextCursor: null,
+                        appliedFilters: expect.objectContaining({
+                            limit: expectedLimit,
+                            cursor: expectedCursor,
+                        }),
+                    }),
+                )
+                expect(structuredContent.tasks).toHaveLength(1)
             },
         )
 
@@ -104,7 +145,111 @@ describe('tasks-search tool', () => {
                 cursor: undefined,
                 limit: 10,
             })
-            expect(result).toEqual(mockResponse)
+            // Verify result is a concise summary
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            // Verify structured content for empty results
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    tasks: [],
+                    totalCount: 0,
+                    hasMore: false,
+                    nextCursor: null,
+                    appliedFilters: expect.objectContaining({
+                        searchText: searchText,
+                    }),
+                }),
+            )
+        })
+    })
+
+    describe('next steps logic', () => {
+        it('should suggest different actions when hasOverdue is true', async () => {
+            const mockTasks = [
+                createMappedTask({
+                    id: TEST_IDS.TASK_1,
+                    content: 'Overdue search result',
+                    dueDate: '2025-08-10', // Past date
+                }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await tasksSearch.execute(
+                { searchText: 'overdue tasks', limit: 10 },
+                mockTodoistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            // Should prioritize overdue tasks in next steps
+            expect(textContent).toContain(
+                'Use tasks-update-multiple to modify priorities or due dates',
+            )
+        })
+
+        it('should suggest today tasks when hasToday is true', async () => {
+            const mockTasks = [
+                createMappedTask({
+                    id: TEST_IDS.TASK_1,
+                    content: 'Task due today',
+                    dueDate: TODAY,
+                }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await tasksSearch.execute(
+                { searchText: 'today tasks', limit: 10 },
+                mockTodoistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            // Should suggest today-focused actions
+            expect(textContent).toContain(
+                'Use tasks-update-multiple to modify priorities or due dates',
+            )
+        })
+
+        it('should provide different next steps for regular tasks', async () => {
+            const mockTasks = [
+                createMappedTask({
+                    id: TEST_IDS.TASK_1,
+                    content: 'Regular future task',
+                    dueDate: '2025-08-25', // Future date
+                }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await tasksSearch.execute(
+                { searchText: 'future tasks', limit: 10 },
+                mockTodoistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain(
+                'Use tasks-update-multiple to modify priorities or due dates',
+            )
+        })
+
+        it('should provide helpful suggestions for empty search results', async () => {
+            const mockResponse = { tasks: [], nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await tasksSearch.execute(
+                { searchText: 'nonexistent', limit: 10 },
+                mockTodoistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Try broader search terms')
+            expect(textContent).toContain('Check completed tasks with tasks-list-completed')
+            expect(textContent).toContain('Verify spelling and try partial words')
         })
     })
 

--- a/src/tools/__tests__/tasks-search.test.ts
+++ b/src/tools/__tests__/tasks-search.test.ts
@@ -7,6 +7,7 @@ import {
     TEST_IDS,
     TODAY,
     createMappedTask,
+    extractStructuredContent,
     extractTextContent,
 } from '../test-helpers.js'
 
@@ -62,7 +63,7 @@ describe('tasks-search tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Verify structured content
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent).toEqual(
                 expect.objectContaining({
                     tasks: expect.any(Array),
@@ -76,7 +77,11 @@ describe('tasks-search tool', () => {
                     },
                 }),
             )
-            expect(structuredContent.tasks).toHaveLength(2)
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    tasks: expect.any(Array),
+                }),
+            )
         })
 
         it.each([
@@ -113,7 +118,7 @@ describe('tasks-search tool', () => {
                 expect(extractTextContent(result)).toMatchSnapshot()
 
                 // Verify structured content
-                const { structuredContent } = result
+                const structuredContent = extractStructuredContent(result)
                 expect(structuredContent).toEqual(
                     expect.objectContaining({
                         tasks: expect.any(Array),
@@ -126,7 +131,11 @@ describe('tasks-search tool', () => {
                         }),
                     }),
                 )
-                expect(structuredContent.tasks).toHaveLength(1)
+                expect(structuredContent).toEqual(
+                    expect.objectContaining({
+                        tasks: expect.any(Array),
+                    }),
+                )
             },
         )
 
@@ -149,7 +158,7 @@ describe('tasks-search tool', () => {
             expect(extractTextContent(result)).toMatchSnapshot()
 
             // Verify structured content for empty results
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent).toEqual(
                 expect.objectContaining({
                     tasks: [],

--- a/src/tools/__tests__/tasks-update-multiple.test.ts
+++ b/src/tools/__tests__/tasks-update-multiple.test.ts
@@ -1,7 +1,12 @@
 import type { Task, TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { tasksUpdateMultiple } from '../tasks-update-multiple.js'
-import { TEST_IDS, createMockTask, extractTextContent } from '../test-helpers.js'
+import {
+    TEST_IDS,
+    createMockTask,
+    extractStructuredContent,
+    extractTextContent,
+} from '../test-helpers.js'
 
 // Mock the Todoist API
 const mockTodoistApi = {
@@ -49,9 +54,13 @@ describe('tasks-update-multiple tool', () => {
             // Verify result matches expected structure with text and structured content
             const textContent = extractTextContent(result)
             expect(textContent).toContain('Updated 1 task')
-            const structuredContent = result.structuredContent
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    tasks: expect.arrayContaining([expect.objectContaining({ id: '8485093748' })]),
+                }),
+            )
             expect(structuredContent.tasks).toHaveLength(1)
-            expect(structuredContent.tasks[0]?.id).toBe('8485093748')
         })
 
         it('should update all tasks when multiple tasks are provided', async () => {
@@ -96,9 +105,14 @@ describe('tasks-update-multiple tool', () => {
             // Verify result matches expected structure with text and structured content
             const textContent = extractTextContent(result)
             expect(textContent).toContain('Updated 2 tasks')
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    totalCount: 2,
+                    tasks: expect.any(Array),
+                }),
+            )
             expect(structuredContent.tasks).toHaveLength(2)
-            expect(structuredContent.totalCount).toBe(2)
         })
 
         it('should update task priority and due date', async () => {
@@ -141,7 +155,7 @@ describe('tasks-update-multiple tool', () => {
             // Verify result structure
             const textContent = extractTextContent(result)
             expect(textContent).toContain('Updated 1 task')
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent.tasks).toHaveLength(1)
         })
 
@@ -176,7 +190,7 @@ describe('tasks-update-multiple tool', () => {
             // Verify result structure
             const textContent = extractTextContent(result)
             expect(textContent).toContain('Updated 1 task')
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent.tasks).toHaveLength(1)
         })
 
@@ -211,7 +225,7 @@ describe('tasks-update-multiple tool', () => {
             // Verify result structure
             const textContent = extractTextContent(result)
             expect(textContent).toContain('Updated 1 task')
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
             expect(structuredContent.tasks).toHaveLength(1)
         })
 
@@ -274,9 +288,13 @@ describe('tasks-update-multiple tool', () => {
             // Verify result structure
             const textContent = extractTextContent(result)
             expect(textContent).toContain('Updated 1 task')
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    tasks: expect.arrayContaining([expect.objectContaining({ id: '8485093752' })]),
+                }),
+            )
             expect(structuredContent.tasks).toHaveLength(1)
-            expect(structuredContent.tasks[0]?.id).toBe('8485093752')
         })
 
         it('should update task duration', async () => {
@@ -310,9 +328,13 @@ describe('tasks-update-multiple tool', () => {
             // Verify result structure
             const textContent = extractTextContent(result)
             expect(textContent).toContain('Updated 1 task')
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    tasks: expect.arrayContaining([expect.objectContaining({ id: '8485093753' })]),
+                }),
+            )
             expect(structuredContent.tasks).toHaveLength(1)
-            expect(structuredContent.tasks[0]?.id).toBe('8485093753')
         })
 
         it('should handle various duration formats', async () => {
@@ -404,9 +426,13 @@ describe('tasks-update-multiple tool', () => {
             // Verify result structure
             const textContent = extractTextContent(result)
             expect(textContent).toContain('Updated 1 task')
-            const { structuredContent } = result
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    tasks: expect.arrayContaining([expect.objectContaining({ id: '8485093755' })]),
+                }),
+            )
             expect(structuredContent.tasks).toHaveLength(1)
-            expect(structuredContent.tasks[0]?.id).toBe('8485093755')
         })
     })
 
@@ -543,7 +569,7 @@ describe('tasks-update-multiple tool', () => {
                 // Verify result structure
                 const textContent = extractTextContent(result)
                 expect(textContent).toContain('Updated 2 tasks')
-                const { structuredContent } = result
+                const structuredContent = extractStructuredContent(result)
                 expect(structuredContent.tasks).toHaveLength(2)
                 expect(structuredContent.totalCount).toBe(2)
             })
@@ -589,7 +615,7 @@ describe('tasks-update-multiple tool', () => {
                 // Verify results are returned in the correct order
                 const textContent = extractTextContent(result)
                 expect(textContent).toContain('Updated 3 tasks')
-                const { structuredContent } = result
+                const structuredContent = extractStructuredContent(result)
                 expect(structuredContent.tasks).toHaveLength(3)
                 expect(structuredContent.totalCount).toBe(3)
             })
@@ -619,9 +645,15 @@ describe('tasks-update-multiple tool', () => {
                 // Verify result structure
                 const textContent = extractTextContent(result)
                 expect(textContent).toContain('Updated 1 task')
-                const { structuredContent } = result
+                const structuredContent = extractStructuredContent(result)
+                expect(structuredContent).toEqual(
+                    expect.objectContaining({
+                        tasks: expect.arrayContaining([
+                            expect.objectContaining({ id: '8485093751' }),
+                        ]),
+                    }),
+                )
                 expect(structuredContent.tasks).toHaveLength(1)
-                expect(structuredContent.tasks[0]?.id).toBe('8485093751')
             })
 
             it('should handle complex reorganization scenario', async () => {
@@ -683,7 +715,7 @@ describe('tasks-update-multiple tool', () => {
                 // Verify result structure
                 const textContent = extractTextContent(result)
                 expect(textContent).toContain('Updated 3 tasks')
-                const { structuredContent } = result
+                const structuredContent = extractStructuredContent(result)
                 expect(structuredContent.tasks).toHaveLength(3)
                 expect(structuredContent.totalCount).toBe(3)
             })
@@ -722,9 +754,14 @@ describe('tasks-update-multiple tool', () => {
                 // Verify result structure
                 const textContent = extractTextContent(result)
                 expect(textContent).toContain('Updated 1 task')
-                const { structuredContent } = result
-                expect(structuredContent.tasks).toHaveLength(1)
-                expect(structuredContent.tasks[0]?.id).toBe('8485093752')
+                const structuredContent = extractStructuredContent(result)
+                expect(structuredContent).toEqual(
+                    expect.objectContaining({
+                        tasks: expect.arrayContaining([
+                            expect.objectContaining({ id: '8485093752' }),
+                        ]),
+                    }),
+                )
             })
 
             it('should handle empty updates (only id provided)', async () => {
@@ -740,7 +777,7 @@ describe('tasks-update-multiple tool', () => {
                 // Returns empty results since no moves were processed
                 const textContent = extractTextContent(result)
                 expect(textContent).toContain('Updated 0 tasks')
-                const { structuredContent } = result
+                const structuredContent = extractStructuredContent(result)
                 expect(structuredContent.tasks).toHaveLength(0)
                 expect(structuredContent.totalCount).toBe(0)
             })

--- a/src/tools/__tests__/tasks-update-multiple.test.ts
+++ b/src/tools/__tests__/tasks-update-multiple.test.ts
@@ -1,7 +1,7 @@
 import type { Task, TodoistApi } from '@doist/todoist-api-typescript'
 import { jest } from '@jest/globals'
 import { tasksUpdateMultiple } from '../tasks-update-multiple.js'
-import { TEST_IDS, createMockTask } from '../test-helpers.js'
+import { TEST_IDS, createMockTask, extractTextContent } from '../test-helpers.js'
 
 // Mock the Todoist API
 const mockTodoistApi = {
@@ -46,8 +46,12 @@ describe('tasks-update-multiple tool', () => {
                 description: 'Updated task description',
             })
 
-            // Verify result matches API response
-            expect(result).toEqual([mockApiResponse])
+            // Verify result matches expected structure with text and structured content
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('Updated 1 task')
+            const structuredContent = result.structuredContent
+            expect(structuredContent.tasks).toHaveLength(1)
+            expect(structuredContent.tasks[0]?.id).toBe('8485093748')
         })
 
         it('should update all tasks when multiple tasks are provided', async () => {
@@ -89,8 +93,12 @@ describe('tasks-update-multiple tool', () => {
                 description: 'Updated task description',
             })
 
-            // Verify result matches API response
-            expect(result).toEqual([mockApiResponse, mockApiResponse])
+            // Verify result matches expected structure with text and structured content
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('Updated 2 tasks')
+            const { structuredContent } = result
+            expect(structuredContent.tasks).toHaveLength(2)
+            expect(structuredContent.totalCount).toBe(2)
         })
 
         it('should update task priority and due date', async () => {
@@ -130,7 +138,11 @@ describe('tasks-update-multiple tool', () => {
                 dueString: 'Aug 20',
             })
 
-            expect(result).toEqual([mockApiResponse])
+            // Verify result structure
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('Updated 1 task')
+            const { structuredContent } = result
+            expect(structuredContent.tasks).toHaveLength(1)
         })
 
         it('should move task to different project', async () => {
@@ -161,7 +173,11 @@ describe('tasks-update-multiple tool', () => {
             })
             expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
 
-            expect(result).toEqual([mockApiResponse])
+            // Verify result structure
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('Updated 1 task')
+            const { structuredContent } = result
+            expect(structuredContent.tasks).toHaveLength(1)
         })
 
         it('should update task parent (create subtask relationship)', async () => {
@@ -192,7 +208,11 @@ describe('tasks-update-multiple tool', () => {
             })
             expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
 
-            expect(result).toEqual([mockApiResponse])
+            // Verify result structure
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('Updated 1 task')
+            const { structuredContent } = result
+            expect(structuredContent.tasks).toHaveLength(1)
         })
 
         it('should move task and update properties at once', async () => {
@@ -251,7 +271,12 @@ describe('tasks-update-multiple tool', () => {
                 dueString: 'every Friday',
             })
 
-            expect(result).toEqual([updatedTask])
+            // Verify result structure
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('Updated 1 task')
+            const { structuredContent } = result
+            expect(structuredContent.tasks).toHaveLength(1)
+            expect(structuredContent.tasks[0]?.id).toBe('8485093752')
         })
 
         it('should update task duration', async () => {
@@ -282,7 +307,12 @@ describe('tasks-update-multiple tool', () => {
                 durationUnit: 'minute',
             })
 
-            expect(result).toEqual([mockApiResponse])
+            // Verify result structure
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('Updated 1 task')
+            const { structuredContent } = result
+            expect(structuredContent.tasks).toHaveLength(1)
+            expect(structuredContent.tasks[0]?.id).toBe('8485093753')
         })
 
         it('should handle various duration formats', async () => {
@@ -371,7 +401,12 @@ describe('tasks-update-multiple tool', () => {
                 durationUnit: 'minute',
             })
 
-            expect(result).toEqual([updatedTask])
+            // Verify result structure
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('Updated 1 task')
+            const { structuredContent } = result
+            expect(structuredContent.tasks).toHaveLength(1)
+            expect(structuredContent.tasks[0]?.id).toBe('8485093755')
         })
     })
 
@@ -505,7 +540,12 @@ describe('tasks-update-multiple tool', () => {
                 })
                 expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
 
-                expect(result).toEqual(mockResponses)
+                // Verify result structure
+                const textContent = extractTextContent(result)
+                expect(textContent).toContain('Updated 2 tasks')
+                const { structuredContent } = result
+                expect(structuredContent.tasks).toHaveLength(2)
+                expect(structuredContent.totalCount).toBe(2)
             })
 
             it('should move multiple tasks with different destinations', async () => {
@@ -547,7 +587,11 @@ describe('tasks-update-multiple tool', () => {
                 expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
 
                 // Verify results are returned in the correct order
-                expect(result).toEqual(mockResponses)
+                const textContent = extractTextContent(result)
+                expect(textContent).toContain('Updated 3 tasks')
+                const { structuredContent } = result
+                expect(structuredContent.tasks).toHaveLength(3)
+                expect(structuredContent.totalCount).toBe(3)
             })
 
             it('should handle single task organization', async () => {
@@ -572,7 +616,12 @@ describe('tasks-update-multiple tool', () => {
                 })
                 expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
 
-                expect(result).toEqual([mockTaskResponse])
+                // Verify result structure
+                const textContent = extractTextContent(result)
+                expect(textContent).toContain('Updated 1 task')
+                const { structuredContent } = result
+                expect(structuredContent.tasks).toHaveLength(1)
+                expect(structuredContent.tasks[0]?.id).toBe('8485093751')
             })
 
             it('should handle complex reorganization scenario', async () => {
@@ -631,7 +680,12 @@ describe('tasks-update-multiple tool', () => {
                 })
                 expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
 
-                expect(result).toEqual(mockResponses)
+                // Verify result structure
+                const textContent = extractTextContent(result)
+                expect(textContent).toContain('Updated 3 tasks')
+                const { structuredContent } = result
+                expect(structuredContent.tasks).toHaveLength(3)
+                expect(structuredContent.totalCount).toBe(3)
             })
         })
 
@@ -664,7 +718,13 @@ describe('tasks-update-multiple tool', () => {
                     projectId: 'new-project-only',
                 })
                 expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
-                expect(result).toEqual([mockResponse])
+
+                // Verify result structure
+                const textContent = extractTextContent(result)
+                expect(textContent).toContain('Updated 1 task')
+                const { structuredContent } = result
+                expect(structuredContent.tasks).toHaveLength(1)
+                expect(structuredContent.tasks[0]?.id).toBe('8485093752')
             })
 
             it('should handle empty updates (only id provided)', async () => {
@@ -677,8 +737,12 @@ describe('tasks-update-multiple tool', () => {
                 expect(mockTodoistApi.moveTasks).not.toHaveBeenCalled()
                 expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
 
-                // Returns empty array since no moves were processed
-                expect(result).toEqual([])
+                // Returns empty results since no moves were processed
+                const textContent = extractTextContent(result)
+                expect(textContent).toContain('Updated 0 tasks')
+                const { structuredContent } = result
+                expect(structuredContent.tasks).toHaveLength(0)
+                expect(structuredContent.totalCount).toBe(0)
             })
         })
 

--- a/src/tools/delete-one.ts
+++ b/src/tools/delete-one.ts
@@ -2,10 +2,10 @@ import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { formatNextSteps } from '../utils/response-builders.js'
-import { TOOL_NAMES } from '../utils/tool-names.js'
+import { ToolNames } from '../utils/tool-names.js'
 
 const { PROJECTS_LIST, OVERVIEW, SECTIONS_SEARCH, TASKS_LIST_FOR_CONTAINER, TASKS_LIST_BY_DATE } =
-    TOOL_NAMES
+    ToolNames
 
 const ArgsSchema = {
     type: z.enum(['project', 'section', 'task']).describe('The type of entity to delete.'),
@@ -13,7 +13,7 @@ const ArgsSchema = {
 }
 
 const deleteOne = {
-    name: TOOL_NAMES.DELETE_ONE,
+    name: ToolNames.DELETE_ONE,
     description: 'Delete a project, section, or task by its ID.',
     parameters: ArgsSchema,
     async execute(args, client) {

--- a/src/tools/delete-one.ts
+++ b/src/tools/delete-one.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
+import { formatNextSteps } from '../utils/response-builders.js'
+import { TOOL_NAMES } from '../utils/tool-names.js'
+
+const { PROJECTS_LIST, OVERVIEW, SECTIONS_SEARCH, TASKS_LIST_FOR_CONTAINER, TASKS_LIST_BY_DATE } =
+    TOOL_NAMES
 
 const ArgsSchema = {
     type: z.enum(['project', 'section', 'task']).describe('The type of entity to delete.'),
@@ -7,7 +13,7 @@ const ArgsSchema = {
 }
 
 const deleteOne = {
-    name: 'delete-one',
+    name: TOOL_NAMES.DELETE_ONE,
     description: 'Delete a project, section, or task by its ID.',
     parameters: ArgsSchema,
     async execute(args, client) {
@@ -22,8 +28,64 @@ const deleteOne = {
                 await client.deleteTask(args.id)
                 break
         }
-        return { success: true }
+
+        const textContent = generateTextContent({
+            type: args.type,
+            id: args.id,
+        })
+
+        return getToolOutput({
+            textContent,
+            structuredContent: {
+                deletedEntity: {
+                    type: args.type,
+                    id: args.id,
+                },
+                success: true,
+            },
+        })
     },
 } satisfies TodoistTool<typeof ArgsSchema>
+
+function generateTextContent({
+    type,
+    id,
+}: {
+    type: 'project' | 'section' | 'task'
+    id: string
+}): string {
+    const summary = `Deleted ${type}: id=${id}`
+
+    // Recovery-focused next steps based on what was deleted
+    const nextSteps: string[] = []
+
+    switch (type) {
+        case 'project':
+            // Help user understand impact and navigate remaining work
+            nextSteps.push(`Use ${PROJECTS_LIST} to see remaining projects`)
+            nextSteps.push('Note: All tasks and sections in this project were also deleted')
+            nextSteps.push(`Use ${OVERVIEW} to review your updated project structure`)
+            break
+
+        case 'section':
+            // Guide user to reorganize remaining sections and tasks
+            nextSteps.push(`Use ${SECTIONS_SEARCH} to see remaining sections in the project`)
+            nextSteps.push('Note: Tasks in this section were also deleted')
+            nextSteps.push(
+                `Use ${TASKS_LIST_FOR_CONTAINER} with type=project to see unorganized tasks`,
+            )
+            break
+
+        case 'task':
+            // Help user stay focused on remaining work
+            nextSteps.push(`Use ${TASKS_LIST_BY_DATE} to see remaining tasks for today`)
+            nextSteps.push(`Use ${OVERVIEW} to check if this affects any dependent tasks`)
+            nextSteps.push('Note: Any subtasks of this task were also deleted')
+            break
+    }
+
+    const next = formatNextSteps(nextSteps)
+    return `${summary}\n${next}`
+}
 
 export { deleteOne }

--- a/src/tools/overview.ts
+++ b/src/tools/overview.ts
@@ -3,8 +3,8 @@ import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { type Project, isPersonalProject, mapTask } from '../tool-helpers.js'
-import { API_LIMITS } from '../utils/constants.js'
-import { TOOL_NAMES } from '../utils/tool-names.js'
+import { ApiLimits } from '../utils/constants.js'
+import { ToolNames } from '../utils/tool-names.js'
 
 const ArgsSchema = {
     projectId: z
@@ -130,7 +130,7 @@ function renderTaskTreeMarkdown(tasks: TaskTreeNode[], indent = ''): string[] {
     return lines
 }
 
-interface ProjectStructure {
+type ProjectStructure = {
     id: string
     name: string
     parentId: string | null
@@ -138,7 +138,7 @@ interface ProjectStructure {
     children: ProjectStructure[]
 }
 
-interface AccountOverviewStructured extends Record<string, unknown> {
+type AccountOverviewStructured = Record<string, unknown> & {
     type: 'account_overview'
     inbox: {
         id: string
@@ -185,7 +185,7 @@ async function getAllTasksForProject(client: TodoistApi, projectId: string): Pro
     do {
         const { results, nextCursor } = await client.getTasks({
             projectId,
-            limit: API_LIMITS.TASKS_BATCH_SIZE,
+            limit: ApiLimits.TASKS_BATCH_SIZE,
             cursor: cursor ?? undefined,
         })
         allTasks = allTasks.concat(results.map(mapTask))
@@ -322,7 +322,7 @@ async function generateProjectOverview(
 }
 
 const overview = {
-    name: TOOL_NAMES.OVERVIEW,
+    name: ToolNames.OVERVIEW,
     description:
         'Get a Markdown overview. If no projectId is provided, shows all projects with hierarchy and sections (useful for navigation). If projectId is provided, shows detailed overview of that specific project including all tasks grouped by sections.',
     parameters: ArgsSchema,

--- a/src/tools/overview.ts
+++ b/src/tools/overview.ts
@@ -1,7 +1,9 @@
 import type { Section, TodoistApi } from '@doist/todoist-api-typescript'
 import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { type Project, isPersonalProject, mapTask } from '../tool-helpers.js'
+import { TOOL_NAMES } from '../utils/tool-names.js'
 
 const ArgsSchema = {
     projectId: z
@@ -127,6 +129,55 @@ function renderTaskTreeMarkdown(tasks: TaskTreeNode[], indent = ''): string[] {
     return lines
 }
 
+interface ProjectStructure {
+    id: string
+    name: string
+    parentId: string | null
+    sections: Section[]
+    children: ProjectStructure[]
+}
+
+interface AccountOverviewStructured extends Record<string, unknown> {
+    type: 'account_overview'
+    inbox: {
+        id: string
+        name: string
+        sections: Section[]
+    } | null
+    projects: ProjectStructure[]
+    totalProjects: number
+    totalSections: number
+    hasNestedProjects: boolean
+}
+
+interface ProjectOverviewStructured extends Record<string, unknown> {
+    type: 'project_overview'
+    project: {
+        id: string
+        name: string
+    }
+    sections: Section[]
+    tasks: Array<ReturnType<typeof mapTask> & { children: never[] }>
+    stats: {
+        totalTasks: number
+        totalSections: number
+        tasksWithoutSection: number
+    }
+}
+
+function buildProjectStructure(
+    project: ProjectWithChildren,
+    sectionsByProject: Record<string, Section[]>,
+): ProjectStructure {
+    return {
+        id: project.id,
+        name: project.name,
+        parentId: isPersonalProject(project) ? (project.parentId ?? null) : null,
+        sections: sectionsByProject[project.id] || [],
+        children: project.children.map((child) => buildProjectStructure(child, sectionsByProject)),
+    }
+}
+
 async function getAllTasksForProject(client: TodoistApi, projectId: string): Promise<MappedTask[]> {
     let allTasks: MappedTask[] = []
     let cursor: string | undefined = undefined
@@ -147,8 +198,9 @@ async function getProjectSections(client: TodoistApi, projectId: string): Promis
     return results
 }
 
-// Account overview implementation
-async function generateAccountOverview(client: TodoistApi): Promise<string> {
+async function generateAccountOverview(
+    client: TodoistApi,
+): Promise<{ textContent: string; structuredContent: AccountOverviewStructured }> {
     const { results: projects } = await client.getProjects({})
     const inbox = projects.find((p) => isPersonalProject(p) && p.inboxProject === true)
     const nonInbox = projects.filter((p) => !isPersonalProject(p) || p.inboxProject !== true)
@@ -156,6 +208,7 @@ async function generateAccountOverview(client: TodoistApi): Promise<string> {
     const allProjectIds = projects.map((p) => p.id)
     const sectionsByProject = await getSectionsByProject(client, allProjectIds)
 
+    // Generate markdown text content
     const lines: string[] = ['# Personal Projects', '']
     if (inbox) {
         lines.push(`- Inbox Project: ${inbox.name} (id=${inbox.id})`)
@@ -179,11 +232,36 @@ async function generateAccountOverview(client: TodoistApi): Promise<string> {
             '',
         )
     }
-    return lines.join('\n')
+    const textContent = lines.join('\n')
+
+    // Generate structured content
+    const structuredContent = {
+        type: 'account_overview' as const,
+        inbox: inbox
+            ? {
+                  id: inbox.id,
+                  name: inbox.name,
+                  sections: sectionsByProject[inbox.id] || [],
+              }
+            : null,
+        projects: tree.map((project) =>
+            buildProjectStructure(project as ProjectWithChildren, sectionsByProject),
+        ),
+        totalProjects: projects.length,
+        totalSections: allProjectIds.reduce(
+            (total, id) => total + (sectionsByProject[id]?.length || 0),
+            0,
+        ),
+        hasNestedProjects: hasNested,
+    }
+
+    return { textContent, structuredContent }
 }
 
-// Project overview implementation
-async function generateProjectOverview(client: TodoistApi, projectId: string): Promise<string> {
+async function generateProjectOverview(
+    client: TodoistApi,
+    projectId: string,
+): Promise<{ textContent: string; structuredContent: ProjectOverviewStructured }> {
     const project: Project = await client.getProject(projectId)
     const sections = await getProjectSections(client, projectId)
     const allTasks = await getAllTasksForProject(client, projectId)
@@ -203,6 +281,7 @@ async function generateProjectOverview(client: TodoistApi, projectId: string): P
         }
     }
 
+    // Generate markdown text content
     const lines: string[] = [`# ${project.name}`]
     if (tasksWithoutSection.length > 0) {
         lines.push('')
@@ -219,20 +298,45 @@ async function generateProjectOverview(client: TodoistApi, projectId: string): P
         const tree = buildTaskTree(sectionTasks)
         lines.push(...renderTaskTreeMarkdown(tree))
     }
-    return lines.join('\n')
+    const textContent = lines.join('\n')
+
+    // Generate structured content
+    const structuredContent = {
+        type: 'project_overview' as const,
+        project: {
+            id: project.id,
+            name: project.name,
+        },
+        sections: sections,
+        tasks: allTasks.map((task) => ({
+            ...task,
+            children: [], // Tasks already include hierarchical info via parentId
+        })),
+        stats: {
+            totalTasks: allTasks.length,
+            totalSections: sections.length,
+            tasksWithoutSection: tasksWithoutSection.length,
+        },
+    }
+
+    return { textContent, structuredContent }
 }
 
 const overview = {
-    name: 'overview',
+    name: TOOL_NAMES.OVERVIEW,
     description:
         'Get a Markdown overview. If no projectId is provided, shows all projects with hierarchy and sections (useful for navigation). If projectId is provided, shows detailed overview of that specific project including all tasks grouped by sections.',
     parameters: ArgsSchema,
     async execute(args, client) {
-        if (args.projectId) {
-            return await generateProjectOverview(client, args.projectId)
-        }
-        return await generateAccountOverview(client)
+        const result = args.projectId
+            ? await generateProjectOverview(client, args.projectId)
+            : await generateAccountOverview(client)
+
+        return getToolOutput({
+            textContent: result.textContent,
+            structuredContent: result.structuredContent,
+        })
     },
 } satisfies TodoistTool<typeof ArgsSchema>
 
-export { overview }
+export { overview, type AccountOverviewStructured, type ProjectOverviewStructured }

--- a/src/tools/projects-list.ts
+++ b/src/tools/projects-list.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { mapProject } from '../tool-helpers.js'
+import { formatProjectPreview, summarizeList } from '../utils/response-builders.js'
+import { TOOL_NAMES } from '../utils/tool-names.js'
+
+const { PROJECTS_MANAGE, TASKS_LIST_FOR_CONTAINER } = TOOL_NAMES
 
 const ArgsSchema = {
     search: z
@@ -25,7 +30,7 @@ const ArgsSchema = {
 }
 
 const projectsList = {
-    name: 'projects-list',
+    name: TOOL_NAMES.PROJECTS_LIST,
     description:
         'List all projects or search for projects by name. If search parameter is omitted, all projects are returned.',
     parameters: ArgsSchema,
@@ -38,11 +43,89 @@ const projectsList = {
         const filtered = searchLower
             ? results.filter((project) => project.name.toLowerCase().includes(searchLower))
             : results
-        return {
-            projects: filtered.map(mapProject),
-            nextCursor,
-        }
+        const projects = filtered.map(mapProject)
+
+        return getToolOutput({
+            textContent: generateTextContent({
+                projects,
+                args,
+                nextCursor,
+            }),
+            structuredContent: {
+                projects,
+                nextCursor,
+                totalCount: projects.length,
+                hasMore: Boolean(nextCursor),
+                appliedFilters: {
+                    search: args.search,
+                    limit: args.limit,
+                    cursor: args.cursor,
+                },
+            },
+        })
     },
 } satisfies TodoistTool<typeof ArgsSchema>
+
+function generateTextContent({
+    projects,
+    args,
+    nextCursor,
+}: {
+    projects: ReturnType<typeof mapProject>[]
+    args: z.infer<z.ZodObject<typeof ArgsSchema>>
+    nextCursor: string | null
+}) {
+    // Generate subject description
+    const subject = args.search ? `Projects matching "${args.search}"` : 'Projects'
+
+    // Generate filter hints
+    const filterHints: string[] = []
+    if (args.search) {
+        filterHints.push(`search: "${args.search}"`)
+    }
+
+    // Generate project preview lines
+    const previewLimit = 10
+    const previewProjects = projects.slice(0, previewLimit)
+    const previewLines = previewProjects.map(formatProjectPreview).join('\n')
+    const remainingCount = projects.length - previewLimit
+    const previewWithMore =
+        remainingCount > 0 ? `${previewLines}\n    …and ${remainingCount} more` : previewLines
+
+    // Generate helpful suggestions for empty results
+    const zeroReasonHints: string[] = []
+    if (projects.length === 0) {
+        if (args.search) {
+            zeroReasonHints.push('Try broader search terms')
+            zeroReasonHints.push('Check spelling')
+            zeroReasonHints.push('Remove search to see all projects')
+        } else {
+            zeroReasonHints.push('No projects created yet')
+            zeroReasonHints.push(`Use ${PROJECTS_MANAGE} to create a project`)
+        }
+    }
+
+    // Generate contextual next steps
+    const nextSteps: string[] = []
+    if (projects.length > 0) {
+        nextSteps.push(
+            `Use ${TASKS_LIST_FOR_CONTAINER} with projectId to see tasks in specific projects.`,
+        )
+        if (projects.some((p) => p.isFavorite)) {
+            nextSteps.push('Favorite projects appear first in most Todoist views.')
+        }
+    }
+
+    return summarizeList({
+        subject,
+        count: projects.length,
+        limit: args.limit,
+        nextCursor: nextCursor ?? undefined,
+        filterHints,
+        previewLines: previewWithMore,
+        zeroReasonHints,
+        nextSteps,
+    })
+}
 
 export { projectsList }

--- a/src/tools/projects-list.ts
+++ b/src/tools/projects-list.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { mapProject } from '../tool-helpers.js'
+import { API_LIMITS } from '../utils/constants.js'
 import { formatProjectPreview, summarizeList } from '../utils/response-builders.js'
 import { TOOL_NAMES } from '../utils/tool-names.js'
 
@@ -18,8 +19,8 @@ const ArgsSchema = {
         .number()
         .int()
         .min(1)
-        .max(100)
-        .default(50)
+        .max(API_LIMITS.PROJECTS_MAX)
+        .default(API_LIMITS.PROJECTS_DEFAULT)
         .describe('The maximum number of projects to return.'),
     cursor: z
         .string()

--- a/src/tools/projects-list.ts
+++ b/src/tools/projects-list.ts
@@ -2,11 +2,11 @@ import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { mapProject } from '../tool-helpers.js'
-import { API_LIMITS } from '../utils/constants.js'
+import { ApiLimits } from '../utils/constants.js'
 import { formatProjectPreview, summarizeList } from '../utils/response-builders.js'
-import { TOOL_NAMES } from '../utils/tool-names.js'
+import { ToolNames } from '../utils/tool-names.js'
 
-const { PROJECTS_MANAGE, TASKS_LIST_FOR_CONTAINER } = TOOL_NAMES
+const { PROJECTS_MANAGE, TASKS_LIST_FOR_CONTAINER } = ToolNames
 
 const ArgsSchema = {
     search: z
@@ -19,8 +19,8 @@ const ArgsSchema = {
         .number()
         .int()
         .min(1)
-        .max(API_LIMITS.PROJECTS_MAX)
-        .default(API_LIMITS.PROJECTS_DEFAULT)
+        .max(ApiLimits.PROJECTS_MAX)
+        .default(ApiLimits.PROJECTS_DEFAULT)
         .describe('The maximum number of projects to return.'),
     cursor: z
         .string()
@@ -31,7 +31,7 @@ const ArgsSchema = {
 }
 
 const projectsList = {
-    name: TOOL_NAMES.PROJECTS_LIST,
+    name: ToolNames.PROJECTS_LIST,
     description:
         'List all projects or search for projects by name. If search parameter is omitted, all projects are returned.',
     parameters: ArgsSchema,
@@ -57,11 +57,7 @@ const projectsList = {
                 nextCursor,
                 totalCount: projects.length,
                 hasMore: Boolean(nextCursor),
-                appliedFilters: {
-                    search: args.search,
-                    limit: args.limit,
-                    cursor: args.cursor,
-                },
+                appliedFilters: args,
             },
         })
     },

--- a/src/tools/projects-manage.ts
+++ b/src/tools/projects-manage.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
-import { mapProject } from '../tool-helpers.js'
+import { formatNextSteps } from '../utils/response-builders.js'
+import { TOOL_NAMES } from '../utils/tool-names.js'
+
+const { SECTIONS_MANAGE, TASKS_ADD_MULTIPLE, PROJECTS_LIST, TASKS_LIST_FOR_CONTAINER, OVERVIEW } =
+    TOOL_NAMES
 
 const ArgsSchema = {
     id: z
@@ -14,7 +19,7 @@ const ArgsSchema = {
 }
 
 const projectsManage = {
-    name: 'projects-manage',
+    name: TOOL_NAMES.PROJECTS_MANAGE,
     description:
         'Add a new project or update an existing project. If id is provided, updates the project. If id is omitted, creates a new project.',
     parameters: ArgsSchema,
@@ -22,13 +27,58 @@ const projectsManage = {
         if (args.id) {
             // Update existing project
             const project = await client.updateProject(args.id, { name: args.name })
-            return project
+            const textContent = generateTextContent({ project, operation: 'updated' })
+
+            return getToolOutput({
+                textContent,
+                structuredContent: {
+                    project,
+                    operation: 'updated',
+                },
+            })
         }
 
         // Create new project
         const project = await client.addProject({ name: args.name })
-        return mapProject(project)
+        const textContent = generateTextContent({ project, operation: 'created' })
+
+        return getToolOutput({
+            textContent,
+            structuredContent: {
+                project,
+                operation: 'created',
+            },
+        })
     },
 } satisfies TodoistTool<typeof ArgsSchema>
+
+function generateTextContent({
+    project,
+    operation,
+}: {
+    project: { id: string; name: string }
+    operation: 'created' | 'updated'
+}): string {
+    const action = operation === 'created' ? 'Created' : 'Updated'
+    const summary = `${action} project: ${project.name} • id=${project.id}`
+
+    // Context-aware next steps based on operation
+    const nextSteps: string[] = []
+
+    if (operation === 'created') {
+        // For new projects, suggest logical setup workflow
+        nextSteps.push(`Use ${SECTIONS_MANAGE} to organize this project with sections`)
+        nextSteps.push(`Use ${TASKS_ADD_MULTIPLE} to add your first tasks`)
+        nextSteps.push(`Use ${OVERVIEW} with projectId to see updated project structure.`)
+    } else {
+        // For updated projects, suggest review and management
+        nextSteps.push(`Use ${OVERVIEW} with projectId=${project.id} to see project structure`)
+        nextSteps.push(`Use ${PROJECTS_LIST} to see all projects with updated name`)
+        nextSteps.push(`Use ${TASKS_LIST_FOR_CONTAINER} to review existing tasks`)
+    }
+
+    const next = formatNextSteps(nextSteps)
+    return `${summary}\n${next}`
+}
 
 export { projectsManage }

--- a/src/tools/projects-manage.ts
+++ b/src/tools/projects-manage.ts
@@ -2,10 +2,10 @@ import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { formatNextSteps } from '../utils/response-builders.js'
-import { TOOL_NAMES } from '../utils/tool-names.js'
+import { ToolNames } from '../utils/tool-names.js'
 
 const { SECTIONS_MANAGE, TASKS_ADD_MULTIPLE, PROJECTS_LIST, TASKS_LIST_FOR_CONTAINER, OVERVIEW } =
-    TOOL_NAMES
+    ToolNames
 
 const ArgsSchema = {
     id: z
@@ -19,7 +19,7 @@ const ArgsSchema = {
 }
 
 const projectsManage = {
-    name: TOOL_NAMES.PROJECTS_MANAGE,
+    name: ToolNames.PROJECTS_MANAGE,
     description:
         'Add a new project or update an existing project. If id is provided, updates the project. If id is omitted, creates a new project.',
     parameters: ArgsSchema,

--- a/src/tools/sections-manage.ts
+++ b/src/tools/sections-manage.ts
@@ -3,9 +3,9 @@ import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { formatNextSteps } from '../utils/response-builders.js'
-import { TOOL_NAMES } from '../utils/tool-names.js'
+import { ToolNames } from '../utils/tool-names.js'
 
-const { TASKS_ADD_MULTIPLE, TASKS_LIST_FOR_CONTAINER, OVERVIEW, SECTIONS_SEARCH } = TOOL_NAMES
+const { TASKS_ADD_MULTIPLE, TASKS_LIST_FOR_CONTAINER, OVERVIEW, SECTIONS_SEARCH } = ToolNames
 
 const ArgsSchema = {
     id: z
@@ -26,7 +26,7 @@ const ArgsSchema = {
 }
 
 const sectionsManage = {
-    name: TOOL_NAMES.SECTIONS_MANAGE,
+    name: ToolNames.SECTIONS_MANAGE,
     description:
         'Add a new section to a project or update an existing section. If id is provided, updates the section. If id is omitted, creates a new section (requires projectId).',
     parameters: ArgsSchema,

--- a/src/tools/sections-manage.ts
+++ b/src/tools/sections-manage.ts
@@ -1,6 +1,11 @@
+import type { Section } from '@doist/todoist-api-typescript'
 import { z } from 'zod'
-import { errorContent } from '../mcp-helpers.js'
+import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
+import { formatNextSteps } from '../utils/response-builders.js'
+import { TOOL_NAMES } from '../utils/tool-names.js'
+
+const { TASKS_ADD_MULTIPLE, TASKS_LIST_FOR_CONTAINER, OVERVIEW, SECTIONS_SEARCH } = TOOL_NAMES
 
 const ArgsSchema = {
     id: z
@@ -21,7 +26,7 @@ const ArgsSchema = {
 }
 
 const sectionsManage = {
-    name: 'sections-manage',
+    name: TOOL_NAMES.SECTIONS_MANAGE,
     description:
         'Add a new section to a project or update an existing section. If id is provided, updates the section. If id is omitted, creates a new section (requires projectId).',
     parameters: ArgsSchema,
@@ -29,12 +34,20 @@ const sectionsManage = {
         if (args.id) {
             // Update existing section
             const section = await client.updateSection(args.id, { name: args.name })
-            return section
+            const textContent = generateTextContent({ section, operation: 'updated' })
+
+            return getToolOutput({
+                textContent,
+                structuredContent: {
+                    section,
+                    operation: 'updated',
+                },
+            })
         }
 
         // Create new section - projectId is required
         if (!args.projectId) {
-            return errorContent(
+            throw new Error(
                 'Error: projectId is required when creating a new section (when id is not provided).',
             )
         }
@@ -44,8 +57,59 @@ const sectionsManage = {
             projectId: args.projectId,
         })
 
-        return section
+        const textContent = generateTextContent({ section, operation: 'created' })
+
+        return getToolOutput({
+            textContent,
+            structuredContent: {
+                section,
+                operation: 'created',
+            },
+        })
     },
 } satisfies TodoistTool<typeof ArgsSchema>
+
+function generateTextContent({
+    section,
+    operation,
+}: {
+    section: Section
+    operation: 'created' | 'updated'
+}): string {
+    const action = operation === 'created' ? 'Created' : 'Updated'
+    const summary = `${action} section: ${section.name} • id=${section.id}`
+
+    // Workflow-aware next steps based on operation and section context
+    const nextSteps: string[] = []
+
+    if (operation === 'created') {
+        // For new sections, suggest immediate setup workflow
+        nextSteps.push(
+            `Use ${TASKS_ADD_MULTIPLE} with sectionId=${section.id} to add your first tasks`,
+        )
+        nextSteps.push(
+            `Use ${TASKS_LIST_FOR_CONTAINER} with type=section and id=${section.id} to verify setup`,
+        )
+
+        // Suggest related organization
+        if (section.projectId) {
+            nextSteps.push(
+                `Use ${OVERVIEW} with projectId=${section.projectId} to see project organization`,
+            )
+        }
+    } else {
+        // For updated sections, suggest review and management
+        nextSteps.push(
+            `Use ${TASKS_LIST_FOR_CONTAINER} with type=section and id=${section.id} to see existing tasks`,
+        )
+        nextSteps.push(`Use ${SECTIONS_SEARCH} to see all sections in this project`)
+
+        // Suggest task updates if section was renamed
+        nextSteps.push('Consider updating task descriptions if section purpose changed')
+    }
+
+    const next = formatNextSteps(nextSteps)
+    return `${summary}\n${next}`
+}
 
 export { sectionsManage }

--- a/src/tools/sections-search.ts
+++ b/src/tools/sections-search.ts
@@ -3,9 +3,9 @@ import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { summarizeList } from '../utils/response-builders.js'
-import { TOOL_NAMES } from '../utils/tool-names.js'
+import { ToolNames } from '../utils/tool-names.js'
 
-const { SECTIONS_MANAGE, TASKS_LIST_FOR_CONTAINER, TASKS_UPDATE_MULTIPLE } = TOOL_NAMES
+const { SECTIONS_MANAGE, TASKS_LIST_FOR_CONTAINER, TASKS_UPDATE_MULTIPLE } = ToolNames
 
 const ArgsSchema = {
     projectId: z.string().min(1).describe('The ID of the project to search sections in.'),
@@ -17,13 +17,13 @@ const ArgsSchema = {
         ),
 }
 
-interface SectionSummary {
+type SectionSummary = {
     id: string
     name: string
 }
 
 const sectionsSearch = {
-    name: TOOL_NAMES.SECTIONS_SEARCH,
+    name: ToolNames.SECTIONS_SEARCH,
     description: 'Search for sections by name or other criteria in a project.',
     parameters: ArgsSchema,
     async execute(args, client) {
@@ -51,10 +51,7 @@ const sectionsSearch = {
             structuredContent: {
                 sections,
                 totalCount: sections.length,
-                appliedFilters: {
-                    projectId: args.projectId,
-                    search: args.search,
-                },
+                appliedFilters: args,
             },
         })
     },

--- a/src/tools/sections-search.ts
+++ b/src/tools/sections-search.ts
@@ -1,6 +1,11 @@
 import type { Section } from '@doist/todoist-api-typescript'
 import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
+import { summarizeList } from '../utils/response-builders.js'
+import { TOOL_NAMES } from '../utils/tool-names.js'
+
+const { SECTIONS_MANAGE, TASKS_LIST_FOR_CONTAINER, TASKS_UPDATE_MULTIPLE } = TOOL_NAMES
 
 const ArgsSchema = {
     projectId: z.string().min(1).describe('The ID of the project to search sections in.'),
@@ -12,8 +17,13 @@ const ArgsSchema = {
         ),
 }
 
+interface SectionSummary {
+    id: string
+    name: string
+}
+
 const sectionsSearch = {
-    name: 'sections-search',
+    name: TOOL_NAMES.SECTIONS_SEARCH,
     description: 'Search for sections by name or other criteria in a project.',
     parameters: ArgsSchema,
     async execute(args, client) {
@@ -24,11 +34,101 @@ const sectionsSearch = {
         const filtered = searchLower
             ? results.filter((section: Section) => section.name.toLowerCase().includes(searchLower))
             : results
-        return filtered.map((section: Section) => ({
+
+        const sections = filtered.map((section) => ({
             id: section.id,
             name: section.name,
         }))
+
+        const textContent = generateTextContent({
+            sections,
+            projectId: args.projectId,
+            search: args.search,
+        })
+
+        return getToolOutput({
+            textContent,
+            structuredContent: {
+                sections,
+                totalCount: sections.length,
+                appliedFilters: {
+                    projectId: args.projectId,
+                    search: args.search,
+                },
+            },
+        })
     },
 } satisfies TodoistTool<typeof ArgsSchema>
+
+function generateTextContent({
+    sections,
+    projectId,
+    search,
+}: {
+    sections: SectionSummary[]
+    projectId: string
+    search?: string
+}): string {
+    const zeroReasonHints: string[] = []
+
+    if (search) {
+        zeroReasonHints.push('Try broader search terms')
+        zeroReasonHints.push('Check spelling')
+        zeroReasonHints.push('Remove search to see all sections')
+    } else {
+        zeroReasonHints.push('Project has no sections yet')
+        zeroReasonHints.push(`Use ${SECTIONS_MANAGE} to create sections`)
+    }
+
+    // Data-driven next steps based on results
+    const nextSteps: string[] = []
+
+    if (sections.length > 0) {
+        // Suggestions based on number of sections found
+        if (sections.length === 1) {
+            const sectionId = sections[0]?.id
+            nextSteps.push(
+                `Use ${TASKS_LIST_FOR_CONTAINER} with type=section and id=${sectionId} to see tasks`,
+            )
+            nextSteps.push(`Use ${SECTIONS_MANAGE} to create additional sections for organization`)
+        } else if (sections.length > 8) {
+            nextSteps.push(
+                'Consider consolidating sections - many small sections can reduce productivity',
+            )
+            nextSteps.push(`Use ${TASKS_UPDATE_MULTIPLE} to move tasks between sections`)
+            nextSteps.push('Use delete-one with type=section to delete empty sections')
+        } else {
+            nextSteps.push(
+                `Use ${TASKS_LIST_FOR_CONTAINER} with type=section to see tasks in any section`,
+            )
+            nextSteps.push(`Use ${SECTIONS_MANAGE} to modify section names or order`)
+        }
+
+        // Search-specific suggestions
+        if (search) {
+            nextSteps.push('Remove search parameter to see all sections in this project')
+        }
+    } else {
+        // Empty result suggestions are already handled in zeroReasonHints
+        // No additional nextSteps needed for empty results
+    }
+
+    const subject = search
+        ? `Sections in project ${projectId} matching "${search}"`
+        : `Sections in project ${projectId}`
+
+    const previewLines =
+        sections.length > 0
+            ? sections.map((section) => `    ${section.name} • id=${section.id}`).join('\n')
+            : undefined
+
+    return summarizeList({
+        subject,
+        count: sections.length,
+        previewLines,
+        zeroReasonHints,
+        nextSteps,
+    })
+}
 
 export { sectionsSearch }

--- a/src/tools/tasks-add-multiple.ts
+++ b/src/tools/tasks-add-multiple.ts
@@ -4,8 +4,12 @@ import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { mapTask } from '../tool-helpers.js'
 import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
-import { generateTaskNextSteps, summarizeTaskOperation } from '../utils/response-builders.js'
-import { TOOL_NAMES } from '../utils/tool-names.js'
+import {
+    generateTaskNextSteps,
+    getDateString,
+    summarizeTaskOperation,
+} from '../utils/response-builders.js'
+import { ToolNames } from '../utils/tool-names.js'
 
 const TaskSchema = z.object({
     content: z.string().min(1).describe('The content of the task to create.'),
@@ -28,7 +32,7 @@ const ArgsSchema = {
 }
 
 const tasksAddMultiple = {
-    name: TOOL_NAMES.TASKS_ADD_MULTIPLE,
+    name: ToolNames.TASKS_ADD_MULTIPLE,
     description: 'Add one or more tasks to a project, section, or parent.',
     parameters: ArgsSchema,
     async execute(args, client) {
@@ -85,7 +89,8 @@ function generateTextContent({
     args: z.infer<z.ZodObject<typeof ArgsSchema>>
 }) {
     // Get context for smart next steps
-    const hasToday = tasks.some((task) => task.dueDate === new Date().toISOString().split('T')[0])
+    const todayStr = getDateString()
+    const hasToday = tasks.some((task) => task.dueDate === todayStr)
 
     // Generate context description without API calls
     let projectContext = ''

--- a/src/tools/tasks-add-multiple.ts
+++ b/src/tools/tasks-add-multiple.ts
@@ -1,8 +1,11 @@
 import type { AddTaskArgs, Task } from '@doist/todoist-api-typescript'
 import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { mapTask } from '../tool-helpers.js'
 import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
+import { generateTaskNextSteps, summarizeTaskOperation } from '../utils/response-builders.js'
+import { TOOL_NAMES } from '../utils/tool-names.js'
 
 const TaskSchema = z.object({
     content: z.string().min(1).describe('The content of the task to create.'),
@@ -25,12 +28,13 @@ const ArgsSchema = {
 }
 
 const tasksAddMultiple = {
-    name: 'tasks-add-multiple',
+    name: TOOL_NAMES.TASKS_ADD_MULTIPLE,
     description: 'Add one or more tasks to a project, section, or parent.',
     parameters: ArgsSchema,
     async execute(args, client) {
         const { projectId, sectionId, parentId, tasks } = args
         const newTasks: Task[] = []
+
         for (const task of tasks) {
             const { duration: durationStr, ...otherTaskArgs } = task
 
@@ -55,8 +59,49 @@ const tasksAddMultiple = {
 
             newTasks.push(await client.addTask(taskArgs))
         }
-        return newTasks.map(mapTask)
+
+        const mappedTasks = newTasks.map(mapTask)
+
+        const textContent = generateTextContent({
+            tasks: mappedTasks,
+            args,
+        })
+
+        return getToolOutput({
+            textContent,
+            structuredContent: {
+                tasks: mappedTasks,
+                totalCount: mappedTasks.length,
+            },
+        })
     },
 } satisfies TodoistTool<typeof ArgsSchema>
+
+function generateTextContent({
+    tasks,
+    args,
+}: {
+    tasks: ReturnType<typeof mapTask>[]
+    args: z.infer<z.ZodObject<typeof ArgsSchema>>
+}) {
+    // Get context for smart next steps
+    const hasToday = tasks.some((task) => task.dueDate === new Date().toISOString().split('T')[0])
+
+    // Generate context description without API calls
+    let projectContext = ''
+    if (args.projectId) {
+        projectContext = 'to specified project'
+    } else if (args.sectionId) {
+        projectContext = 'to specified section'
+    } else if (args.parentId) {
+        projectContext = 'as subtasks'
+    }
+
+    return summarizeTaskOperation('Added', tasks, {
+        context: projectContext,
+        nextSteps: generateTaskNextSteps('added', tasks, { hasToday }),
+        showDetails: true,
+    })
+}
 
 export { tasksAddMultiple }

--- a/src/tools/tasks-complete-multiple.ts
+++ b/src/tools/tasks-complete-multiple.ts
@@ -2,14 +2,14 @@ import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { summarizeBatch } from '../utils/response-builders.js'
-import { TOOL_NAMES } from '../utils/tool-names.js'
+import { ToolNames } from '../utils/tool-names.js'
 
 const ArgsSchema = {
     ids: z.array(z.string().min(1)).min(1).describe('The IDs of the tasks to complete.'),
 }
 
 const tasksCompleteMultiple = {
-    name: TOOL_NAMES.TASKS_COMPLETE_MULTIPLE,
+    name: ToolNames.TASKS_COMPLETE_MULTIPLE,
     description: 'Complete one or more tasks by their IDs.',
     parameters: ArgsSchema,
     async execute(args, client) {

--- a/src/tools/tasks-complete-multiple.ts
+++ b/src/tools/tasks-complete-multiple.ts
@@ -1,26 +1,87 @@
 import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
+import { summarizeBatch } from '../utils/response-builders.js'
+import { TOOL_NAMES } from '../utils/tool-names.js'
 
 const ArgsSchema = {
     ids: z.array(z.string().min(1)).min(1).describe('The IDs of the tasks to complete.'),
 }
 
 const tasksCompleteMultiple = {
-    name: 'tasks-complete-multiple',
+    name: TOOL_NAMES.TASKS_COMPLETE_MULTIPLE,
     description: 'Complete one or more tasks by their IDs.',
     parameters: ArgsSchema,
     async execute(args, client) {
         const completed: string[] = []
+        const failures: Array<{ item: string; error: string; code?: string }> = []
+
         for (const id of args.ids) {
             try {
                 await client.closeTask(id)
                 completed.push(id)
-            } catch {
-                // Ignore errors for individual tasks, continue with others
+            } catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+                failures.push({
+                    item: id,
+                    error: errorMessage,
+                })
             }
         }
-        return { success: true, completed }
+
+        const textContent = generateTextContent({
+            completed,
+            failures,
+            args,
+        })
+
+        return getToolOutput({
+            textContent,
+            structuredContent: {
+                completed,
+                failures,
+                totalRequested: args.ids.length,
+                successCount: completed.length,
+                failureCount: failures.length,
+            },
+        })
     },
 } satisfies TodoistTool<typeof ArgsSchema>
+
+function generateNextSteps(completed: number, failures: number): string[] {
+    if (completed > 0) {
+        const moveResult =
+            failures === 0
+                ? "Use tasks-list-by-date('overdue') to tackle remaining overdue items."
+                : 'Review failed completions and retry if needed.'
+        return [moveResult]
+    }
+
+    if (failures > 0) {
+        return ['Check task IDs and permissions, then retry.']
+    }
+
+    return ['No tasks were completed.']
+}
+
+function generateTextContent({
+    completed,
+    failures,
+    args,
+}: {
+    completed: string[]
+    failures: Array<{ item: string; error: string; code?: string }>
+    args: z.infer<z.ZodObject<typeof ArgsSchema>>
+}) {
+    const nextSteps = generateNextSteps(completed.length, failures.length)
+    return summarizeBatch({
+        action: 'Completed tasks',
+        success: completed.length,
+        total: args.ids.length,
+        successItems: completed,
+        failures,
+        nextSteps,
+    })
+}
 
 export { tasksCompleteMultiple }

--- a/src/tools/tasks-list-by-date.ts
+++ b/src/tools/tasks-list-by-date.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { getTasksByFilter } from '../tool-helpers.js'
+import { API_LIMITS } from '../utils/constants.js'
 import { generateTaskNextSteps, previewTasks, summarizeList } from '../utils/response-builders.js'
 import { TOOL_NAMES } from '../utils/tool-names.js'
 
@@ -26,8 +27,8 @@ const ArgsSchema = {
         .number()
         .int()
         .min(1)
-        .max(50)
-        .default(10)
+        .max(API_LIMITS.TASKS_MAX)
+        .default(API_LIMITS.TASKS_DEFAULT)
         .describe('The maximum number of tasks to return.'),
     cursor: z
         .string()

--- a/src/tools/tasks-list-by-date.ts
+++ b/src/tools/tasks-list-by-date.ts
@@ -130,13 +130,13 @@ function generateTextContent({
     }
 
     // Generate contextual next steps
+    const now = new Date()
+    const todayStr = now.toISOString().split('T')[0]
     const nextSteps = generateTaskNextSteps('listed', tasks, {
-        hasToday:
-            args.startDate === 'today' ||
-            tasks.some((task) => task.dueDate === new Date().toISOString().split('T')[0]),
+        hasToday: args.startDate === 'today' || tasks.some((task) => task.dueDate === todayStr),
         hasOverdue:
             args.startDate === 'overdue' ||
-            tasks.some((task) => task.dueDate && new Date(task.dueDate) < new Date()),
+            tasks.some((task) => task.dueDate && new Date(task.dueDate) < now),
     })
 
     return summarizeList({

--- a/src/tools/tasks-list-completed.ts
+++ b/src/tools/tasks-list-completed.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { mapTask } from '../tool-helpers.js'
+import { API_LIMITS } from '../utils/constants.js'
 import { previewTasks, summarizeList } from '../utils/response-builders.js'
 import { TOOL_NAMES } from '../utils/tool-names.js'
 
@@ -30,9 +31,9 @@ const ArgsSchema = {
         .number()
         .int()
         .min(1)
-        .max(200)
-        .default(50)
-        .describe('The maximum number of tasks to return. Default is 50, maximum is 200.'),
+        .max(API_LIMITS.COMPLETED_TASKS_MAX)
+        .default(API_LIMITS.COMPLETED_TASKS_DEFAULT)
+        .describe('The maximum number of tasks to return.'),
     cursor: z
         .string()
         .optional()

--- a/src/tools/tasks-list-completed.ts
+++ b/src/tools/tasks-list-completed.ts
@@ -2,9 +2,9 @@ import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { mapTask } from '../tool-helpers.js'
-import { API_LIMITS } from '../utils/constants.js'
+import { ApiLimits } from '../utils/constants.js'
 import { previewTasks, summarizeList } from '../utils/response-builders.js'
-import { TOOL_NAMES } from '../utils/tool-names.js'
+import { ToolNames } from '../utils/tool-names.js'
 
 const ArgsSchema = {
     getBy: z
@@ -31,8 +31,8 @@ const ArgsSchema = {
         .number()
         .int()
         .min(1)
-        .max(API_LIMITS.COMPLETED_TASKS_MAX)
-        .default(API_LIMITS.COMPLETED_TASKS_DEFAULT)
+        .max(ApiLimits.COMPLETED_TASKS_MAX)
+        .default(ApiLimits.COMPLETED_TASKS_DEFAULT)
         .describe('The maximum number of tasks to return.'),
     cursor: z
         .string()
@@ -43,7 +43,7 @@ const ArgsSchema = {
 }
 
 const tasksListCompleted = {
-    name: TOOL_NAMES.TASKS_LIST_COMPLETED,
+    name: ToolNames.TASKS_LIST_COMPLETED,
     description: 'Get completed tasks.',
     parameters: ArgsSchema,
     async execute(args, client) {
@@ -67,17 +67,7 @@ const tasksListCompleted = {
                 nextCursor,
                 totalCount: mappedTasks.length,
                 hasMore: Boolean(nextCursor),
-                appliedFilters: {
-                    getBy: args.getBy,
-                    since: args.since,
-                    until: args.until,
-                    workspaceId: args.workspaceId,
-                    projectId: args.projectId,
-                    sectionId: args.sectionId,
-                    parentId: args.parentId,
-                    limit: args.limit,
-                    cursor: args.cursor,
-                },
+                appliedFilters: args,
             },
         })
     },

--- a/src/tools/tasks-list-for-container.ts
+++ b/src/tools/tasks-list-for-container.ts
@@ -1,7 +1,12 @@
 import { GetTasksArgs } from '@doist/todoist-api-typescript'
 import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { mapTask } from '../tool-helpers.js'
+import { generateTaskNextSteps, previewTasks, summarizeList } from '../utils/response-builders.js'
+import { TOOL_NAMES } from '../utils/tool-names.js'
+
+const { TASKS_ADD_MULTIPLE } = TOOL_NAMES
 
 const ArgsSchema = {
     type: z
@@ -24,7 +29,7 @@ const ArgsSchema = {
 }
 
 const tasksListForContainer = {
-    name: 'tasks-list-for-container',
+    name: TOOL_NAMES.TASKS_LIST_FOR_CONTAINER,
     description: 'Get tasks for a specific project, section, or parent task (subtasks).',
     parameters: ArgsSchema,
     async execute(args, client) {
@@ -48,12 +53,95 @@ const tasksListForContainer = {
         }
 
         const { results, nextCursor } = await client.getTasks(taskParams)
+        const mappedTasks = results.map(mapTask)
 
-        return {
-            tasks: results.map(mapTask),
+        const textContent = generateTextContent({
+            tasks: mappedTasks,
+            args,
             nextCursor,
-        }
+        })
+
+        return getToolOutput({
+            textContent,
+            structuredContent: {
+                tasks: mappedTasks,
+                nextCursor,
+                totalCount: mappedTasks.length,
+                hasMore: Boolean(nextCursor),
+                appliedFilters: {
+                    type: args.type,
+                    id: args.id,
+                    limit: args.limit,
+                    cursor: args.cursor,
+                },
+                containerInfo: {
+                    type: args.type,
+                    id: args.id,
+                },
+            },
+        })
     },
 } satisfies TodoistTool<typeof ArgsSchema>
+
+function generateTextContent({
+    tasks,
+    args,
+    nextCursor,
+}: {
+    tasks: ReturnType<typeof mapTask>[]
+    args: z.infer<z.ZodObject<typeof ArgsSchema>>
+    nextCursor: string | null
+}) {
+    // Generate container descriptions without API calls
+    let subject: string
+    let filterHints: string[] = []
+
+    switch (args.type) {
+        case 'project':
+            subject = 'Tasks in project'
+            filterHints = [`in project ${args.id}`]
+            break
+        case 'section':
+            subject = 'Tasks in section'
+            filterHints = [`in section ${args.id}`]
+            break
+        case 'parent':
+            subject = 'Subtasks'
+            filterHints = [`subtasks of ${args.id}`]
+            break
+    }
+
+    // Generate helpful suggestions for empty results
+    const zeroReasonHints: string[] = []
+    if (tasks.length === 0) {
+        if (args.type === 'project') {
+            zeroReasonHints.push('Project has no tasks yet')
+            zeroReasonHints.push(`Use ${TASKS_ADD_MULTIPLE} to create tasks`)
+        } else if (args.type === 'section') {
+            zeroReasonHints.push('Section is empty')
+            zeroReasonHints.push('Tasks may be in other sections of the project')
+        } else {
+            zeroReasonHints.push('No subtasks created yet')
+            zeroReasonHints.push(`Use ${TASKS_ADD_MULTIPLE} with parentId to add subtasks`)
+        }
+    }
+
+    // Generate contextual next steps
+    const nextSteps = generateTaskNextSteps('listed', tasks, {
+        hasToday: tasks.some((task) => task.dueDate === new Date().toISOString().split('T')[0]),
+        hasOverdue: tasks.some((task) => task.dueDate && new Date(task.dueDate) < new Date()),
+    })
+
+    return summarizeList({
+        subject,
+        count: tasks.length,
+        limit: args.limit,
+        nextCursor: nextCursor ?? undefined,
+        filterHints,
+        previewLines: previewTasks(tasks),
+        zeroReasonHints,
+        nextSteps,
+    })
+}
 
 export { tasksListForContainer }

--- a/src/tools/tasks-list-for-container.ts
+++ b/src/tools/tasks-list-for-container.ts
@@ -127,9 +127,11 @@ function generateTextContent({
     }
 
     // Generate contextual next steps
+    const now = new Date()
+    const todayStr = now.toISOString().split('T')[0]
     const nextSteps = generateTaskNextSteps('listed', tasks, {
-        hasToday: tasks.some((task) => task.dueDate === new Date().toISOString().split('T')[0]),
-        hasOverdue: tasks.some((task) => task.dueDate && new Date(task.dueDate) < new Date()),
+        hasToday: tasks.some((task) => task.dueDate === todayStr),
+        hasOverdue: tasks.some((task) => task.dueDate && new Date(task.dueDate) < now),
     })
 
     return summarizeList({

--- a/src/tools/tasks-list-for-container.ts
+++ b/src/tools/tasks-list-for-container.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { mapTask } from '../tool-helpers.js'
+import { API_LIMITS } from '../utils/constants.js'
 import { generateTaskNextSteps, previewTasks, summarizeList } from '../utils/response-builders.js'
 import { TOOL_NAMES } from '../utils/tool-names.js'
 
@@ -17,8 +18,8 @@ const ArgsSchema = {
         .number()
         .int()
         .min(1)
-        .max(50)
-        .default(10)
+        .max(API_LIMITS.TASKS_MAX)
+        .default(API_LIMITS.TASKS_DEFAULT)
         .describe('The maximum number of tasks to return.'),
     cursor: z
         .string()

--- a/src/tools/tasks-search.ts
+++ b/src/tools/tasks-search.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { getTasksByFilter } from '../tool-helpers.js'
+import { generateTaskNextSteps, previewTasks, summarizeList } from '../utils/response-builders.js'
+import { TOOL_NAMES } from '../utils/tool-names.js'
 
 const ArgsSchema = {
     searchText: z.string().min(1).describe('The text to search for in tasks.'),
@@ -20,17 +23,77 @@ const ArgsSchema = {
 }
 
 const tasksSearch = {
-    name: 'tasks-search',
+    name: TOOL_NAMES.TASKS_SEARCH,
     description: "Search tasks by text using Todoist's filter query.",
     parameters: ArgsSchema,
     async execute(args, client) {
-        return await getTasksByFilter({
+        const result = await getTasksByFilter({
             client,
             query: `search: ${args.searchText}`,
             cursor: args.cursor,
             limit: args.limit,
         })
+
+        const textContent = generateTextContent({
+            tasks: result.tasks,
+            args,
+            nextCursor: result.nextCursor,
+        })
+
+        return getToolOutput({
+            textContent,
+            structuredContent: {
+                tasks: result.tasks,
+                nextCursor: result.nextCursor,
+                totalCount: result.tasks.length,
+                hasMore: Boolean(result.nextCursor),
+                appliedFilters: {
+                    searchText: args.searchText,
+                    limit: args.limit,
+                    cursor: args.cursor,
+                },
+                searchQuery: `search: ${args.searchText}`,
+            },
+        })
     },
 } satisfies TodoistTool<typeof ArgsSchema>
+
+function generateTextContent({
+    tasks,
+    args,
+    nextCursor,
+}: {
+    tasks: Awaited<ReturnType<typeof getTasksByFilter>>['tasks']
+    args: z.infer<z.ZodObject<typeof ArgsSchema>>
+    nextCursor: string | null
+}) {
+    // Generate filter description
+    const filterHints = [`matching "${args.searchText}"`]
+
+    // Generate helpful suggestions for empty results
+    const zeroReasonHints: string[] = []
+    if (tasks.length === 0) {
+        zeroReasonHints.push('Try broader search terms')
+        zeroReasonHints.push('Check completed tasks with tasks-list-completed')
+        zeroReasonHints.push('Verify spelling and try partial words')
+    }
+
+    // Generate contextual next steps
+    const nextSteps = generateTaskNextSteps('listed', tasks, {
+        hasToday: tasks.some((task) => task.dueDate === new Date().toISOString().split('T')[0]),
+        hasOverdue: tasks.some((task) => task.dueDate && new Date(task.dueDate) < new Date()),
+    })
+
+    return summarizeList({
+        subject: `Search results for "${args.searchText}"`,
+        count: tasks.length,
+        limit: args.limit,
+        nextCursor: nextCursor ?? undefined,
+        filterHints,
+        previewLines: previewTasks(tasks),
+        zeroReasonHints,
+        nextSteps,
+    })
+}
 
 export { tasksSearch }

--- a/src/tools/tasks-search.ts
+++ b/src/tools/tasks-search.ts
@@ -79,9 +79,11 @@ function generateTextContent({
     }
 
     // Generate contextual next steps
+    const now = new Date()
+    const todayDateString = now.toISOString().split('T')[0]
     const nextSteps = generateTaskNextSteps('listed', tasks, {
-        hasToday: tasks.some((task) => task.dueDate === new Date().toISOString().split('T')[0]),
-        hasOverdue: tasks.some((task) => task.dueDate && new Date(task.dueDate) < new Date()),
+        hasToday: tasks.some((task) => task.dueDate === todayDateString),
+        hasOverdue: tasks.some((task) => task.dueDate && new Date(task.dueDate) < now),
     })
 
     return summarizeList({

--- a/src/tools/tasks-search.ts
+++ b/src/tools/tasks-search.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
 import { getTasksByFilter } from '../tool-helpers.js'
+import { API_LIMITS } from '../utils/constants.js'
 import { generateTaskNextSteps, previewTasks, summarizeList } from '../utils/response-builders.js'
 import { TOOL_NAMES } from '../utils/tool-names.js'
 
@@ -11,8 +12,8 @@ const ArgsSchema = {
         .number()
         .int()
         .min(1)
-        .max(50)
-        .default(10)
+        .max(API_LIMITS.TASKS_MAX)
+        .default(API_LIMITS.TASKS_DEFAULT)
         .describe('The maximum number of tasks to return.'),
     cursor: z
         .string()

--- a/src/tools/tasks-update-multiple.ts
+++ b/src/tools/tasks-update-multiple.ts
@@ -1,8 +1,11 @@
 import type { Task, UpdateTaskArgs } from '@doist/todoist-api-typescript'
 import { z } from 'zod'
-import type { TodoistTool } from '../todoist-tool'
-import { createMoveTaskArgs } from '../tool-helpers.js'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TodoistTool } from '../todoist-tool.js'
+import { createMoveTaskArgs, mapTask } from '../tool-helpers.js'
 import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
+import { summarizeTaskOperation } from '../utils/response-builders.js'
+import { TOOL_NAMES } from '../utils/tool-names.js'
 
 const TasksUpdateSchema = z.object({
     id: z.string().min(1).describe('The ID of the task to update.'),
@@ -38,7 +41,7 @@ const ArgsSchema = {
 }
 
 const tasksUpdateMultiple = {
-    name: 'tasks-update-multiple',
+    name: TOOL_NAMES.TASKS_UPDATE_MULTIPLE,
     description: 'Update multiple existing tasks with new values.',
     parameters: ArgsSchema,
     async execute(args, client) {
@@ -93,9 +96,59 @@ const tasksUpdateMultiple = {
         const updatedTasks = (await Promise.all(updateTasksPromises)).filter(
             (task): task is Task => task !== undefined,
         )
-        return updatedTasks
+
+        const mappedTasks = updatedTasks.map(mapTask)
+
+        const textContent = generateTextContent({
+            tasks: mappedTasks,
+            args,
+        })
+
+        return getToolOutput({
+            textContent,
+            structuredContent: {
+                tasks: mappedTasks,
+                totalCount: mappedTasks.length,
+                updatedTaskIds: updatedTasks.map((task) => task.id),
+                appliedOperations: {
+                    updateCount: mappedTasks.length,
+                    skippedCount: tasks.length - mappedTasks.length,
+                },
+            },
+        })
     },
 } satisfies TodoistTool<typeof ArgsSchema>
+
+function generateTextContent({
+    tasks,
+    args,
+}: {
+    tasks: ReturnType<typeof mapTask>[]
+    args: z.infer<z.ZodObject<typeof ArgsSchema>>
+}) {
+    const totalRequested = args.tasks.length
+    const actuallyUpdated = tasks.length
+    const skipped = totalRequested - actuallyUpdated
+
+    let context = ''
+    if (skipped > 0) {
+        context = ` (${skipped} skipped - no changes)`
+    }
+
+    const nextSteps: string[] = []
+    if (tasks.length > 0) {
+        nextSteps.push('Use tasks-list-by-date to see your updated schedule')
+        nextSteps.push('Use overview to see updated project organization')
+    } else {
+        nextSteps.push('Use tasks-list-by-date to see current tasks')
+    }
+
+    return summarizeTaskOperation('Updated', tasks, {
+        context,
+        nextSteps,
+        showDetails: tasks.length <= 5,
+    })
+}
 
 function hasUpdatesToMake({ id, ...otherUpdateArgs }: TaskUpdate) {
     return Object.keys(otherUpdateArgs).length > 0

--- a/src/tools/tasks-update-multiple.ts
+++ b/src/tools/tasks-update-multiple.ts
@@ -5,7 +5,7 @@ import type { TodoistTool } from '../todoist-tool.js'
 import { createMoveTaskArgs, mapTask } from '../tool-helpers.js'
 import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
 import { summarizeTaskOperation } from '../utils/response-builders.js'
-import { TOOL_NAMES } from '../utils/tool-names.js'
+import { ToolNames } from '../utils/tool-names.js'
 
 const TasksUpdateSchema = z.object({
     id: z.string().min(1).describe('The ID of the task to update.'),
@@ -41,7 +41,7 @@ const ArgsSchema = {
 }
 
 const tasksUpdateMultiple = {
-    name: TOOL_NAMES.TASKS_UPDATE_MULTIPLE,
+    name: ToolNames.TASKS_UPDATE_MULTIPLE,
     description: 'Update multiple existing tasks with new values.',
     parameters: ArgsSchema,
     async execute(args, client) {

--- a/src/tools/test-helpers.ts
+++ b/src/tools/test-helpers.ts
@@ -160,6 +160,33 @@ export function createTestCases<T, E = unknown>(
 }
 
 /**
+ * Extracts the text content from a tool output for snapshot testing.
+ * This allows tests to match against just the text content while tools return structured output.
+ */
+export function extractTextContent(toolOutput: unknown): string {
+    if (typeof toolOutput === 'string') {
+        return toolOutput
+    }
+
+    if (typeof toolOutput === 'object' && toolOutput !== null && 'content' in toolOutput) {
+        const output = toolOutput as { content: unknown }
+        if (
+            Array.isArray(output.content) &&
+            output.content[0] &&
+            typeof output.content[0] === 'object' &&
+            output.content[0] !== null &&
+            'type' in output.content[0] &&
+            'text' in output.content[0] &&
+            output.content[0].type === 'text'
+        ) {
+            return output.content[0].text as string
+        }
+    }
+
+    throw new Error('Expected tool output to have text content')
+}
+
+/**
  * Common mock IDs used across tests for consistency.
  */
 export const TEST_IDS = {
@@ -173,3 +200,9 @@ export const TEST_IDS = {
     SECTION_2: 'section-456',
     USER_ID: '713437',
 } as const
+
+/**
+ * Fixed date for consistent test snapshots.
+ * Use this instead of new Date() in tests to avoid snapshot drift.
+ */
+export const TODAY = '2025-08-17' as const

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -6,7 +6,7 @@
  */
 
 // API Pagination Limits
-export const API_LIMITS = {
+export const ApiLimits = {
     /** Default limit for task listings */
     TASKS_DEFAULT: 10,
     /** Maximum limit for task search and list operations */
@@ -24,7 +24,7 @@ export const API_LIMITS = {
 } as const
 
 // UI Display Limits
-export const DISPLAY_LIMITS = {
+export const DisplayLimits = {
     /** Maximum number of failures to show in detailed error messages */
     MAX_FAILURES_SHOWN: 3,
     /** Threshold for suggesting batch operations */
@@ -32,7 +32,7 @@ export const DISPLAY_LIMITS = {
 } as const
 
 // Response Builder Configuration
-export const RESPONSE_CONFIG = {
+export const ResponseConfig = {
     /** Maximum characters per line in text responses */
     MAX_LINE_LENGTH: 100,
     /** Indentation for nested items */

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,40 @@
+/**
+ * Application-wide constants
+ *
+ * This module centralizes magic numbers and configuration values
+ * to improve maintainability and provide a single source of truth.
+ */
+
+// API Pagination Limits
+export const API_LIMITS = {
+    /** Default limit for task listings */
+    TASKS_DEFAULT: 10,
+    /** Maximum limit for task search and list operations */
+    TASKS_MAX: 50,
+    /** Default limit for completed tasks */
+    COMPLETED_TASKS_DEFAULT: 50,
+    /** Maximum limit for completed tasks */
+    COMPLETED_TASKS_MAX: 200,
+    /** Default limit for project listings */
+    PROJECTS_DEFAULT: 50,
+    /** Maximum limit for project listings */
+    PROJECTS_MAX: 100,
+    /** Batch size for fetching all tasks in a project */
+    TASKS_BATCH_SIZE: 50,
+} as const
+
+// UI Display Limits
+export const DISPLAY_LIMITS = {
+    /** Maximum number of failures to show in detailed error messages */
+    MAX_FAILURES_SHOWN: 3,
+    /** Threshold for suggesting batch operations */
+    BATCH_OPERATION_THRESHOLD: 10,
+} as const
+
+// Response Builder Configuration
+export const RESPONSE_CONFIG = {
+    /** Maximum characters per line in text responses */
+    MAX_LINE_LENGTH: 100,
+    /** Indentation for nested items */
+    INDENT_SIZE: 2,
+} as const

--- a/src/utils/response-builders.ts
+++ b/src/utils/response-builders.ts
@@ -1,5 +1,13 @@
-import { DISPLAY_LIMITS } from './constants.js'
-import { TOOL_NAMES } from './tool-names.js'
+import { DisplayLimits } from './constants.js'
+import { ToolNames } from './tool-names.js'
+
+/**
+ * Helper function to get date string in YYYY-MM-DD format
+ */
+export function getDateString(date: Date = new Date()): string {
+    const parts = date.toISOString().split('T')
+    return parts[0] ?? ''
+}
 
 const {
     TASKS_LIST_BY_DATE,
@@ -7,9 +15,9 @@ const {
     TASKS_UPDATE_MULTIPLE,
     TASKS_COMPLETE_MULTIPLE,
     OVERVIEW,
-} = TOOL_NAMES
+} = ToolNames
 
-interface TaskLike {
+type TaskLike = {
     id?: string
     content?: string
     title?: string
@@ -18,7 +26,7 @@ interface TaskLike {
     projectName?: string
 }
 
-interface ProjectLike {
+type ProjectLike = {
     id: string
     name: string
     color?: string
@@ -29,13 +37,13 @@ interface ProjectLike {
     viewStyle?: string
 }
 
-interface TaskOperationOptions {
+type TaskOperationOptions = {
     nextSteps?: string[]
     context?: string
     showDetails?: boolean
 }
 
-interface BatchOperationParams {
+type BatchOperationParams = {
     action: string
     success: number
     total: number
@@ -103,11 +111,11 @@ export function summarizeBatch(params: BatchOperationParams): string {
     if (failures?.length) {
         const failureCount = failures.length
         const failureBit = `Failed (${failureCount}):\n${failures
-            .slice(0, DISPLAY_LIMITS.MAX_FAILURES_SHOWN)
+            .slice(0, DisplayLimits.MAX_FAILURES_SHOWN)
             .map((f) => `    ${f.item} (Error: ${f.error}${f.code ? ` [${f.code}]` : ''})`)
             .join(
                 '\n',
-            )}${failureCount > DISPLAY_LIMITS.MAX_FAILURES_SHOWN ? `, +${failureCount - DISPLAY_LIMITS.MAX_FAILURES_SHOWN} more` : ''}.`
+            )}${failureCount > DisplayLimits.MAX_FAILURES_SHOWN ? `, +${failureCount - DisplayLimits.MAX_FAILURES_SHOWN} more` : ''}.`
         bits.push(failureBit)
     }
 
@@ -293,7 +301,7 @@ export function generateTaskNextSteps(
                 nextSteps.push(`Use ${OVERVIEW} with projectId to see tasks in other projects`)
             } else if (count > 0) {
                 // Tailor suggestions based on result size
-                if (count > DISPLAY_LIMITS.BATCH_OPERATION_THRESHOLD) {
+                if (count > DisplayLimits.BATCH_OPERATION_THRESHOLD) {
                     nextSteps.push(
                         `Use ${TASKS_UPDATE_MULTIPLE} to batch-update priorities or dates`,
                     )

--- a/src/utils/response-builders.ts
+++ b/src/utils/response-builders.ts
@@ -1,0 +1,312 @@
+import { TOOL_NAMES } from './tool-names.js'
+
+const {
+    TASKS_LIST_BY_DATE,
+    TASKS_ADD_MULTIPLE,
+    TASKS_UPDATE_MULTIPLE,
+    TASKS_COMPLETE_MULTIPLE,
+    OVERVIEW,
+} = TOOL_NAMES
+
+interface TaskLike {
+    id?: string
+    content?: string
+    title?: string
+    dueDate?: string
+    priority?: number
+    projectName?: string
+}
+
+interface ProjectLike {
+    id: string
+    name: string
+    color?: string
+    isFavorite?: boolean
+    isShared?: boolean
+    parentId?: string | null
+    inboxProject?: boolean
+    viewStyle?: string
+}
+
+interface TaskOperationOptions {
+    nextSteps?: string[]
+    context?: string
+    showDetails?: boolean
+}
+
+interface BatchOperationParams {
+    action: string
+    success: number
+    total: number
+    successItems?: string[]
+    failures?: Array<{
+        item: string
+        error: string
+        code?: string
+    }>
+    nextSteps?: string[]
+}
+
+/**
+ * Creates concise, actionable summaries for task operations instead of raw JSON
+ */
+export function summarizeTaskOperation(
+    action: string,
+    tasks: TaskLike[],
+    options: TaskOperationOptions = {},
+): string {
+    const { nextSteps, context, showDetails = false } = options
+    const count = tasks.length
+    const bits: string[] = []
+
+    // Main action summary
+    const taskOrTasks = count === 1 ? 'task' : 'tasks'
+    const actionSummary = `${action} ${count} ${taskOrTasks}${context ? ` ${context}` : ''}.`
+    bits.push(actionSummary)
+
+    // Task details preview (if requested or small batch)
+    const smallBatchLimit = 5
+    if (showDetails || count <= smallBatchLimit) {
+        const previews = previewTasks(tasks, smallBatchLimit)
+        if (previews.length > 0) {
+            const moreInfo = count > smallBatchLimit ? `, +${count - smallBatchLimit} more` : ''
+            bits.push(`Tasks:\n${previews}${moreInfo}.`)
+        }
+    }
+
+    // Next steps guidance
+    if (nextSteps?.length) {
+        bits.push(formatNextSteps(nextSteps))
+    }
+
+    return bits.join('\n')
+}
+
+/**
+ * Creates batch operation summaries with success/failure breakdown
+ */
+export function summarizeBatch(params: BatchOperationParams): string {
+    const { action, success, total, successItems, failures, nextSteps } = params
+    const bits: string[] = []
+
+    // Main result summary
+    const successBit = `${action}: ${success}/${total} successful.`
+    bits.push(successBit)
+
+    // Success items (if provided and reasonable count)
+    if (successItems?.length && successItems.length <= 5) {
+        bits.push(`Completed:\n${successItems.map((item) => `    ${item}`).join('\n')}.`)
+    }
+
+    // Failure details (if any)
+    if (failures?.length) {
+        const failureCount = failures.length
+        const failureBit = `Failed (${failureCount}):\n${failures
+            .slice(0, 3)
+            .map((f) => `    ${f.item} (Error: ${f.error}${f.code ? ` [${f.code}]` : ''})`)
+            .join('\n')}${failureCount > 3 ? `, +${failureCount - 3} more` : ''}.`
+        bits.push(failureBit)
+    }
+
+    // Next steps
+    if (nextSteps?.length) {
+        bits.push(formatNextSteps(nextSteps))
+    }
+
+    return bits.join('\n')
+}
+
+/**
+ * Formats a single task-like object into a readable preview line
+ */
+function formatTaskPreview(task: TaskLike): string {
+    const content = task.content || task.title || 'Untitled'
+    const due = task.dueDate ? ` • due ${task.dueDate}` : ''
+    const priority = task.priority && task.priority < 4 ? ` • P${task.priority}` : ''
+    const project = task.projectName ? ` • ${task.projectName}` : ''
+    const id = task.id ? ` • id=${task.id}` : ''
+    return `    ${content}${due}${priority}${project}${id}`
+}
+
+/**
+ * Formats a single project-like object into a readable preview line
+ */
+export function formatProjectPreview(project: ProjectLike): string {
+    const isInbox = project.inboxProject ? ' • Inbox' : ''
+    const isFavorite = project.isFavorite ? ' • ⭐' : ''
+    const isShared = project.isShared ? ' • Shared' : ''
+    const viewStyle =
+        project.viewStyle && project.viewStyle !== 'list' ? ` • ${project.viewStyle}` : ''
+    const id = ` • id=${project.id}`
+    return `    ${project.name}${isInbox}${isFavorite}${isShared}${viewStyle}${id}`
+}
+
+/**
+ * Creates preview lines for task lists
+ */
+export function previewTasks(tasks: TaskLike[], limit = 5): string {
+    return tasks.slice(0, limit).map(formatTaskPreview).join('\n')
+}
+
+interface SummarizeListParams {
+    subject: string
+    count: number
+    limit?: number
+    nextCursor?: string
+    filterHints?: string[]
+    previewLines?: string
+    zeroReasonHints?: string[]
+    nextSteps?: string[]
+}
+
+/**
+ * Creates list summaries with counts, filters, and guidance
+ */
+export function summarizeList({
+    subject,
+    count,
+    limit,
+    nextCursor,
+    filterHints,
+    previewLines,
+    zeroReasonHints,
+    nextSteps,
+}: SummarizeListParams): string {
+    const bits: string[] = []
+
+    // Header with count and pagination info
+    const header = `${subject}: ${count}${
+        typeof limit === 'number' ? ` (limit ${limit})` : ''
+    }${nextCursor ? ', more available' : ''}.`
+    bits.push(header)
+
+    // Filter information
+    if (filterHints?.length) {
+        bits.push(`Filter: ${filterHints.join('; ')}.`)
+    }
+
+    // Preview of items
+    if (previewLines?.length) {
+        bits.push(`Preview:\n${previewLines}`)
+    }
+
+    // Help for empty results
+    if (!count && zeroReasonHints?.length) {
+        bits.push(`No results. ${zeroReasonHints.join('; ')}.`)
+    }
+
+    // Next steps guidance
+    if (nextSteps?.length || nextCursor) {
+        bits.push(formatNextSteps(nextSteps || [], nextCursor))
+    }
+
+    return bits.join('\n')
+}
+
+/**
+ * Formats next steps array into a consistent "Next:" section
+ * If nextCursor is provided, adds cursor instruction to the steps
+ */
+export function formatNextSteps(nextSteps: string[], nextCursor?: string): string {
+    const allSteps = [...nextSteps]
+    if (nextCursor) {
+        allSteps.push(`Pass cursor '${nextCursor}' to fetch more results.`)
+    }
+    return `Next:\n${allSteps.map((step) => `- ${step}`).join('\n')}`
+}
+
+/**
+ * Helper to generate contextual next steps based on task operations
+ */
+export function generateTaskNextSteps(
+    operation: 'added' | 'updated' | 'listed' | 'completed' | 'organized',
+    tasks: TaskLike[],
+    context?: {
+        hasToday?: boolean
+        hasOverdue?: boolean
+        hasHighPriority?: boolean
+        projectName?: string
+        count?: number
+        timeOfDay?: 'morning' | 'afternoon' | 'evening'
+        isEmptyResult?: boolean
+    },
+): string[] {
+    const nextSteps: string[] = []
+    const count = context?.count ?? tasks.length
+
+    switch (operation.toLowerCase()) {
+        case 'added':
+            // Context-aware suggestions for newly added tasks
+            if (context?.hasToday) {
+                nextSteps.push(
+                    `Use ${TASKS_LIST_BY_DATE}('today') to review today's updated schedule`,
+                )
+            } else if (context?.hasOverdue) {
+                nextSteps.push(`Use ${TASKS_LIST_BY_DATE}('overdue') to prioritize past-due items`)
+            } else if (context?.projectName) {
+                nextSteps.push(
+                    `Use ${OVERVIEW} with projectId to see ${context.projectName} structure`,
+                )
+            } else {
+                nextSteps.push(`Use ${OVERVIEW} to see your updated project organization`)
+            }
+
+            // Time-based suggestions
+            if (context?.timeOfDay === 'morning') {
+                nextSteps.push(`Use ${TASKS_LIST_BY_DATE}('today') to plan your day`)
+            }
+            break
+
+        case 'updated':
+        case 'organized':
+            if (context?.hasToday) {
+                nextSteps.push(
+                    `Use ${TASKS_LIST_BY_DATE}('today') to see your prioritized schedule`,
+                )
+            } else if (context?.hasHighPriority) {
+                nextSteps.push(
+                    `Use ${TASKS_LIST_BY_DATE} with filter to focus on high-priority items`,
+                )
+            } else {
+                nextSteps.push(`Use ${OVERVIEW} to see your updated project structure`)
+            }
+            break
+
+        case 'completed':
+            if (context?.timeOfDay === 'evening') {
+                nextSteps.push(`Use ${TASKS_LIST_BY_DATE}('tomorrow') to plan upcoming work`)
+            } else if (context?.hasOverdue) {
+                nextSteps.push(
+                    `Use ${TASKS_LIST_BY_DATE}('overdue') to tackle remaining past-due items`,
+                )
+            } else {
+                nextSteps.push(`Use ${TASKS_LIST_BY_DATE}('today') to see remaining work`)
+            }
+            break
+
+        case 'listed':
+            if (context?.isEmptyResult) {
+                nextSteps.push(`Use ${TASKS_ADD_MULTIPLE} to add tasks for this timeframe`)
+                nextSteps.push(`Use ${OVERVIEW} with projectId to see tasks in other projects`)
+            } else if (count > 0) {
+                // Tailor suggestions based on result size
+                if (count > 10) {
+                    nextSteps.push(
+                        `Use ${TASKS_UPDATE_MULTIPLE} to batch-update priorities or dates`,
+                    )
+                    nextSteps.push('Consider breaking large tasks into subtasks')
+                } else {
+                    nextSteps.push(`Use ${TASKS_UPDATE_MULTIPLE} to modify priorities or due dates`)
+                }
+                nextSteps.push(`Use ${TASKS_COMPLETE_MULTIPLE} to mark finished tasks`)
+
+                // Time-sensitive suggestions
+                if (context?.hasOverdue) {
+                    nextSteps.push('Focus on overdue items first to get back on track')
+                }
+            }
+            break
+    }
+
+    return nextSteps
+}

--- a/src/utils/response-builders.ts
+++ b/src/utils/response-builders.ts
@@ -1,3 +1,4 @@
+import { DISPLAY_LIMITS } from './constants.js'
 import { TOOL_NAMES } from './tool-names.js'
 
 const {
@@ -102,9 +103,11 @@ export function summarizeBatch(params: BatchOperationParams): string {
     if (failures?.length) {
         const failureCount = failures.length
         const failureBit = `Failed (${failureCount}):\n${failures
-            .slice(0, 3)
+            .slice(0, DISPLAY_LIMITS.MAX_FAILURES_SHOWN)
             .map((f) => `    ${f.item} (Error: ${f.error}${f.code ? ` [${f.code}]` : ''})`)
-            .join('\n')}${failureCount > 3 ? `, +${failureCount - 3} more` : ''}.`
+            .join(
+                '\n',
+            )}${failureCount > DISPLAY_LIMITS.MAX_FAILURES_SHOWN ? `, +${failureCount - DISPLAY_LIMITS.MAX_FAILURES_SHOWN} more` : ''}.`
         bits.push(failureBit)
     }
 
@@ -290,7 +293,7 @@ export function generateTaskNextSteps(
                 nextSteps.push(`Use ${OVERVIEW} with projectId to see tasks in other projects`)
             } else if (count > 0) {
                 // Tailor suggestions based on result size
-                if (count > 10) {
+                if (count > DISPLAY_LIMITS.BATCH_OPERATION_THRESHOLD) {
                     nextSteps.push(
                         `Use ${TASKS_UPDATE_MULTIPLE} to batch-update priorities or dates`,
                     )

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -6,7 +6,7 @@
  * This prevents outdated references when tool names change.
  */
 
-export const TOOL_NAMES = {
+export const ToolNames = {
     // Task management tools
     TASKS_ADD_MULTIPLE: 'tasks-add-multiple',
     TASKS_COMPLETE_MULTIPLE: 'tasks-complete-multiple',
@@ -30,4 +30,4 @@ export const TOOL_NAMES = {
 } as const
 
 // Type for all tool names
-export type ToolName = (typeof TOOL_NAMES)[keyof typeof TOOL_NAMES]
+export type ToolName = (typeof ToolNames)[keyof typeof ToolNames]

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -1,0 +1,33 @@
+/**
+ * Centralized tool names module
+ *
+ * This module provides a single source of truth for all tool names used throughout the codebase.
+ * Each tool should import its own name from this module to avoid hardcoded strings.
+ * This prevents outdated references when tool names change.
+ */
+
+export const TOOL_NAMES = {
+    // Task management tools
+    TASKS_ADD_MULTIPLE: 'tasks-add-multiple',
+    TASKS_COMPLETE_MULTIPLE: 'tasks-complete-multiple',
+    TASKS_UPDATE_MULTIPLE: 'tasks-update-multiple',
+    TASKS_SEARCH: 'tasks-search',
+    TASKS_LIST_BY_DATE: 'tasks-list-by-date',
+    TASKS_LIST_COMPLETED: 'tasks-list-completed',
+    TASKS_LIST_FOR_CONTAINER: 'tasks-list-for-container',
+
+    // Project management tools
+    PROJECTS_LIST: 'projects-list',
+    PROJECTS_MANAGE: 'projects-manage',
+
+    // Section management tools
+    SECTIONS_SEARCH: 'sections-search',
+    SECTIONS_MANAGE: 'sections-manage',
+
+    // General tools
+    OVERVIEW: 'overview',
+    DELETE_ONE: 'delete-one',
+} as const
+
+// Type for all tool names
+export type ToolName = (typeof TOOL_NAMES)[keyof typeof TOOL_NAMES]


### PR DESCRIPTION
## 🗺️ Overview

Implements more human and LLM-readable responses for all Todoist AI tools using MCP dual content format. Tools now provide both contextual text summaries and structured content, improving LLM comprehension and user experience.

- Closes #48
- https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-result

## 🧩 Problem

Tools returned only structured JSON, forcing LLMs to interpret raw data without context:

-   Poor LLM comprehension of operation outcomes
-   No actionable next-step suggestions
-   Missing workflow guidance

## 💡 Solution

1. **Response builders** (`src/utils/response-builders.ts`) - Task summaries, batch operations, list formatting, next-step suggestions
2. **MCP dual format** (`src/mcp-helpers.ts`) - Text + structured content via new `getToolOutput()` function
3. **All 13 tools migrated** with human-readable summaries and preserved or improved structured data

### 🌟 Benefits

-   Enhanced LLM comprehension with explicit context
-   Better user assistance via contextual suggestions
-   MCP specification compliance
-   Backwards compatibility maintained
    - The new structured content is sent serialized as JSON in the `content` part for now
    - The newer `structuredContent` field from the more recent [June 18th MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) is hidden for now, controlled by an environment variable.

## 🧪 Test plan

These instructions are specific for _Claude Desktop_, but you should be able to adapt them for _Claude Code_ or _Cursor_ or _VS Code_ by searching the web to see where their MCP config file can be found.

1. Clone this repository
2. Run `npm install && npm run build`
3. Set it up in Claude Desktop's MCP json configuration:
    - Find it in Claude Desktop settings > Developer > Edit Config
    - or find it in `/Users/<username>/Library/Application Support/Claude/claude_desktop_config.json` in macOS
    - add this `todoist-ai-local` entry under the `mcpServers` object
        ```jsonc
        {
            "mcpServers": {
                "todoist-ai-local": {
                    "command": "node",
                    "args": ["/path/to/todoist-ai/dist/main.js"], // change this path ⚠️
                    "env": {
                        "TODOIST_API_KEY": "<PRODUCTION-API-KEY>" // change this API key ⚠️
                    }
                }
            }
        }
        ```
    - ⚠️ **Make sure to put the right path to your `dist/main.js` file, and a valid production API key for Todoist**
4. Open _Claude Desktop_ and enjoy

## 🎥 Demo

https://github.com/user-attachments/assets/22712db6-66d1-4049-a607-c18ce229a7de

### 🌐 Usage in other languages

I was worried about the natural language response being in English, and what would happen if we used this when chatting with the LLM in a language other than English. So I tried, and it seems to work well.

👉 **Here's a demo and a screenshot:**

<details><summary>(click to expand)</summary>
<p>

https://github.com/user-attachments/assets/bc17d5de-f271-4c70-a8de-b3e360a95f13

I even asked the LLM if it received some suggestions for actions that could come next, and it totally got it from the English language response, but answered me in Spanish about it:

<img width="1858" height="2358" alt="CleanShot 2025-08-19 at 17 20 50@2x" src="https://github.com/user-attachments/assets/60ffc1ed-05de-46da-8c88-b2ce47e81163" />

</p>
</details> 
