### PR TITLE
fix: Convert the API priorities into a consumable priority

### DIFF
--- a/src/tools/__tests__/__snapshots__/add-tasks.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/add-tasks.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`add-tasks tool adding multiple tasks should add multiple tasks and return mapped results 1`] = `
 "Added 2 tasks to projects.
 Tasks:
-    First task content • P1 • id=8485093748
-    Second task content • due 2025-08-15 • P2 • id=8485093749.
+    First task content • P4 • id=8485093748
+    Second task content • due 2025-08-15 • P3 • id=8485093749.
 Next:
 - Use get-overview to see your updated project organization"
 `;
@@ -12,8 +12,8 @@ Next:
 exports[`add-tasks tool adding multiple tasks should add tasks with duration 1`] = `
 "Added 2 tasks to projects.
 Tasks:
-    Task with 2 hour duration • P1 • id=8485093752
-    Task with 45 minute duration • P1 • id=8485093753.
+    Task with 2 hour duration • P4 • id=8485093752
+    Task with 45 minute duration • P4 • id=8485093753.
 Next:
 - Use get-overview to see your updated project organization"
 `;
@@ -21,7 +21,7 @@ Next:
 exports[`add-tasks tool adding multiple tasks should handle tasks with section and parent IDs 1`] = `
 "Added 1 task to projects.
 Tasks:
-    Subtask content • P3 • id=8485093750.
+    Subtask content • P2 • id=8485093750.
 Next:
 - Use get-overview to see your updated project organization"
 `;
@@ -29,7 +29,7 @@ Next:
 exports[`add-tasks tool next steps logic should suggest find-tasks-by-date for today when hasToday is true 1`] = `
 "Added 1 task to projects.
 Tasks:
-    Task due today • due 2025-08-17 • P1 • id=8485093755.
+    Task due today • due 2025-08-17 • P4 • id=8485093755.
 Next:
 - Use get-overview to see your updated project organization"
 `;
@@ -37,7 +37,7 @@ Next:
 exports[`add-tasks tool next steps logic should suggest overview tool when no hasToday context 1`] = `
 "Added 1 task to projects.
 Tasks:
-    Regular task • P1 • id=8485093756.
+    Regular task • P4 • id=8485093756.
 Next:
 - Use get-overview to see your updated project organization"
 `;

--- a/src/tools/__tests__/__snapshots__/find-completed-tasks.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/find-completed-tasks.test.ts.snap
@@ -4,7 +4,7 @@ exports[`find-completed-tasks tool getting completed tasks by completion date (d
 "Completed tasks (by completed date): 1 (limit 50).
 Filter: completed date: 2025-08-10 to 2025-08-15.
 Preview:
-    Completed task 1 • due 2025-08-14 • P2 • id=8485093748
+    Completed task 1 • due 2025-08-14 • P3 • id=8485093748
 Next:
 - Use find-tasks-by-date for active tasks or get-overview for current productivity."
 `;
@@ -21,7 +21,7 @@ exports[`find-completed-tasks tool getting completed tasks by due date should ge
 "Completed tasks (by due date): 1 (limit 50).
 Filter: due date: 2025-08-10 to 2025-08-20.
 Preview:
-    Task completed by due date • due 2025-08-15 • P3 • id=8485093750
+    Task completed by due date • due 2025-08-15 • P2 • id=8485093750
 Next:
 - Use find-tasks-by-date for active tasks or get-overview for current productivity.
 - Recurring tasks will automatically create new instances."
@@ -31,7 +31,7 @@ exports[`find-completed-tasks tool label filtering should combine other filters 
 "Completed tasks (by due date): 1 (limit 25).
 Filter: due date: 2025-08-01 to 2025-08-31; project: test-project-id; section: test-section-id; labels: @important.
 Preview:
-    Important completed task • P1 • id=8485093748
+    Important completed task • P4 • id=8485093748
 Next:
 - Use find-tasks-by-date for active tasks or get-overview for current productivity."
 `;
@@ -40,7 +40,7 @@ exports[`find-completed-tasks tool label filtering should filter completed tasks
 "Completed tasks (by due date): 1 (limit 50).
 Filter: due date: 2025-08-01 to 2025-08-31; labels: @work & @urgent.
 Preview:
-    Completed task with label • P1 • id=8485093748
+    Completed task with label • P4 • id=8485093748
 Next:
 - Use find-tasks-by-date for active tasks or get-overview for current productivity."
 `;
@@ -49,7 +49,7 @@ exports[`find-completed-tasks tool label filtering should filter completed tasks
 "Completed tasks (by completed date): 1 (limit 25).
 Filter: completed date: 2025-08-10 to 2025-08-20; labels: @personal | @shopping.
 Preview:
-    Completed task with label • P1 • id=8485093748
+    Completed task with label • P4 • id=8485093748
 Next:
 - Use find-tasks-by-date for active tasks or get-overview for current productivity."
 `;
@@ -58,7 +58,7 @@ exports[`find-completed-tasks tool label filtering should filter completed tasks
 "Completed tasks (by completed date): 1 (limit 50).
 Filter: completed date: 2025-08-01 to 2025-08-31; labels: @work.
 Preview:
-    Completed task with label • P1 • id=8485093748
+    Completed task with label • P4 • id=8485093748
 Next:
 - Use find-tasks-by-date for active tasks or get-overview for current productivity."
 `;

--- a/src/tools/__tests__/__snapshots__/find-tasks-by-date.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/find-tasks-by-date.test.ts.snap
@@ -10,7 +10,7 @@ exports[`find-tasks-by-date tool label filtering should combine date filters wit
 "Tasks for 2025-08-15: 1 (limit 25).
 Filter: 2025-08-15; labels: @important.
 Preview:
-    Important task for specific date • due 2025-08-15 • P1 • id=8485093748
+    Important task for specific date • due 2025-08-15 • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks
@@ -27,7 +27,7 @@ exports[`find-tasks-by-date tool listing overdue tasks should handle overdue tas
 "Overdue tasks: 1 (limit 50).
 Filter: overdue tasks only.
 Preview:
-    Overdue task • due 2025-08-10 • P2 • id=8485093748
+    Overdue task • due 2025-08-10 • P3 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks
@@ -38,7 +38,7 @@ exports[`find-tasks-by-date tool listing tasks by date range should get tasks fo
 "Today's tasks: 1 (limit 50).
 Filter: today + 6 more days.
 Preview:
-    Today task • due 2025-08-15 • P1 • id=8485093748
+    Today task • due 2025-08-15 • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks
@@ -49,8 +49,8 @@ exports[`find-tasks-by-date tool listing tasks by date range should handle multi
 "Tasks for 2025-08-20: 2 (limit 20), more available.
 Filter: 2025-08-20 to 2025-08-16.
 Preview:
-    Multi-day task 1 • due 2025-08-20 • P1 • id=8485093749
-    Multi-day task 2 • due 2025-08-21 • P1 • id=8485093750
+    Multi-day task 1 • due 2025-08-20 • P4 • id=8485093749
+    Multi-day task 2 • due 2025-08-21 • P4 • id=8485093750
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks
@@ -62,7 +62,7 @@ exports[`find-tasks-by-date tool listing tasks by date range should handle speci
 "Tasks for 2025-08-20: 1 (limit 50).
 Filter: 2025-08-20 to 2025-08-16.
 Preview:
-    Specific date task • due 2025-08-20 • P1 • id=8485093748
+    Specific date task • due 2025-08-20 • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks
@@ -85,7 +85,7 @@ exports[`find-tasks-by-date tool next steps logic should suggest appropriate act
 "Tasks for 2025-08-15: 1 (limit 10).
 Filter: 2025-08-15.
 Preview:
-    Overdue task from list • due 2025-08-10 • P1 • id=8485093748
+    Overdue task from list • due 2025-08-10 • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks
@@ -96,7 +96,7 @@ exports[`find-tasks-by-date tool next steps logic should suggest appropriate act
 "Overdue tasks: 1 (limit 10).
 Filter: overdue tasks only.
 Preview:
-    Overdue task • due 2025-08-10 • P1 • id=8485093748
+    Overdue task • due 2025-08-10 • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks
@@ -107,7 +107,7 @@ exports[`find-tasks-by-date tool next steps logic should suggest today-focused a
 "Today's tasks: 1 (limit 10).
 Filter: today.
 Preview:
-    Today's task • due 2025-08-15 • P1 • id=8485093748
+    Today's task • due 2025-08-15 • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks

--- a/src/tools/__tests__/__snapshots__/find-tasks.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/find-tasks.test.ts.snap
@@ -4,7 +4,7 @@ exports[`find-tasks tool container filtering should find tasks in parent task 1`
 "Subtasks: 1 (limit 10).
 Filter: subtasks of 8485093748.
 Preview:
-    Subtask • P1 • id=8485093748
+    Subtask • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks"
@@ -14,7 +14,7 @@ exports[`find-tasks tool container filtering should find tasks in project 1`] = 
 "Tasks in project: 1 (limit 10).
 Filter: in project 6cfCcrrCFg2xP94Q.
 Preview:
-    Project task • P1 • id=8485093748
+    Project task • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks"
@@ -24,7 +24,7 @@ exports[`find-tasks tool container filtering should find tasks in section 1`] = 
 "Tasks in section: 1 (limit 10).
 Filter: in section section-123.
 Preview:
-    Section task • P1 • id=8485093748
+    Section task • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks"
@@ -34,7 +34,7 @@ exports[`find-tasks tool next steps logic should provide different next steps fo
 "Search results for "future tasks": 1 (limit 10).
 Filter: matching "future tasks".
 Preview:
-    Regular future task • due 2025-08-25 • P1 • id=8485093748
+    Regular future task • due 2025-08-25 • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks
@@ -51,7 +51,7 @@ exports[`find-tasks tool next steps logic should suggest different actions when 
 "Search results for "overdue tasks": 1 (limit 10).
 Filter: matching "overdue tasks".
 Preview:
-    Overdue search result • due 2025-08-10 • P1 • id=8485093748
+    Overdue search result • due 2025-08-10 • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks
@@ -62,7 +62,7 @@ exports[`find-tasks tool next steps logic should suggest today tasks when hasTod
 "Search results for "today tasks": 1 (limit 10).
 Filter: matching "today tasks".
 Preview:
-    Task due today • due 2025-08-17 • P1 • id=8485093748
+    Task due today • due 2025-08-17 • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks
@@ -73,7 +73,7 @@ exports[`find-tasks tool searching tasks should handle custom limit 1`] = `
 "Search results for "project update": 1 (limit 5).
 Filter: matching "project update".
 Preview:
-    Test result • P1 • id=8485093748
+    Test result • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks"
@@ -83,7 +83,7 @@ exports[`find-tasks tool searching tasks should handle pagination cursor 1`] = `
 "Search results for "follow up": 1 (limit 20).
 Filter: matching "follow up".
 Preview:
-    Test result • P1 • id=8485093748
+    Test result • P4 • id=8485093748
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks"
@@ -105,8 +105,8 @@ exports[`find-tasks tool searching tasks should search tasks and return results 
 "Search results for "important meeting": 2 (limit 10), more available.
 Filter: matching "important meeting".
 Preview:
-    Task containing search term • P1 • id=8485093748
-    Another matching task • P2 • id=8485093749
+    Task containing search term • P4 • id=8485093748
+    Another matching task • P3 • id=8485093749
 Next:
 - Use update-tasks to modify priorities or due dates
 - Use complete-tasks to mark finished tasks

--- a/src/utils/priorities.ts
+++ b/src/utils/priorities.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 const PRIORITY_VALUES = ['p1', 'p2', 'p3', 'p4'] as const
-type Priority = (typeof PRIORITY_VALUES)[number]
+export type Priority = (typeof PRIORITY_VALUES)[number]
 
 export const PrioritySchema = z.enum(PRIORITY_VALUES, {
     description: 'Task priority: p1 (highest), p2 (high), p3 (medium), p4 (lowest/default)',
@@ -17,4 +17,10 @@ export function convertNumberToPriority(priority: number): Priority | undefined 
     // Convert Todoist API numbers back to our enum
     const numberMap = { 4: 'p1', 3: 'p2', 2: 'p3', 1: 'p4' } as const
     return numberMap[priority as keyof typeof numberMap]
+}
+
+export function formatPriorityForDisplay(priority: number): string {
+    // Convert Todoist API numbers to display format (P1, P2, P3, P4)
+    const displayMap = { 4: 'P1', 3: 'P2', 2: 'P3', 1: 'P4' } as const
+    return displayMap[priority as keyof typeof displayMap] || ''
 }

--- a/src/utils/response-builders.ts
+++ b/src/utils/response-builders.ts
@@ -1,4 +1,5 @@
 import { DisplayLimits } from './constants.js'
+import { formatPriorityForDisplay } from './priorities.js'
 import { ToolNames } from './tool-names.js'
 
 /**
@@ -127,7 +128,7 @@ export function summarizeBatch(params: BatchOperationParams): string {
 function formatTaskPreview(task: TaskLike): string {
     const content = task.content || task.title || 'Untitled'
     const due = task.dueDate ? ` • due ${task.dueDate}` : ''
-    const priority = task.priority && task.priority < 4 ? ` • P${task.priority}` : ''
+    const priority = task.priority ? ` • ${formatPriorityForDisplay(task.priority)}` : ''
     const project = task.projectName ? ` • ${task.projectName}` : ''
     const id = task.id ? ` • id=${task.id}` : ''
     return `    ${content}${due}${priority}${project}${id}`


### PR DESCRIPTION
# Pull Request

Closes #112 

## Short description

We recently decided that our priorities should be based on what the user expectation is, rather than what the API actually is. So essentially priority of 1 is actually just a p4. What we forgot to do was during the task mapping, we weren't updating the priorities in the task data going out of the MCP

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (README, etc.)
-   [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->