### PR TITLE
chore: Ensure npm 11.5.1 or later is installed in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,9 @@ jobs:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Ensure npm 11.5.1 or later is installed
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
# Pull Request

This is a requirement for [Trusted Publishing](https://docs.npmjs.com/trusted-publishers), and should fix [this broken workflow](https://github.com/Doist/todoist-ai/actions/runs/18746682018/job/53475533224) that was caused from the changes in https://github.com/Doist/todoist-ai/pull/164.