### PR TITLE
chore: Improve dev docs and dev script

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -27,6 +27,8 @@ npm run dev
 
 This command starts the TypeScript compiler in watch mode and automatically restarts the [MCP inspector](https://modelcontextprotocol.io/docs/tools/inspector) whenever you make changes to the source code.
 
+In MCP Inspector, ensure that the Transport type is `STDIO`, the command is `npx` and the arguments `nodemon --quiet --watch dist --ext js --exec node dist/main.js`, this will make sure that the MCP inspector is pointing at your locally running setup.
+
 ### For testing the built version:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "build": "rimraf dist && npx tsc --project tsconfig.json",
         "postbuild": "chmod +x dist/main.js",
         "start": "npm run build && npx @modelcontextprotocol/inspector node dist/main.js",
-        "dev": "concurrently \"npx tsc --watch\" \"nodemon --watch dist --ext js --exec 'npx @modelcontextprotocol/inspector node dist/main.js'\"",
+        "dev": "concurrently \"npx tsc --watch\" \"npx @modelcontextprotocol/inspector npx nodemon --quiet --watch dist --ext js --exec node dist/main.js\"",
         "setup": "cp .env.example .env && npm install && npm run build",
         "test:executable": "npm run build && node scripts/test-executable.cjs",
         "type-check": "npx tsc --noEmit",


### PR DESCRIPTION
# Pull Request

## Short description

Improved the dev-setup docs because I found myself continually being pointed at the production MCP server.

Improved the `npm run dev` script. Previously, you would start the script, it would start the server and the MCP inspector, but then when you made any code changes, it would [correctly] restart the server, but it would also restart the MCP inspector, losing whatever session you had going on. Now it just restarts the server. 

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (README, etc.)
-   [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->