### PR TITLE
feat: add parentId support to add-projects tool

### DIFF
--- a/src/tools/__tests__/__snapshots__/add-projects.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/add-projects.test.ts.snap
@@ -18,6 +18,15 @@ Next:
 - Use get-overview with projectId=project-789 to see project structure"
 `;
 
+exports[`add-projects tool creating a single project should create project with parentId to create a sub-project 1`] = `
+"Added 1 project:
+• Child Project (id=project-child)
+Next:
+- Use add-sections to organize new project with sections
+- Use add-tasks to add your first tasks to this project
+- Use get-overview with projectId=project-child to see project structure"
+`;
+
 exports[`add-projects tool creating a single project should handle different project properties from API 1`] = `
 "Added 1 project:
 • My Blue Project (id=project-456)

--- a/src/tools/__tests__/add-projects.test.ts
+++ b/src/tools/__tests__/add-projects.test.ts
@@ -126,6 +126,32 @@ describe(`${ADD_PROJECTS} tool`, () => {
             expect(textContent).toContain('Board Project')
             expect(textContent).toContain('id=project-789')
         })
+
+        it('should create project with parentId to create a sub-project', async () => {
+            const mockApiResponse = createMockProject({
+                id: 'project-child',
+                name: 'Child Project',
+                parentId: 'project-parent',
+            })
+
+            mockTodoistApi.addProject.mockResolvedValue(mockApiResponse)
+
+            const result = await addProjects.execute(
+                { projects: [{ name: 'Child Project', parentId: 'project-parent' }] },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.addProject).toHaveBeenCalledWith({
+                name: 'Child Project',
+                parentId: 'project-parent',
+            })
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Added 1 project:')
+            expect(textContent).toContain('Child Project')
+            expect(textContent).toContain('id=project-child')
+        })
     })
 
     describe('creating multiple projects', () => {

--- a/src/tools/add-projects.ts
+++ b/src/tools/add-projects.ts
@@ -9,6 +9,10 @@ const { ADD_SECTIONS, ADD_TASKS, FIND_PROJECTS, GET_OVERVIEW } = ToolNames
 
 const ProjectSchema = z.object({
     name: z.string().min(1).describe('The name of the project.'),
+    parentId: z
+        .string()
+        .optional()
+        .describe('The ID of the parent project. If provided, creates this as a sub-project.'),
     isFavorite: z
         .boolean()
         .optional()


### PR DESCRIPTION
## Summary
Adds `parentId` parameter support to the `add-projects` tool, enabling creation of subprojects under a parent project.

Fixes (partially) #76

The REST API endpoint to update projects does not support modifying the `parent_id`. We may work on it to add the capability to the API, then to the Todoist API Typescript library, and then we can add this capability to the MCP server tools.

## Demo

Here's a project hierarchy I just created using the MCP server with the changes in this branch:

<img width="1093" height="758" alt="CleanShot 2025-09-30 at 09 09 23" src="https://github.com/user-attachments/assets/8ed5d062-df48-434b-8016-b9459d2b9f42" />

## Changes
- Added `parentId` optional parameter to `ProjectSchema` in `add-projects` tool
- Added test coverage for creating projects with `parentId`
- Updated snapshots

## Context
The Todoist REST API v2 supports `parent_id` when creating projects, but the MCP tool wasn't exposing this parameter. This prevented users from programmatically creating project hierarchies.

## Testing
- ✅ Added test: "should create project with `parentId` to create a subproject"
- ✅ All 258 tests pass
- ✅ Type checking passes
- ✅ Build succeeds

## Note
This PR only fixes `add-projects`. The `update-projects` tool still doesn't support changing a project's parent, as the Todoist REST API v2 doesn't officially support updating `parent_id`. That will be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)