### PR TITLE
chore: auto-publish draft releases to trigger npm workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,3 +21,12 @@ jobs:
                   release-type: node
                   config-file: .github/release-please-config.json
                   manifest-file: .github/release-please-manifest.json
+
+            - name: Publish draft release
+              if: ${{ steps.release.outputs.release_created }}
+              run: |
+                  RELEASE_TAG="${{ steps.release.outputs.tag_name }}"
+                  echo "Publishing release $RELEASE_TAG"
+                  gh release edit "$RELEASE_TAG" --draft=false
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add step to release-please workflow to automatically publish draft releases
- This ensures the `release: published` event fires and triggers the npm publish workflow

## Problem
Despite having `draft: false` in release-please-config.json, release-please creates GitHub releases as drafts. The publish workflow only triggers on `release: published` events, so draft releases don't automatically publish to npm.

## Solution
Added a step to the release-please workflow that:
1. Checks if a release was created (`release_created` output)
2. Uses `gh release edit --draft=false` to publish the release
3. This triggers the `release: published` event, which runs the npm publish workflow

## Test plan
- [x] Verified the workflow syntax
- [ ] Next release PR merge will test the full flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)