### PR TITLE
fix: clarify find-completed-tasks scope

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -44,7 +44,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 - **complete-tasks**: Mark tasks as done using task IDs
 - **find-tasks**: Search by text, project/section/parent container, responsible user, or labels. Requires at least one search parameter
 - **find-tasks-by-date**: Get tasks by date range (startDate: YYYY-MM-DD or 'today' which includes overdue tasks) or specific day counts
-- **find-completed-tasks**: View completed tasks by completion date or original due date
+- **find-completed-tasks**: View completed tasks by completion date or original due date (returns all collaborators unless filtered)
 
 **Project & Organization:**
 - **add-projects/update-projects/find-projects**: Manage project lifecycle with names, favorites, and view styles (list/board/calendar)

--- a/src/tools/find-completed-tasks.ts
+++ b/src/tools/find-completed-tasks.ts
@@ -34,7 +34,9 @@ const ArgsSchema = {
     responsibleUser: z
         .string()
         .optional()
-        .describe('Find tasks assigned to this user. Can be a user ID, name, or email address.'),
+        .describe(
+            'Find tasks assigned to this user. Can be a user ID, name, or email address. Defaults to all collaborators when omitted.',
+        ),
 
     limit: z
         .number()
@@ -54,7 +56,8 @@ const ArgsSchema = {
 
 const findCompletedTasks = {
     name: ToolNames.FIND_COMPLETED_TASKS,
-    description: 'Get completed tasks.',
+    description:
+        'Get completed tasks (includes all collaborators by default—use responsibleUser to narrow).',
     parameters: ArgsSchema,
     async execute(args, client) {
         const { getBy, labels, labelsOperator, since, until, responsibleUser, ...rest } = args


### PR DESCRIPTION
## Context
A minor nit: explains that the tool returns tasks for all collaborators by default and how to narrow by responsibleUser.
