### PR TITLE
feat: Expose completion and modification metadata in task mapping

### DIFF
--- a/src/tool-helpers.ts
+++ b/src/tool-helpers.ts
@@ -86,6 +86,9 @@ function mapTask(task: Task) {
         duration: task.duration ? formatDuration(task.duration.amount) : null,
         responsibleUid: task.responsibleUid,
         assignedByUid: task.assignedByUid,
+        checked: task.checked,
+        completedAt: task.completedAt,
+        updatedAt: task.updatedAt,
     }
 }
 

--- a/src/utils/test-helpers.ts
+++ b/src/utils/test-helpers.ts
@@ -19,6 +19,9 @@ export type MappedTask = {
     duration: string | null
     responsibleUid: string | null
     assignedByUid: string | null
+    checked: boolean
+    completedAt: string | null
+    updatedAt: string | null
 }
 
 /**
@@ -142,6 +145,9 @@ export function createMappedTask(overrides: Partial<MappedTask> = {}): MappedTas
         duration: null,
         responsibleUid: null,
         assignedByUid: null,
+        checked: false,
+        completedAt: null,
+        updatedAt: '2025-08-13T22:09:56.123456Z',
         ...overrides,
     }
 }


### PR DESCRIPTION
Add checked, completedAt, and updatedAt fields to mapTask output. These fields were available in the Todoist SDK but not exposed through our mapping layer.

This allows agents to:
- Determine task completion status without additional API calls
- Track when tasks were completed for productivity analysis
- Monitor task modification history

Fixes #152

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [x] Added tests for bugs / new features
-   [ ] Updated docs (README, etc.)
-   [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->