### PR TITLE
feat: merge overdue into today's tasks in find-tasks-by-date tool

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -41,7 +41,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 - **update-tasks**: Modify existing tasks - get task IDs from search results first, only include fields that need changes
 - **complete-tasks**: Mark tasks as done using task IDs
 - **find-tasks**: Search by text, project/section/parent container, responsible user, or labels. Requires at least one search parameter
-- **find-tasks-by-date**: Get tasks by date range (startDate: YYYY-MM-DD, 'today', or 'overdue') or specific day counts
+- **find-tasks-by-date**: Get tasks by date range (startDate: YYYY-MM-DD or 'today' which includes overdue tasks) or specific day counts
 - **find-completed-tasks**: View completed tasks by completion date or original due date
 
 **Project & Organization:**
@@ -68,7 +68,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 
 4. **Bulk Operations**: When working with multiple items, prefer bulk tools (complete-tasks, manage-assignments) over individual operations for better performance.
 
-5. **Date Handling**: All dates respect user timezone settings. Use 'today' and 'overdue' keywords for dynamic date filtering.
+5. **Date Handling**: All dates respect user timezone settings. Use 'today' keyword for dynamic date filtering (includes overdue tasks).
 
 6. **Labels**: Use label filtering with AND/OR operators for advanced task organization. Most search tools support labels parameter.
 

--- a/src/tools/__tests__/__snapshots__/complete-tasks.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/complete-tasks.test.ts.snap
@@ -7,7 +7,7 @@ Completed:
     task-2
     task-3.
 Next:
-- Use find-tasks-by-date('overdue') to tackle remaining overdue items."
+- Use find-tasks-by-date('today') to tackle remaining overdue items."
 `;
 
 exports[`complete-tasks tool completing multiple tasks should complete single task 1`] = `
@@ -15,7 +15,7 @@ exports[`complete-tasks tool completing multiple tasks should complete single ta
 Completed:
     8485093748.
 Next:
-- Use find-tasks-by-date('overdue') to tackle remaining overdue items."
+- Use find-tasks-by-date('today') to tackle remaining overdue items."
 `;
 
 exports[`complete-tasks tool completing multiple tasks should continue processing remaining tasks after failures 1`] = `
@@ -66,7 +66,7 @@ exports[`complete-tasks tool edge cases should handle empty task completion (min
 Completed:
     single-task.
 Next:
-- Use find-tasks-by-date('overdue') to tackle remaining overdue items."
+- Use find-tasks-by-date('today') to tackle remaining overdue items."
 `;
 
 exports[`complete-tasks tool edge cases should handle tasks with special ID formats 1`] = `
@@ -76,7 +76,7 @@ Completed:
     task-with-dashes
     1234567890.
 Next:
-- Use find-tasks-by-date('overdue') to tackle remaining overdue items."
+- Use find-tasks-by-date('today') to tackle remaining overdue items."
 `;
 
 exports[`complete-tasks tool error message truncation should not show truncation message for exactly 3 errors 1`] = `
@@ -127,7 +127,7 @@ Completed:
     task-1
     task-2.
 Next:
-- Use find-tasks-by-date('overdue') to tackle remaining overdue items."
+- Use find-tasks-by-date('today') to tackle remaining overdue items."
 `;
 
 exports[`complete-tasks tool next steps logic validation should suggest reviewing failures when mixed results 1`] = `

--- a/src/tools/__tests__/__snapshots__/find-tasks-by-date.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/find-tasks-by-date.test.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`find-tasks-by-date tool edge cases should handle empty results 1`] = `
-"Today's tasks: 0 (limit 50).
-Filter: today + 6 more days.
-No results. Expand date range with larger 'daysCount'; Check 'overdue' for past-due items."
+"Today's tasks + overdue: 0 (limit 50).
+Filter: today + overdue tasks + 6 more days.
+No results. Great job! No tasks for today or overdue."
 `;
 
 exports[`find-tasks-by-date tool label filtering should combine date filters with label filters 1`] = `
@@ -17,26 +17,9 @@ Next:
 - Focus on overdue items first to get back on track"
 `;
 
-exports[`find-tasks-by-date tool listing overdue tasks should handle overdue tasks ignoring daysCount 1`] = `
-"Overdue tasks: 0 (limit 50).
-Filter: overdue tasks only.
-No results. Great job! No overdue tasks; Check today's tasks with startDate='today'."
-`;
-
-exports[`find-tasks-by-date tool listing overdue tasks should handle overdue tasks with tasks 1`] = `
-"Overdue tasks: 1 (limit 50).
-Filter: overdue tasks only.
-Preview:
-    Overdue task • due 2025-08-10 • P2 • id=8485093748
-Next:
-- Use update-tasks to modify priorities or due dates
-- Use complete-tasks to mark finished tasks
-- Focus on overdue items first to get back on track"
-`;
-
-exports[`find-tasks-by-date tool listing tasks by date range should get tasks for today when startDate is "today" 1`] = `
-"Today's tasks: 1 (limit 50).
-Filter: today + 6 more days.
+exports[`find-tasks-by-date tool listing tasks by date range should get tasks for today when startDate is "today" (includes overdue) 1`] = `
+"Today's tasks + overdue: 1 (limit 50).
+Filter: today + overdue tasks + 6 more days.
 Preview:
     Today task • due 2025-08-15 • P1 • id=8485093748
 Next:
@@ -72,13 +55,13 @@ Next:
 exports[`find-tasks-by-date tool next steps logic should provide helpful suggestions for empty date range results 1`] = `
 "Tasks for 2025-08-20: 0 (limit 10).
 Filter: 2025-08-20.
-No results. Expand date range with larger 'daysCount'; Check 'overdue' for past-due items."
+No results. Expand date range with larger 'daysCount'; Check today's tasks with startDate='today'."
 `;
 
-exports[`find-tasks-by-date tool next steps logic should provide helpful suggestions for empty overdue results 1`] = `
-"Overdue tasks: 0 (limit 10).
-Filter: overdue tasks only.
-No results. Great job! No overdue tasks; Check today's tasks with startDate='today'."
+exports[`find-tasks-by-date tool next steps logic should provide helpful suggestions for empty today results 1`] = `
+"Today's tasks + overdue: 0 (limit 10).
+Filter: today + overdue tasks.
+No results. Great job! No tasks for today or overdue."
 `;
 
 exports[`find-tasks-by-date tool next steps logic should suggest appropriate actions when hasOverdue is true 1`] = `
@@ -92,20 +75,9 @@ Next:
 - Focus on overdue items first to get back on track"
 `;
 
-exports[`find-tasks-by-date tool next steps logic should suggest appropriate actions when startDate is overdue 1`] = `
-"Overdue tasks: 1 (limit 10).
-Filter: overdue tasks only.
-Preview:
-    Overdue task • due 2025-08-10 • P1 • id=8485093748
-Next:
-- Use update-tasks to modify priorities or due dates
-- Use complete-tasks to mark finished tasks
-- Focus on overdue items first to get back on track"
-`;
-
 exports[`find-tasks-by-date tool next steps logic should suggest today-focused actions when startDate is today 1`] = `
-"Today's tasks: 1 (limit 10).
-Filter: today.
+"Today's tasks + overdue: 1 (limit 10).
+Filter: today + overdue tasks.
 Preview:
     Today's task • due 2025-08-15 • P1 • id=8485093748
 Next:

--- a/src/tools/__tests__/add-tasks.test.ts
+++ b/src/tools/__tests__/add-tasks.test.ts
@@ -312,10 +312,8 @@ describe(`${ADD_TASKS} tool`, () => {
             // Verify structured content includes labels
             const structuredContent = extractStructuredContent(result)
             expect(structuredContent.tasks).toHaveLength(1)
-            expect((structuredContent.tasks as any[])[0]).toEqual(
-                expect.objectContaining({
-                    labels: ['urgent', 'work'],
-                }),
+            expect(structuredContent.tasks).toEqual(
+                expect.arrayContaining([expect.objectContaining({ labels: ['urgent', 'work'] })]),
             )
         })
 

--- a/src/tools/__tests__/complete-tasks.test.ts
+++ b/src/tools/__tests__/complete-tasks.test.ts
@@ -204,7 +204,7 @@ describe(`${COMPLETE_TASKS} tool`, () => {
 
             const textContent = extractTextContent(result)
             expect(textContent).toMatchSnapshot()
-            expect(textContent).toContain("Use find-tasks-by-date('overdue')")
+            expect(textContent).toContain("Use find-tasks-by-date('today')")
         })
 
         it('should suggest reviewing failures when mixed results', async () => {

--- a/src/tools/__tests__/find-tasks-by-date.test.ts
+++ b/src/tools/__tests__/find-tasks-by-date.test.ts
@@ -53,58 +53,10 @@ describe(`${FIND_TASKS_BY_DATE} tool`, () => {
         jest.restoreAllMocks()
     })
 
-    describe('listing overdue tasks', () => {
-        it.each([
-            { daysCount: 7, hasTasks: true, description: 'with tasks' },
-            { daysCount: 5, hasTasks: false, description: 'ignoring daysCount' },
-        ])('should handle overdue tasks $description', async ({ daysCount, hasTasks }) => {
-            const mockTasks = hasTasks
-                ? [
-                      createMappedTask({
-                          id: TEST_IDS.TASK_1,
-                          content: 'Overdue task',
-                          dueDate: '2025-08-10',
-                          priority: 2,
-                          labels: ['urgent'],
-                      }),
-                  ]
-                : []
-
-            const mockResponse = { tasks: mockTasks, nextCursor: null }
-            mockGetTasksByFilter.mockResolvedValue(mockResponse)
-
-            const result = await findTasksByDate.execute(
-                { startDate: 'overdue', limit: 50, daysCount },
-                mockTodoistApi,
-            )
-
-            expect(mockGetTasksByFilter).toHaveBeenCalledWith({
-                client: mockTodoistApi,
-                query: 'overdue',
-                cursor: undefined,
-                limit: 50,
-            })
-            // Verify result is a concise summary
-            expect(extractTextContent(result)).toMatchSnapshot()
-
-            // Verify structured content
-            const structuredContent = extractStructuredContent(result)
-            expect(structuredContent.tasks).toHaveLength(hasTasks ? 1 : 0)
-            expect(structuredContent).toEqual(
-                expect.objectContaining({
-                    totalCount: hasTasks ? 1 : 0,
-                    hasMore: false,
-                    nextCursor: null,
-                    appliedFilters: expect.objectContaining({
-                        startDate: 'overdue',
-                    }),
-                }),
-            )
-        })
-    })
+    // Overdue functionality is now integrated into "today" - no standalone overdue tests needed
 
     describe('listing tasks by date range', () => {
-        it('should get tasks for today when startDate is "today"', async () => {
+        it('should get tasks for today when startDate is "today" (includes overdue)', async () => {
             const mockTasks = [createMappedTask({ content: 'Today task', dueDate: '2025-08-15' })]
             const mockResponse = { tasks: mockTasks, nextCursor: null }
             mockGetTasksByFilter.mockResolvedValue(mockResponse)
@@ -116,8 +68,7 @@ describe(`${FIND_TASKS_BY_DATE} tool`, () => {
 
             expect(mockGetTasksByFilter).toHaveBeenCalledWith({
                 client: mockTodoistApi,
-                query:
-                    expect.stringContaining('due after:') && expect.stringContaining('due before:'),
+                query: 'today | overdue',
                 cursor: undefined,
                 limit: 50,
             })
@@ -275,40 +226,18 @@ describe(`${FIND_TASKS_BY_DATE} tool`, () => {
             expect(textContent).toContain(`Use ${UPDATE_TASKS} to modify priorities or due dates`)
         })
 
-        it('should suggest appropriate actions when startDate is overdue', async () => {
-            const mockTasks = [
-                createMappedTask({
-                    id: TEST_IDS.TASK_1,
-                    content: 'Overdue task',
-                    dueDate: '2025-08-10',
-                }),
-            ]
-            const mockResponse = { tasks: mockTasks, nextCursor: null }
-            mockGetTasksByFilter.mockResolvedValue(mockResponse)
-
-            const result = await findTasksByDate.execute(
-                { startDate: 'overdue', limit: 10, daysCount: 1 },
-                mockTodoistApi,
-            )
-
-            const textContent = extractTextContent(result)
-            expect(textContent).toMatchSnapshot()
-            expect(textContent).toContain(`Use ${UPDATE_TASKS} to modify priorities or due dates`)
-        })
-
-        it('should provide helpful suggestions for empty overdue results', async () => {
+        it('should provide helpful suggestions for empty today results', async () => {
             const mockResponse = { tasks: [], nextCursor: null }
             mockGetTasksByFilter.mockResolvedValue(mockResponse)
 
             const result = await findTasksByDate.execute(
-                { startDate: 'overdue', limit: 10, daysCount: 1 },
+                { startDate: 'today', limit: 10, daysCount: 1 },
                 mockTodoistApi,
             )
 
             const textContent = extractTextContent(result)
             expect(textContent).toMatchSnapshot()
-            expect(textContent).toContain('Great job! No overdue tasks')
-            expect(textContent).toContain("Check today's tasks with startDate='today'")
+            expect(textContent).toContain('Great job! No tasks for today or overdue')
         })
 
         it('should provide helpful suggestions for empty date range results', async () => {
@@ -327,7 +256,7 @@ describe(`${FIND_TASKS_BY_DATE} tool`, () => {
             const textContent = extractTextContent(result)
             expect(textContent).toMatchSnapshot()
             expect(textContent).toContain("Expand date range with larger 'daysCount'")
-            expect(textContent).toContain("Check 'overdue' for past-due items")
+            expect(textContent).toContain("Check today's tasks with startDate='today'")
         })
     })
 
@@ -341,18 +270,18 @@ describe(`${FIND_TASKS_BY_DATE} tool`, () => {
                     limit: 50,
                     labels: ['work'],
                 },
-                expectedQueryPattern: '((@work))', // Will be combined with date query
+                expectedQueryPattern: 'today | overdue & ((@work))', // Will be combined with date query
             },
             {
                 name: 'multiple labels with AND operator',
                 params: {
-                    startDate: 'overdue',
+                    startDate: 'today',
                     daysCount: 1,
                     limit: 50,
                     labels: ['work', 'urgent'],
                     labelsOperator: 'and' as const,
                 },
-                expectedQueryPattern: 'overdue & ((@work  &  @urgent))',
+                expectedQueryPattern: 'today | overdue & ((@work  &  @urgent))',
             },
             {
                 name: 'multiple labels with OR operator',
@@ -386,8 +315,8 @@ describe(`${FIND_TASKS_BY_DATE} tool`, () => {
                 limit: 50,
             })
 
-            // For overdue specifically, check the exact pattern
-            if (params.startDate === 'overdue') {
+            // For today specifically, check the exact pattern
+            if (params.startDate === 'today') {
                 expect(mockGetTasksByFilter).toHaveBeenCalledWith({
                     client: mockTodoistApi,
                     query: expectedQueryPattern,
@@ -467,7 +396,7 @@ describe(`${FIND_TASKS_BY_DATE} tool`, () => {
             },
             {
                 error: TEST_ERRORS.API_RATE_LIMIT,
-                params: { startDate: 'overdue', limit: 50, daysCount: 7 },
+                params: { startDate: 'today', limit: 50, daysCount: 7 },
             },
             {
                 error: TEST_ERRORS.INVALID_CURSOR,

--- a/src/tools/complete-tasks.ts
+++ b/src/tools/complete-tasks.ts
@@ -52,7 +52,7 @@ function generateNextSteps(completed: number, failures: number): string[] {
     if (completed > 0) {
         const moveResult =
             failures === 0
-                ? "Use find-tasks-by-date('overdue') to tackle remaining overdue items."
+                ? "Use find-tasks-by-date('today') to tackle remaining overdue items."
                 : 'Review failed completions and retry if needed.'
         return [moveResult]
     }

--- a/src/utils/response-builders.ts
+++ b/src/utils/response-builders.ts
@@ -256,7 +256,7 @@ export function generateTaskNextSteps(
                     `Use ${FIND_TASKS_BY_DATE}('today') to review today's updated schedule`,
                 )
             } else if (context?.hasOverdue) {
-                nextSteps.push(`Use ${FIND_TASKS_BY_DATE}('overdue') to prioritize past-due items`)
+                nextSteps.push(`Use ${FIND_TASKS_BY_DATE}('today') to prioritize past-due items`)
             } else if (context?.projectName) {
                 nextSteps.push(
                     `Use ${GET_OVERVIEW} with projectId to see ${context.projectName} structure`,
@@ -291,7 +291,7 @@ export function generateTaskNextSteps(
                 nextSteps.push(`Use ${FIND_TASKS_BY_DATE}('tomorrow') to plan upcoming work`)
             } else if (context?.hasOverdue) {
                 nextSteps.push(
-                    `Use ${FIND_TASKS_BY_DATE}('overdue') to tackle remaining past-due items`,
+                    `Use ${FIND_TASKS_BY_DATE}('today') to tackle remaining past-due items`,
                 )
             } else {
                 nextSteps.push(`Use ${FIND_TASKS_BY_DATE}('today') to see remaining work`)


### PR DESCRIPTION
## Short description

The fact that `find-tasks-by-date` needs to be called twice in order to find today tasks AND overdue tasks is bothering. Not only that, but I found it an issue in practice. Sometimes, Claude Desktop only called it once with the "today" argument when I asked to know my tasks for today. When in fact 100% we want today tasks to include the overdue onces (to mimic the today view in the UI apps).

Here's evidence of the issue. I tried the same question on the same Todoist account. Once in the current production version of this MCP server, and another one using the version in this branch.

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>

<img width="759" height="677" alt="CleanShot 2025-09-24 at 18 54 07" src="https://github.com/user-attachments/assets/212ebcb3-5ea3-4aeb-bc95-55b23df981c2" />

</td><td>

<img width="756" height="791" alt="CleanShot 2025-09-24 at 18 47 12" src="https://github.com/user-attachments/assets/6027db80-07ec-4ba7-9a62-114916871967" />

</td></tr>
</tbody>
</table>

### Alternatives I tried but did not work

I tried to tell the LLM in the instructions (system prompt) of this MCP server. It still happened as in the "Before" screenshot above.

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [x] Added tests for bugs / new features
-   [x] Updated docs (README, etc.)
