### PR TITLE
feat: Add user-info tool and upgrade Todoist API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "4.2.0",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-api-typescript": "5.1.2",
+                "@doist/todoist-api-typescript": "5.4.0",
                 "@modelcontextprotocol/sdk": "^1.11.1",
                 "date-fns": "^4.1.0",
                 "dotenv": "^16.5.0",
@@ -550,6 +550,7 @@
             "version": "7.27.3",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.3.tgz",
             "integrity": "sha512-7EYtGezsdiDMyY80+65EzwiGmcJqpmcZCojSXaRgdrBaGtWTgDZKq69cPIVped6MkIM78cTQ2GOiEYjwOlG4xw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -800,22 +801,31 @@
             }
         },
         "node_modules/@doist/todoist-api-typescript": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-5.1.2.tgz",
-            "integrity": "sha512-uCr3r4w8aN8ZafSttG6XEBIhcIT65ELyuLZZo9Uw1sT8mAzxVlom9GA7230WIZJx5FLVCGJ0ONdwvXxANkbhkw==",
+            "version": "5.4.0",
+            "resolved": "https://npm.pkg.github.com/download/@Doist/todoist-api-typescript/5.4.0/afcaeed9896a20fb10371b9bd88e5d1298468917",
+            "integrity": "sha512-Ui5J6LXRmGTKnXlwiCXtue3u2+Bnzj2VBt9bprf6NtXdYg6ekOoSSlR/bBcPaM+XWoHYjqLoN0NQh7tdENcAtw==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.0.0",
                 "axios-case-converter": "^1.0.0",
-                "axios-retry": "^3.1.9",
+                "axios-retry": "^4.0.0",
                 "camelcase": "6.3.0",
-                "emoji-regex": "10.4.0",
+                "emoji-regex": "10.5.0",
                 "ts-custom-error": "^3.2.0",
-                "uuid": "^9.0.0",
-                "zod": "^3.24.1"
+                "uuid": "^11.0.0",
+                "zod": "4.1.5"
             },
             "peerDependencies": {
                 "type-fest": "^4.12.0"
+            }
+        },
+        "node_modules/@doist/todoist-api-typescript/node_modules/zod": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
+            "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/@emnapi/core": {
@@ -2469,13 +2479,15 @@
             }
         },
         "node_modules/axios-retry": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
-            "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+            "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime": "^7.15.4",
                 "is-retry-allowed": "^2.2.0"
+            },
+            "peerDependencies": {
+                "axios": "0.x || 1.x"
             }
         },
         "node_modules/babel-jest": {
@@ -3393,9 +3405,9 @@
             }
         },
         "node_modules/emoji-regex": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-            "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+            "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
             "license": "MIT"
         },
         "node_modules/encodeurl": {
@@ -7387,16 +7399,16 @@
             }
         },
         "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-api-typescript": "5.1.2",
+        "@doist/todoist-api-typescript": "5.4.0",
         "@modelcontextprotocol/sdk": "^1.11.1",
         "date-fns": "^4.1.0",
         "dotenv": "^16.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { updateComments } from './tools/update-comments.js'
 // General tools
 import { deleteObject } from './tools/delete-object.js'
 import { getOverview } from './tools/get-overview.js'
+import { userInfo } from './tools/user-info.js'
 
 const tools = {
     // Task management tools
@@ -50,6 +51,7 @@ const tools = {
     // General tools
     getOverview,
     deleteObject,
+    userInfo,
 }
 
 export { tools, getMcpServer }
@@ -77,4 +79,5 @@ export {
     // General tools
     getOverview,
     deleteObject,
+    userInfo,
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -28,6 +28,7 @@ import { updateComments } from './tools/update-comments.js'
 // General tools
 import { deleteObject } from './tools/delete-object.js'
 import { getOverview } from './tools/get-overview.js'
+import { userInfo } from './tools/user-info.js'
 
 const instructions = `
 Tools to help you manage your todoist tasks.
@@ -78,6 +79,7 @@ function getMcpServer({ todoistApiKey, baseUrl }: { todoistApiKey: string; baseU
     // General tools
     registerTool(getOverview, server, todoist)
     registerTool(deleteObject, server, todoist)
+    registerTool(userInfo, server, todoist)
 
     return server
 }

--- a/src/tools/__tests__/update-sections.test.ts
+++ b/src/tools/__tests__/update-sections.test.ts
@@ -34,6 +34,7 @@ describe(`${UPDATE_SECTIONS} tool`, () => {
                 isDeleted: false,
                 isCollapsed: false,
                 name: 'Updated Section Name',
+                url: 'https://todoist.com/sections/existing-section-123',
             }
 
             mockTodoistApi.updateSection.mockResolvedValue(mockApiResponse)

--- a/src/tools/__tests__/user-info.test.ts
+++ b/src/tools/__tests__/user-info.test.ts
@@ -1,0 +1,161 @@
+import type { CurrentUser, TodoistApi } from '@doist/todoist-api-typescript'
+import { jest } from '@jest/globals'
+import {
+    TEST_ERRORS,
+    extractStructuredContent,
+    extractTextContent,
+} from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { userInfo } from '../user-info.js'
+
+// Mock the Todoist API
+const mockTodoistApi = {
+    getUser: jest.fn(),
+} as unknown as jest.Mocked<TodoistApi>
+
+const { USER_INFO } = ToolNames
+
+describe(`${USER_INFO} tool`, () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('should generate user info with all required fields', async () => {
+        const mockUser: CurrentUser = {
+            id: '123',
+            fullName: 'Test User',
+            email: 'test@example.com',
+            isPremium: true,
+            completedToday: 12,
+            dailyGoal: 10,
+            weeklyGoal: 100,
+            startDay: 1, // Monday
+            tzInfo: {
+                timezone: 'Europe/Madrid',
+                gmtString: '+02:00',
+                hours: 2,
+                minutes: 0,
+                isDst: 1,
+            },
+            lang: 'en',
+            avatarBig: 'https://example.com/avatar.jpg',
+            avatarMedium: null,
+            avatarS640: null,
+            avatarSmall: null,
+            karma: 86394.0,
+            karmaTrend: 'up',
+            nextWeek: 1,
+            weekendStartDay: 6,
+            timeFormat: 0,
+            dateFormat: 0,
+            daysOff: [6, 7],
+            businessAccountId: null,
+            completedCount: 102920,
+            inboxProjectId: '6PVw8cMf7m8fWwRp',
+            startPage: 'overdue',
+        }
+
+        mockTodoistApi.getUser.mockResolvedValue(mockUser)
+
+        const result = await userInfo.execute({}, mockTodoistApi)
+
+        expect(mockTodoistApi.getUser).toHaveBeenCalledWith()
+
+        // Test text content contains expected information
+        const textContent = extractTextContent(result)
+        expect(textContent).toContain('Test User')
+        expect(textContent).toContain('test@example.com')
+        expect(textContent).toContain('Europe/Madrid')
+        expect(textContent).toContain('Monday (1)')
+        expect(textContent).toContain('Completed Today:** 12')
+        expect(textContent).toContain('Plan:** Todoist Pro')
+
+        // Test structured content
+        const structuredContent = extractStructuredContent(result)
+        expect(structuredContent).toEqual(
+            expect.objectContaining({
+                type: 'user_info',
+                fullName: 'Test User',
+                email: 'test@example.com',
+                timezone: 'Europe/Madrid',
+                startDay: 1,
+                startDayName: 'Monday',
+                completedToday: 12,
+                dailyGoal: 10,
+                weeklyGoal: 100,
+                plan: 'Todoist Pro',
+                currentLocalTime: expect.any(String),
+                weekStartDate: expect.any(String),
+                weekEndDate: expect.any(String),
+                currentWeekNumber: expect.any(Number),
+            }),
+        )
+
+        // Verify date formats
+        expect(structuredContent.weekStartDate).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+        expect(structuredContent.weekEndDate).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+        expect(structuredContent.currentLocalTime).toMatch(
+            /^\d{2}\/\d{2}\/\d{4}, \d{2}:\d{2}:\d{2}$/,
+        )
+    })
+
+    it('should handle missing timezone info', async () => {
+        const mockUser: CurrentUser = {
+            id: '789',
+            fullName: 'Anonymous User',
+            email: 'anonymous@example.com',
+            isPremium: false,
+            completedToday: 0,
+            dailyGoal: 5,
+            weeklyGoal: 35,
+            startDay: 1, // Default to Monday since it can't be null
+            tzInfo: {
+                timezone: 'UTC',
+                gmtString: '+00:00',
+                hours: 0,
+                minutes: 0,
+                isDst: 0,
+            },
+            lang: 'en',
+            avatarBig: null,
+            avatarMedium: null,
+            avatarS640: null,
+            avatarSmall: null,
+            karma: 500.0,
+            karmaTrend: 'up',
+            nextWeek: 1,
+            weekendStartDay: 6,
+            timeFormat: 0,
+            dateFormat: 0,
+            daysOff: [6, 7],
+            businessAccountId: null,
+            completedCount: 100,
+            inboxProjectId: 'inbox456',
+            startPage: 'overdue',
+        }
+
+        mockTodoistApi.getUser.mockResolvedValue(mockUser)
+
+        const result = await userInfo.execute({}, mockTodoistApi)
+
+        const textContent = extractTextContent(result)
+        expect(textContent).toContain('UTC') // Should default to UTC
+        expect(textContent).toContain('Monday (1)') // Should default to Monday
+        expect(textContent).toContain('Plan:** Todoist Free')
+
+        const structuredContent = extractStructuredContent(result)
+        expect(structuredContent.timezone).toBe('UTC')
+        expect(structuredContent.startDay).toBe(1)
+        expect(structuredContent.startDayName).toBe('Monday')
+        expect(structuredContent.plan).toBe('Todoist Free')
+    })
+
+    it('should propagate API errors', async () => {
+        const apiError = new Error(TEST_ERRORS.API_UNAUTHORIZED)
+        mockTodoistApi.getUser.mockRejectedValue(apiError)
+
+        await expect(userInfo.execute({}, mockTodoistApi)).rejects.toThrow(
+            TEST_ERRORS.API_UNAUTHORIZED,
+        )
+    })
+})

--- a/src/tools/user-info.ts
+++ b/src/tools/user-info.ts
@@ -1,0 +1,168 @@
+import type { TodoistApi } from '@doist/todoist-api-typescript'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TodoistTool } from '../todoist-tool.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {}
+
+type UserInfoStructured = Record<string, unknown> & {
+    type: 'user_info'
+    fullName: string
+    timezone: string
+    currentLocalTime: string
+    startDay: number
+    startDayName: string
+    weekStartDate: string
+    weekEndDate: string
+    currentWeekNumber: number
+    completedToday: number
+    dailyGoal: number
+    weeklyGoal: number
+    email: string
+    plan: string
+}
+
+function getUserPlan(user: { isPremium: boolean; businessAccountId?: string | null }): string {
+    if (user.businessAccountId) {
+        return 'Todoist Business'
+    }
+    if (user.isPremium) {
+        return 'Todoist Pro'
+    }
+    return 'Todoist Free'
+}
+
+// Helper functions for date and time calculations
+function getWeekStartDate(date: Date, startDay: number): Date {
+    const currentDay = date.getDay() || 7 // Convert Sunday (0) to 7 for ISO format
+    const daysFromStart = (currentDay - startDay + 7) % 7
+    const weekStart = new Date(date)
+    weekStart.setDate(date.getDate() - daysFromStart)
+    return weekStart
+}
+
+function getWeekEndDate(weekStart: Date): Date {
+    const weekEnd = new Date(weekStart)
+    weekEnd.setDate(weekStart.getDate() + 6)
+    return weekEnd
+}
+
+function getWeekNumber(date: Date): number {
+    const firstDayOfYear = new Date(date.getFullYear(), 0, 1)
+    const pastDaysOfYear = (date.getTime() - firstDayOfYear.getTime()) / 86400000
+    return Math.ceil((pastDaysOfYear + firstDayOfYear.getDay() + 1) / 7)
+}
+
+function getDayName(dayNumber: number): string {
+    const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+    // Convert ISO day number (1=Monday, 7=Sunday) to array index (0=Sunday, 6=Saturday)
+    const index = dayNumber === 7 ? 0 : dayNumber
+    return days[index] ?? 'Unknown'
+}
+
+function formatDate(date: Date): string {
+    return date.toISOString().split('T')[0] ?? ''
+}
+
+function formatLocalTime(date: Date, timezone: string): string {
+    return date.toLocaleString('en-US', {
+        timeZone: timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+    })
+}
+
+async function generateUserInfo(
+    client: TodoistApi,
+): Promise<{ textContent: string; structuredContent: UserInfoStructured }> {
+    // Get user information from Todoist API
+    const user = await client.getUser()
+
+    // Parse timezone from user data
+    const timezone = user.tzInfo?.timezone ?? 'UTC'
+
+    // Get current time in user's timezone
+    const now = new Date()
+    const localTime = formatLocalTime(now, timezone)
+
+    // Calculate week information based on user's start day
+    const startDay = user.startDay ?? 1 // Default to Monday if not set
+    const startDayName = getDayName(startDay)
+
+    // Determine user's plan
+    const plan = getUserPlan(user)
+
+    // Create a date object in user's timezone for accurate week calculations
+    const userDate = new Date(now.toLocaleString('en-US', { timeZone: timezone }))
+    const weekStart = getWeekStartDate(userDate, startDay)
+    const weekEnd = getWeekEndDate(weekStart)
+    const weekNumber = getWeekNumber(userDate)
+
+    // Generate markdown text content
+    const lines: string[] = [
+        '# User Information',
+        '',
+        `**Full Name:** ${user.fullName}`,
+        `**Email:** ${user.email}`,
+        `**Timezone:** ${timezone}`,
+        `**Current Local Time:** ${localTime}`,
+        '',
+        '## Week Settings',
+        `**Week Start Day:** ${startDayName} (${startDay})`,
+        `**Current Week:** Week ${weekNumber}`,
+        `**Week Start Date:** ${formatDate(weekStart)}`,
+        `**Week End Date:** ${formatDate(weekEnd)}`,
+        '',
+        '## Daily Progress',
+        `**Completed Today:** ${user.completedToday}`,
+        `**Daily Goal:** ${user.dailyGoal}`,
+        `**Weekly Goal:** ${user.weeklyGoal}`,
+        '',
+        '## Account Info',
+        `**Plan:** ${plan}`,
+    ]
+
+    const textContent = lines.join('\n')
+
+    // Generate structured content
+    const structuredContent: UserInfoStructured = {
+        type: 'user_info',
+        fullName: user.fullName,
+        timezone: timezone,
+        currentLocalTime: localTime,
+        startDay: startDay,
+        startDayName: startDayName,
+        weekStartDate: formatDate(weekStart),
+        weekEndDate: formatDate(weekEnd),
+        currentWeekNumber: weekNumber,
+        completedToday: user.completedToday,
+        dailyGoal: user.dailyGoal,
+        weeklyGoal: user.weeklyGoal,
+        email: user.email,
+        plan: plan,
+    }
+
+    return { textContent, structuredContent }
+}
+
+const userInfo = {
+    name: ToolNames.USER_INFO,
+    description:
+        'Get comprehensive user information including full name, email, timezone with current local time, week start day preferences, current week dates, daily/weekly goal progress, and user plan (Free/Pro/Business).',
+    parameters: ArgsSchema,
+    async execute(_args, client) {
+        const result = await generateUserInfo(client)
+
+        return getToolOutput({
+            textContent: result.textContent,
+            structuredContent: result.structuredContent,
+        })
+    },
+} satisfies TodoistTool<typeof ArgsSchema>
+
+export { userInfo, type UserInfoStructured }

--- a/src/utils/test-helpers.ts
+++ b/src/utils/test-helpers.ts
@@ -72,6 +72,7 @@ export function createMockSection(overrides: Partial<Section> = {}): Section {
         isDeleted: false,
         isCollapsed: false,
         name: 'Test Section',
+        url: 'https://todoist.com/sections/section-123',
         ...overrides,
     }
 }

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -32,6 +32,7 @@ export const ToolNames = {
     // General tools
     GET_OVERVIEW: 'get-overview',
     DELETE_OBJECT: 'delete-object',
+    USER_INFO: 'user-info',
 } as const
 
 // Type for all tool names


### PR DESCRIPTION
## Short description

- Adds a new `user-info` tool to retrieve the session user's information, such as name, email, timezone, time, etc. 
- Upgrades @doist/todoist-api-typescript to latest version
- Includes test coverage for the new tool

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [x] Added tests for bugs / new features
-   [x] Updated docs (README, etc.)
-   [x] New tools added to `getMcpServer` AND exported in `src/index.ts`.