### PR TITLE
fix: preserve markdown in tasks content and description

### DIFF
--- a/src/tool-helpers.test.ts
+++ b/src/tool-helpers.test.ts
@@ -88,6 +88,58 @@ describe('shared utilities', () => {
 
             expect(result.duration).toBe('2h30m')
         })
+
+        it('should preserve markdown links and formatting in content and description', () => {
+            const mockTask = {
+                id: '123',
+                content: 'Task with **bold** and [link](https://example.com)',
+                description: `Rich markdown description:
+
+### Links
+[Wikipedia](https://en.wikipedia.org/wiki/Test)
+[GitHub](https://github.com/example/repo)
+
+### Formatting
+**Bold text**
+*Italic text*
+\`code block\`
+
+End of description.`,
+                projectId: 'proj-1',
+                sectionId: null,
+                parentId: null,
+                labels: [],
+                priority: 1,
+            } as unknown as Task
+
+            const result = mapTask(mockTask)
+
+            // Verify exact preservation of markdown content
+            expect(result.content).toBe('Task with **bold** and [link](https://example.com)')
+            expect(result.description).toBe(`Rich markdown description:
+
+### Links
+[Wikipedia](https://en.wikipedia.org/wiki/Test)
+[GitHub](https://github.com/example/repo)
+
+### Formatting
+**Bold text**
+*Italic text*
+\`code block\`
+
+End of description.`)
+
+            // Verify specific URLs are preserved
+            expect(result.content).toContain('[link](https://example.com)')
+            expect(result.description).toContain('[Wikipedia](https://en.wikipedia.org/wiki/Test)')
+            expect(result.description).toContain('[GitHub](https://github.com/example/repo)')
+
+            // Verify other markdown formatting is preserved
+            expect(result.content).toContain('**bold**')
+            expect(result.description).toContain('**Bold text**')
+            expect(result.description).toContain('*Italic text*')
+            expect(result.description).toContain('`code block`')
+        })
     })
 
     describe('mapProject', () => {

--- a/src/tool-helpers.ts
+++ b/src/tool-helpers.ts
@@ -1,10 +1,9 @@
-import {
-    getSanitizedContent,
-    type MoveTaskArgs,
-    type PersonalProject,
-    type Task,
-    type TodoistApi,
-    type WorkspaceProject,
+import type {
+    MoveTaskArgs,
+    PersonalProject,
+    Task,
+    TodoistApi,
+    WorkspaceProject,
 } from '@doist/todoist-api-typescript'
 import z from 'zod'
 import { formatDuration } from './utils/duration-parser.js'
@@ -65,8 +64,8 @@ export function createMoveTaskArgs(
 function mapTask(task: Task) {
     return {
         id: task.id,
-        content: getSanitizedContent(task.content),
-        description: getSanitizedContent(task.description),
+        content: task.content,
+        description: task.description,
         dueDate: task.due?.date,
         recurring: task.due?.isRecurring && task.due.string ? task.due.string : false,
         priority: task.priority,


### PR DESCRIPTION
Closes #65 

## Short description

We were incorrectly wrapping the task content and description in calls to `getSanitizedContent` from the Todoist Typescript API library. This is no longer the case. LLMs can correctly handle the Markdown, and strip the Markdown notation if needed.

<img width="764" height="490" alt="CleanShot 2025-09-30 at 12 05 28" src="https://github.com/user-attachments/assets/9dbdcbb8-0a88-451f-abc6-503afc291b9f" />

But the LLM is still capable of extracting that info if requested:

<img width="728" height="325" alt="CleanShot 2025-09-30 at 12 07 09" src="https://github.com/user-attachments/assets/a591f74e-12b0-4ad5-a847-dea27c83ee1b" />

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [x] Added tests for bugs / new features
