### PR TITLE
fix: Switch to using `moveTask` instead of `moveTasks`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "4.13.2",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-api-typescript": "5.6.4",
+                "@doist/todoist-api-typescript": "5.7.0",
                 "@modelcontextprotocol/sdk": "^1.11.1",
                 "date-fns": "^4.1.0",
                 "dotenv": "^16.5.0",
@@ -81,7 +81,6 @@
             "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -791,9 +790,9 @@
             }
         },
         "node_modules/@doist/todoist-api-typescript": {
-            "version": "5.6.4",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-5.6.4.tgz",
-            "integrity": "sha512-ZmKkG59stQT2sDKJm8il2vyM/J7Nn6AhWCSspsQASxn9wWZKp0JbOeEJViLYmMrDlrlJ2ISCQN1cOjsQpEFvzA==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-5.7.0.tgz",
+            "integrity": "sha512-d/pz7BBJguXxTuesR+CziwhmW9GjY8FtpbbgJtzCCbDxbioCgTqphE1Dc3PiqKMdxt+faInx2IXYUmFf8R+TiA==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.0.0",
@@ -802,7 +801,7 @@
                 "camelcase": "6.3.0",
                 "emoji-regex": "10.5.0",
                 "ts-custom-error": "^3.2.0",
-                "uuid": "^11.0.0",
+                "uuid": "11.1.0",
                 "zod": "4.1.5"
             },
             "peerDependencies": {
@@ -2188,7 +2187,6 @@
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
             "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.4",
@@ -2448,7 +2446,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001733",
                 "electron-to-chromium": "^1.5.199",
@@ -3373,7 +3370,6 @@
             "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
             "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.0",
@@ -4289,7 +4285,6 @@
             "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "30.2.0",
                 "@jest/types": "30.2.0",
@@ -6910,7 +6905,6 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
             "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "license": "(MIT OR CC0-1.0)",
-            "peer": true,
             "engines": {
                 "node": ">=16"
             },
@@ -6959,7 +6953,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7415,7 +7408,6 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-api-typescript": "5.6.4",
+        "@doist/todoist-api-typescript": "5.7.0",
         "@modelcontextprotocol/sdk": "^1.11.1",
         "date-fns": "^4.1.0",
         "dotenv": "^16.5.0",

--- a/src/tools/__tests__/update-tasks.test.ts
+++ b/src/tools/__tests__/update-tasks.test.ts
@@ -12,7 +12,7 @@ import { updateTasks } from '../update-tasks.js'
 // Mock the Todoist API
 const mockTodoistApi = {
     updateTask: jest.fn(),
-    moveTasks: jest.fn(),
+    moveTask: jest.fn(),
 } as unknown as jest.Mocked<TodoistApi>
 
 const { UPDATE_TASKS } = ToolNames
@@ -171,7 +171,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 addedAt: '2025-08-13T22:09:56.123456Z',
             })
 
-            mockTodoistApi.moveTasks.mockResolvedValue([mockApiResponse])
+            mockTodoistApi.moveTask.mockResolvedValue(mockApiResponse)
 
             const result = await updateTasks.execute(
                 {
@@ -185,7 +185,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 mockTodoistApi,
             )
 
-            expect(mockTodoistApi.moveTasks).toHaveBeenCalledWith(['8485093750'], {
+            expect(mockTodoistApi.moveTask).toHaveBeenCalledWith('8485093750', {
                 projectId: 'new-project-id',
             })
             expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
@@ -206,7 +206,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 addedAt: '2025-08-13T22:09:56.123456Z',
             })
 
-            mockTodoistApi.moveTasks.mockResolvedValue([mockApiResponse])
+            mockTodoistApi.moveTask.mockResolvedValue(mockApiResponse)
 
             const result = await updateTasks.execute(
                 {
@@ -220,7 +220,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 mockTodoistApi,
             )
 
-            expect(mockTodoistApi.moveTasks).toHaveBeenCalledWith(['8485093751'], {
+            expect(mockTodoistApi.moveTask).toHaveBeenCalledWith('8485093751', {
                 parentId: 'parent-task-123',
             })
             expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
@@ -256,7 +256,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 },
             })
 
-            mockTodoistApi.moveTasks.mockResolvedValue([movedTask])
+            mockTodoistApi.moveTask.mockResolvedValue(movedTask)
             mockTodoistApi.updateTask.mockResolvedValue(updatedTask)
 
             const result = await updateTasks.execute(
@@ -275,8 +275,8 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 mockTodoistApi,
             )
 
-            // Should call moveTasks first for the projectId
-            expect(mockTodoistApi.moveTasks).toHaveBeenCalledWith(['8485093752'], {
+            // Should call moveTask first for the projectId
+            expect(mockTodoistApi.moveTask).toHaveBeenCalledWith('8485093752', {
                 projectId: 'different-project-id',
             })
 
@@ -397,7 +397,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 projectId: 'new-project-id',
             })
 
-            mockTodoistApi.moveTasks.mockResolvedValue([movedTask])
+            mockTodoistApi.moveTask.mockResolvedValue(movedTask)
             mockTodoistApi.updateTask.mockResolvedValue(updatedTask)
 
             const result = await updateTasks.execute(
@@ -414,8 +414,8 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 mockTodoistApi,
             )
 
-            // Should call moveTasks first
-            expect(mockTodoistApi.moveTasks).toHaveBeenCalledWith(['8485093755'], {
+            // Should call moveTask first
+            expect(mockTodoistApi.moveTask).toHaveBeenCalledWith('8485093755', {
                 projectId: 'new-project-id',
             })
 
@@ -645,9 +645,9 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 ]
 
                 // Each task should be moved individually to avoid bulk operation issues
-                mockTodoistApi.moveTasks
-                    .mockResolvedValueOnce([mockResponses[0] as Task])
-                    .mockResolvedValueOnce([mockResponses[1] as Task])
+                mockTodoistApi.moveTask
+                    .mockResolvedValueOnce(mockResponses[0] as Task)
+                    .mockResolvedValueOnce(mockResponses[1] as Task)
 
                 const result = await updateTasks.execute(
                     {
@@ -659,12 +659,12 @@ describe(`${UPDATE_TASKS} tool`, () => {
                     mockTodoistApi,
                 )
 
-                // Should call moveTasks twice, once for each task individually
-                expect(mockTodoistApi.moveTasks).toHaveBeenCalledTimes(2)
-                expect(mockTodoistApi.moveTasks).toHaveBeenNthCalledWith(1, ['6cPHJm59x4WhMwR4'], {
+                // Should call moveTask twice, once for each task individually
+                expect(mockTodoistApi.moveTask).toHaveBeenCalledTimes(2)
+                expect(mockTodoistApi.moveTask).toHaveBeenNthCalledWith(1, '6cPHJm59x4WhMwR4', {
                     sectionId,
                 })
-                expect(mockTodoistApi.moveTasks).toHaveBeenNthCalledWith(2, ['6cPHJj2MV4HMj92W'], {
+                expect(mockTodoistApi.moveTask).toHaveBeenNthCalledWith(2, '6cPHJj2MV4HMj92W', {
                     sectionId,
                 })
                 expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
@@ -686,10 +686,10 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 ]
 
                 // Each task should be moved individually
-                mockTodoistApi.moveTasks
-                    .mockResolvedValueOnce([mockResponses[0] as Task])
-                    .mockResolvedValueOnce([mockResponses[1] as Task])
-                    .mockResolvedValueOnce([mockResponses[2] as Task])
+                mockTodoistApi.moveTask
+                    .mockResolvedValueOnce(mockResponses[0] as Task)
+                    .mockResolvedValueOnce(mockResponses[1] as Task)
+                    .mockResolvedValueOnce(mockResponses[2] as Task)
 
                 const result = await updateTasks.execute(
                     {
@@ -703,14 +703,14 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 )
 
                 // Verify API was called correctly - 3 individual move calls
-                expect(mockTodoistApi.moveTasks).toHaveBeenCalledTimes(3)
-                expect(mockTodoistApi.moveTasks).toHaveBeenNthCalledWith(1, ['8485093748'], {
+                expect(mockTodoistApi.moveTask).toHaveBeenCalledTimes(3)
+                expect(mockTodoistApi.moveTask).toHaveBeenNthCalledWith(1, '8485093748', {
                     projectId: 'new-project-id',
                 })
-                expect(mockTodoistApi.moveTasks).toHaveBeenNthCalledWith(2, ['8485093749'], {
+                expect(mockTodoistApi.moveTask).toHaveBeenNthCalledWith(2, '8485093749', {
                     sectionId: 'new-section-id',
                 })
-                expect(mockTodoistApi.moveTasks).toHaveBeenNthCalledWith(3, ['8485093750'], {
+                expect(mockTodoistApi.moveTask).toHaveBeenNthCalledWith(3, '8485093750', {
                     parentId: 'parent-task-123',
                 })
                 expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
@@ -732,15 +732,15 @@ describe(`${UPDATE_TASKS} tool`, () => {
                     addedAt: '2025-08-13T22:09:59.123456Z',
                 })
 
-                mockTodoistApi.moveTasks.mockResolvedValue([mockTaskResponse])
+                mockTodoistApi.moveTask.mockResolvedValue(mockTaskResponse)
 
                 const result = await updateTasks.execute(
                     { tasks: [{ id: '8485093751', sectionId: 'target-section' }] },
                     mockTodoistApi,
                 )
 
-                expect(mockTodoistApi.moveTasks).toHaveBeenCalledTimes(1)
-                expect(mockTodoistApi.moveTasks).toHaveBeenCalledWith(['8485093751'], {
+                expect(mockTodoistApi.moveTask).toHaveBeenCalledTimes(1)
+                expect(mockTodoistApi.moveTask).toHaveBeenCalledWith('8485093751', {
                     sectionId: 'target-section',
                 })
                 expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
@@ -786,10 +786,10 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 ]
 
                 // Each task should be moved individually
-                mockTodoistApi.moveTasks
-                    .mockResolvedValueOnce([mockResponses[0] as Task])
-                    .mockResolvedValueOnce([mockResponses[1] as Task])
-                    .mockResolvedValueOnce([mockResponses[2] as Task])
+                mockTodoistApi.moveTask
+                    .mockResolvedValueOnce(mockResponses[0] as Task)
+                    .mockResolvedValueOnce(mockResponses[1] as Task)
+                    .mockResolvedValueOnce(mockResponses[2] as Task)
 
                 const result = await updateTasks.execute(
                     {
@@ -803,14 +803,14 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 )
 
                 // Verify API was called correctly - 3 individual move calls
-                expect(mockTodoistApi.moveTasks).toHaveBeenCalledTimes(3)
-                expect(mockTodoistApi.moveTasks).toHaveBeenNthCalledWith(1, ['task-1'], {
+                expect(mockTodoistApi.moveTask).toHaveBeenCalledTimes(3)
+                expect(mockTodoistApi.moveTask).toHaveBeenNthCalledWith(1, 'task-1', {
                     projectId: 'project-new',
                 })
-                expect(mockTodoistApi.moveTasks).toHaveBeenNthCalledWith(2, ['task-2'], {
+                expect(mockTodoistApi.moveTask).toHaveBeenNthCalledWith(2, 'task-2', {
                     parentId: 'task-1',
                 })
-                expect(mockTodoistApi.moveTasks).toHaveBeenNthCalledWith(3, ['task-3'], {
+                expect(mockTodoistApi.moveTask).toHaveBeenNthCalledWith(3, 'task-3', {
                     sectionId: 'section-new',
                 })
                 expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
@@ -834,7 +834,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
                     addedAt: '2025-08-13T22:10:07.123456Z',
                 })
 
-                mockTodoistApi.moveTasks.mockResolvedValue([mockResponse])
+                mockTodoistApi.moveTask.mockResolvedValue(mockResponse)
 
                 const result = await updateTasks.execute(
                     {
@@ -849,7 +849,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
                     mockTodoistApi,
                 )
 
-                expect(mockTodoistApi.moveTasks).toHaveBeenCalledWith(['8485093752'], {
+                expect(mockTodoistApi.moveTask).toHaveBeenCalledWith('8485093752', {
                     projectId: 'new-project-only',
                 })
                 expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
@@ -874,7 +874,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 )
 
                 // No API calls should be made since no move parameters are provided
-                expect(mockTodoistApi.moveTasks).not.toHaveBeenCalled()
+                expect(mockTodoistApi.moveTask).not.toHaveBeenCalled()
                 expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
 
                 // Returns empty results since no moves were processed
@@ -908,7 +908,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
 
             it('should propagate API errors for individual task moves', async () => {
                 const apiError = new Error('API Error: Task not found')
-                mockTodoistApi.moveTasks.mockRejectedValue(apiError)
+                mockTodoistApi.moveTask.mockRejectedValue(apiError)
 
                 await expect(
                     updateTasks.execute(
@@ -920,7 +920,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
 
             it('should handle validation errors', async () => {
                 const validationError = new Error('API Error: Invalid section ID')
-                mockTodoistApi.moveTasks.mockRejectedValue(validationError)
+                mockTodoistApi.moveTask.mockRejectedValue(validationError)
 
                 await expect(
                     updateTasks.execute(
@@ -934,7 +934,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 const permissionError = new Error(
                     'API Error: Insufficient permissions to move task',
                 )
-                mockTodoistApi.moveTasks.mockRejectedValue(permissionError)
+                mockTodoistApi.moveTask.mockRejectedValue(permissionError)
 
                 await expect(
                     updateTasks.execute(
@@ -946,7 +946,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
 
             it('should handle circular parent dependency errors', async () => {
                 const circularError = new Error('API Error: Circular dependency detected')
-                mockTodoistApi.moveTasks.mockRejectedValue(circularError)
+                mockTodoistApi.moveTask.mockRejectedValue(circularError)
 
                 await expect(
                     updateTasks.execute(

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -137,19 +137,19 @@ const updateTasks = {
                 }
             }
 
-            // If no move parameters are provided, use updateTask without moveTasks
+            // If no move parameters are provided, use updateTask without moveTask
             if (!projectId && !sectionId && !parentId) {
                 return await client.updateTask(id, updateArgs)
             }
 
             const moveArgs = createMoveTaskArgs(id, projectId, sectionId, parentId)
-            const movedTasks = await client.moveTasks([id], moveArgs)
+            const movedTask = await client.moveTask(id, moveArgs)
 
             if (Object.keys(updateArgs).length > 0) {
                 return await client.updateTask(id, updateArgs)
             }
 
-            return movedTasks[0]
+            return movedTask
         })
         const updatedTasks = (await Promise.all(updateTasksPromises)).filter(
             (task): task is Task => task !== undefined,


### PR DESCRIPTION
# Pull Request

## Short description

Updates to the latest Todoist SDK and switches to using the newer `moveTask` function instead of `moveTasks`. 

`moveTask` uses the newer API endpoints, and since we aren't trying to update multiple tasks at once, makes no difference swapping the bulk one for the singular. 

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (README, etc.)
-   [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->