### PR TITLE
feat: export comment tools

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ Feel free to leave unchecked or remove the lines that are not applicable.
 
 -   [ ] Added tests for bugs / new features
 -   [ ] Updated docs (README, etc.)
+-   [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.
 
 <!--
 _Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,11 @@ import { addSections } from './tools/add-sections.js'
 import { findSections } from './tools/find-sections.js'
 import { updateSections } from './tools/update-sections.js'
 
+// Comment management tools
+import { addComments } from './tools/add-comments.js'
+import { findComments } from './tools/find-comments.js'
+import { updateComments } from './tools/update-comments.js'
+
 // General tools
 import { deleteObject } from './tools/delete-object.js'
 import { getOverview } from './tools/get-overview.js'
@@ -38,6 +43,10 @@ const tools = {
     addSections,
     updateSections,
     findSections,
+    // Comment management tools
+    addComments,
+    updateComments,
+    findComments,
     // General tools
     getOverview,
     deleteObject,
@@ -61,6 +70,10 @@ export {
     addSections,
     updateSections,
     findSections,
+    // Comment management tools
+    addComments,
+    updateComments,
+    findComments,
     // General tools
     getOverview,
     deleteObject,


### PR DESCRIPTION
## Short description

In #58 I forgot to export the new comment tools in the `src/index.ts` file. This is of little consequence, as they were included in the `getMcpServer` convenience function, so any MCP server application that updated to v4.0.0 would still get the new tools. But it is still important to formally export them for individual use.

This PR also adds a new checkbox to the GitHub PR template to remind PR authors to do this when needed. This hopefully minimizes the chances of this happening again.

## PR Checklist

-   [x] New tools added to `getMcpServer` AND exported in `src/index.ts`.
