### PR TITLE
ci: Remove `NPM_TOKEN`/`NPM_PUBLISH_TOKEN` from release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,5 +44,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Overview

This PR updates the repository’s GitHub Actions workflow to use **npm’s Trusted Publishing** feature for package releases. Using Trusted Publishing eliminates the need to store long-lived npm tokens in GitHub secrets, reducing security risks and simplifying credential management. This also standardizes the publishing process across repositories.

> [!IMPORTANT]
> The npm organization and repository must be linked and authorized for Trusted Publishing before merging.

**What’s changing:**

* Replaces manual `NPM_TOKEN` authentication with GitHub’s **OpenID Connect (OIDC)**–based authentication.
* Updates the release workflow configuration to align with [npm’s Trusted Publishers documentation](https://docs.npmjs.com/trusted-publishers)
* Ensures that package publishing permissions are managed directly through GitHub and npm, improving security and maintainability.