### PR TITLE
fix: allow add-tasks to work with only content parameter

### DIFF
--- a/src/tools/add-tasks.ts
+++ b/src/tools/add-tasks.ts
@@ -86,8 +86,8 @@ async function processTask(task: z.infer<typeof TaskSchema>, client: TodoistApi)
         taskArgs.priority = convertPriorityToNumber(priority)
     }
 
-    // Prevent assignment to tasks without sufficient project context
-    if (!projectId && !sectionId && !parentId) {
+    // Only prevent assignment (not task creation) without sufficient project context
+    if (responsibleUser && !projectId && !sectionId && !parentId) {
         throw new Error(
             `Task "${task.content}": Cannot assign tasks without specifying project context. Please specify a projectId, sectionId, or parentId.`,
         )


### PR DESCRIPTION
## 🐛 Fix

Allow `add-tasks` tool to create tasks with only the `content` parameter, without requiring `projectId`, `sectionId`, or `parentId`.

## 📋 Problem

The `add-tasks` tool was incorrectly throwing an error when no project context was provided, even for simple task creation. This prevented users from creating basic tasks that would automatically go to their Inbox project (which is the standard Todoist API behavior).