### PR TITLE
feat: Improve findCompletedTasks to handle user timezones

### DIFF
--- a/src/tools/__tests__/__snapshots__/find-completed-tasks.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/find-completed-tasks.test.ts.snap
@@ -62,3 +62,12 @@ Preview:
 Next:
 - Use find-tasks-by-date for active tasks or get-overview for current productivity."
 `;
+
+exports[`find-completed-tasks tool timezone handling should convert user timezone to UTC correctly (Europe/Madrid) 1`] = `
+"Completed tasks (by completed date): 1 (limit 50).
+Filter: completed date: 2025-10-11 to 2025-10-11.
+Preview:
+    Task completed in Madrid timezone • P4 • id=8485093750
+Next:
+- Use find-tasks-by-date for active tasks or get-overview for current productivity."
+`;


### PR DESCRIPTION
## Context
The find-completed-tasks tool doesn't work properly because it ignores time zones. This PR fixes this by:

- Adding support for converting user local dates to UTC in the findCompletedTasks tool
- Updating the execute method to accept 'since' and 'until' parameters, adjusting them based on the user's timezone
- I've also added a test to verify timezone handling, including a case for users in the Europe/Madrid timezone