### PR TITLE
feat: Add find-activity tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import { completeTasks } from './tools/complete-tasks.js'
 // General tools
 import { deleteObject } from './tools/delete-object.js'
 import { fetch } from './tools/fetch.js'
+// Activity and audit tools
+import { findActivity } from './tools/find-activity.js'
 import { findComments } from './tools/find-comments.js'
 import { findCompletedTasks } from './tools/find-completed-tasks.js'
 // Assignment and collaboration tools
@@ -48,6 +50,8 @@ const tools = {
     addComments,
     updateComments,
     findComments,
+    // Activity and audit tools
+    findActivity,
     // General tools
     getOverview,
     deleteObject,
@@ -82,6 +86,8 @@ export {
     addComments,
     updateComments,
     findComments,
+    // Activity and audit tools
+    findActivity,
     // General tools
     getOverview,
     deleteObject,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -8,6 +8,7 @@ import { addTasks } from './tools/add-tasks.js'
 import { completeTasks } from './tools/complete-tasks.js'
 import { deleteObject } from './tools/delete-object.js'
 import { fetch } from './tools/fetch.js'
+import { findActivity } from './tools/find-activity.js'
 import { findComments } from './tools/find-comments.js'
 import { findCompletedTasks } from './tools/find-completed-tasks.js'
 import { findProjectCollaborators } from './tools/find-project-collaborators.js'
@@ -56,6 +57,9 @@ You have access to comprehensive Todoist management tools for personal productiv
 - **find-project-collaborators**: Find team members by name or email for assignments
 - **manage-assignments**: Bulk assign/unassign/reassign up to 50 tasks with atomic operations and dry-run validation
 
+**Activity & Audit:**
+- **find-activity**: Retrieve recent activity logs to monitor and audit changes. Shows events from all users by default; use initiatorId to filter by specific user. Filter by object type (task/project/comment), event type (added/updated/deleted/completed/uncompleted/archived/unarchived/shared/left), and specific objects (objectId, projectId, taskId). Useful for tracking who did what and when. Note: Date-based filtering is not supported.
+
 **General Operations:**
 - **delete-object**: Remove projects, sections, tasks, or comments by type and ID
 - **user-info**: Get user details including timezone, goals, and plan information
@@ -85,6 +89,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 - **Task Search**: find-tasks with multiple filters → update-tasks or complete-tasks based on results
 - **Project Organization**: add-projects → add-sections → add-tasks with projectId and sectionId
 - **Progress Reviews**: find-completed-tasks with date ranges → get-overview for project summaries
+- **Activity Auditing**: find-activity with event/object filters to track changes, monitor team activity, or investigate specific actions
 
 Always provide clear, actionable task titles and descriptions. Use the overview tools to give users context about their workload and project status.
 `
@@ -130,6 +135,9 @@ function getMcpServer({ todoistApiKey, baseUrl }: { todoistApiKey: string; baseU
     registerTool(addComments, server, todoist)
     registerTool(findComments, server, todoist)
     registerTool(updateComments, server, todoist)
+
+    // Activity and audit tools
+    registerTool(findActivity, server, todoist)
 
     // General tools
     registerTool(getOverview, server, todoist)

--- a/src/tool-helpers.ts
+++ b/src/tool-helpers.ts
@@ -1,4 +1,5 @@
 import type {
+    ActivityEvent,
     MoveTaskArgs,
     PersonalProject,
     Task,
@@ -109,6 +110,25 @@ function mapProject(project: Project) {
     }
 }
 
+/**
+ * Map a single Todoist activity event to a more structured format, for LLM consumption.
+ * @param event - The activity event to map.
+ * @returns The mapped activity event.
+ */
+function mapActivityEvent(event: ActivityEvent) {
+    return {
+        id: event.id,
+        objectType: event.objectType,
+        objectId: event.objectId,
+        eventType: event.eventType,
+        eventDate: event.eventDate,
+        parentProjectId: event.parentProjectId,
+        parentItemId: event.parentItemId,
+        initiatorId: event.initiatorId,
+        extraData: event.extraData,
+    }
+}
+
 const ErrorSchema = z.object({
     httpStatusCode: z.number(),
     responseData: z.object({
@@ -158,4 +178,4 @@ function buildTodoistUrl(type: 'task' | 'project', id: string): string {
     return `https://app.todoist.com/app/${type}/${id}`
 }
 
-export { buildTodoistUrl, getTasksByFilter, mapProject, mapTask }
+export { buildTodoistUrl, getTasksByFilter, mapActivityEvent, mapProject, mapTask }

--- a/src/tools/__tests__/__snapshots__/find-activity.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/find-activity.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`find-activity tool basic functionality should handle empty results 1`] = `
+"Activity events: 0 (limit 20).
+No results. No activity events match the specified filters; Note: Activity logs only show recent events."
+`;
+
+exports[`find-activity tool basic functionality should retrieve activity events with default parameters 1`] = `
+"Activity events: 2 (limit 20).
+Preview:
+    [Oct 23, 10:00] added task • id=task-456 • by=user-001 • project=project-789
+    [Oct 23, 11:00] completed task • id=task-456 • by=user-001 • project=project-789
+Next:
+- Use find-tasks to view current task details
+- Review completed tasks to track productivity"
+`;
+
+exports[`find-activity tool filtering should support multiple filters simultaneously 1`] = `
+"Activity: completed tasks: 1 (limit 50).
+Filter: project: project-work; initiator: user-bob.
+Preview:
+    [Oct 23, 10:30] completed task • id=task-456 • by=user-bob • project=project-work
+Next:
+- Use find-tasks to view current task details
+- Review completed tasks to track productivity
+- Use user-info to get details about the user"
+`;

--- a/src/tools/__tests__/find-activity.test.ts
+++ b/src/tools/__tests__/find-activity.test.ts
@@ -1,0 +1,305 @@
+import type { ActivityEvent, TodoistApi } from '@doist/todoist-api-typescript'
+import { jest } from '@jest/globals'
+import { extractTextContent } from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { findActivity } from '../find-activity.js'
+
+// Mock the Todoist API
+const mockTodoistApi = {
+    getActivityLogs: jest.fn(),
+} as unknown as jest.Mocked<TodoistApi>
+
+const { FIND_ACTIVITY } = ToolNames
+
+/**
+ * Helper to create a mock activity event
+ */
+function createMockActivityEvent(overrides: Partial<ActivityEvent> = {}): ActivityEvent {
+    return {
+        id: 'event-123',
+        objectType: 'task',
+        objectId: 'task-456',
+        eventType: 'added',
+        eventDate: '2024-10-23T10:30:00Z',
+        parentProjectId: 'project-789',
+        parentItemId: null,
+        initiatorId: 'user-001',
+        extraData: null,
+        ...overrides,
+    }
+}
+
+describe(`${FIND_ACTIVITY} tool`, () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('basic functionality', () => {
+        it('should retrieve activity events with default parameters', async () => {
+            const mockEvents: ActivityEvent[] = [
+                createMockActivityEvent({
+                    id: 'event-1',
+                    eventType: 'added',
+                    eventDate: '2024-10-23T10:00:00Z',
+                }),
+                createMockActivityEvent({
+                    id: 'event-2',
+                    eventType: 'completed',
+                    eventDate: '2024-10-23T11:00:00Z',
+                }),
+            ]
+
+            mockTodoistApi.getActivityLogs.mockResolvedValue({
+                results: mockEvents,
+                nextCursor: null,
+            })
+
+            const result = await findActivity.execute({ limit: 20 }, mockTodoistApi)
+
+            expect(mockTodoistApi.getActivityLogs).toHaveBeenCalledWith({
+                limit: 20,
+                cursor: null,
+            })
+
+            expect(extractTextContent(result)).toMatchSnapshot()
+        })
+
+        it('should handle empty results', async () => {
+            mockTodoistApi.getActivityLogs.mockResolvedValue({
+                results: [],
+                nextCursor: null,
+            })
+
+            const result = await findActivity.execute({ limit: 20 }, mockTodoistApi)
+
+            expect(extractTextContent(result)).toMatchSnapshot()
+        })
+
+        it('should handle pagination with cursor', async () => {
+            const mockEvents: ActivityEvent[] = Array.from({ length: 20 }, (_, i) =>
+                createMockActivityEvent({
+                    id: `event-${i}`,
+                    objectId: `task-${i}`,
+                }),
+            )
+
+            mockTodoistApi.getActivityLogs.mockResolvedValue({
+                results: mockEvents,
+                nextCursor: 'next-page-cursor',
+            })
+
+            const result = await findActivity.execute(
+                { limit: 20, cursor: 'current-cursor' },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.getActivityLogs).toHaveBeenCalledWith({
+                limit: 20,
+                cursor: 'current-cursor',
+            })
+
+            expect(extractTextContent(result)).toContain('Pass cursor')
+            expect(extractTextContent(result)).toContain('next-page-cursor')
+        })
+    })
+
+    describe('filtering', () => {
+        it.each([
+            ['task', 'added'],
+            ['project', 'updated'],
+            ['comment', 'deleted'],
+        ])('should filter by object type: %s', async (objectType, eventType) => {
+            const mockEvents: ActivityEvent[] = [
+                createMockActivityEvent({
+                    objectType: objectType as ActivityEvent['objectType'],
+                    eventType: eventType as ActivityEvent['eventType'],
+                }),
+            ]
+
+            mockTodoistApi.getActivityLogs.mockResolvedValue({
+                results: mockEvents,
+                nextCursor: null,
+            })
+
+            const result = await findActivity.execute(
+                { objectType: objectType as 'task' | 'project' | 'comment', limit: 20 },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.getActivityLogs).toHaveBeenCalledWith({
+                objectType,
+                limit: 20,
+                cursor: null,
+            })
+
+            expect(extractTextContent(result)).toContain(objectType)
+        })
+
+        it.each([
+            ['added', 'task-1'],
+            ['completed', 'task-2'],
+            ['updated', 'task-3'],
+            ['deleted', 'task-4'],
+        ])('should filter by event type: %s', async (eventType, objectId) => {
+            const mockEvents: ActivityEvent[] = [
+                createMockActivityEvent({
+                    eventType: eventType as ActivityEvent['eventType'],
+                    objectId,
+                }),
+            ]
+
+            mockTodoistApi.getActivityLogs.mockResolvedValue({
+                results: mockEvents,
+                nextCursor: null,
+            })
+
+            const result = await findActivity.execute(
+                {
+                    eventType: eventType as
+                        | 'added'
+                        | 'updated'
+                        | 'deleted'
+                        | 'completed'
+                        | 'uncompleted'
+                        | 'archived'
+                        | 'unarchived'
+                        | 'shared'
+                        | 'left',
+                    limit: 20,
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.getActivityLogs).toHaveBeenCalledWith({
+                eventType,
+                limit: 20,
+                cursor: null,
+            })
+
+            expect(extractTextContent(result)).toContain(eventType)
+        })
+
+        it.each([
+            ['objectId', 'task-123', { objectId: 'task-123' }],
+            ['projectId', 'project-abc', { parentProjectId: 'project-abc' }],
+            ['taskId', 'parent-task-789', { parentItemId: 'parent-task-789' }],
+            ['initiatorId', 'user-alice', { initiatorId: 'user-alice' }],
+        ])('should filter by %s', async (filterName, filterId, expectedApiCall) => {
+            const mockEvents: ActivityEvent[] = [createMockActivityEvent()]
+
+            mockTodoistApi.getActivityLogs.mockResolvedValue({
+                results: mockEvents,
+                nextCursor: null,
+            })
+
+            const args: Record<string, unknown> = { limit: 20 }
+            args[filterName] = filterId
+
+            await findActivity.execute(
+                args as Parameters<typeof findActivity.execute>[0],
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.getActivityLogs).toHaveBeenCalledWith({
+                ...expectedApiCall,
+                limit: 20,
+                cursor: null,
+            })
+        })
+
+        it('should support multiple filters simultaneously', async () => {
+            const mockEvents: ActivityEvent[] = [
+                createMockActivityEvent({
+                    objectType: 'task',
+                    eventType: 'completed',
+                    parentProjectId: 'project-work',
+                    initiatorId: 'user-bob',
+                }),
+            ]
+
+            mockTodoistApi.getActivityLogs.mockResolvedValue({
+                results: mockEvents,
+                nextCursor: null,
+            })
+
+            const result = await findActivity.execute(
+                {
+                    objectType: 'task',
+                    eventType: 'completed',
+                    projectId: 'project-work',
+                    initiatorId: 'user-bob',
+                    limit: 50,
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.getActivityLogs).toHaveBeenCalledWith({
+                objectType: 'task',
+                eventType: 'completed',
+                parentProjectId: 'project-work',
+                initiatorId: 'user-bob',
+                limit: 50,
+                cursor: null,
+            })
+
+            expect(extractTextContent(result)).toMatchSnapshot()
+        })
+    })
+
+    describe('content extraction', () => {
+        it('should extract task content from extraData', async () => {
+            const mockEvents: ActivityEvent[] = [
+                createMockActivityEvent({
+                    eventType: 'added',
+                    extraData: { content: 'Buy groceries' },
+                }),
+            ]
+
+            mockTodoistApi.getActivityLogs.mockResolvedValue({
+                results: mockEvents,
+                nextCursor: null,
+            })
+
+            const result = await findActivity.execute({ limit: 20 }, mockTodoistApi)
+
+            expect(extractTextContent(result)).toContain('Buy groceries')
+        })
+
+        it('should handle system-generated events with no initiator', async () => {
+            const mockEvents: ActivityEvent[] = [
+                createMockActivityEvent({
+                    initiatorId: null,
+                    eventType: 'completed',
+                }),
+            ]
+
+            mockTodoistApi.getActivityLogs.mockResolvedValue({
+                results: mockEvents,
+                nextCursor: null,
+            })
+
+            const result = await findActivity.execute({ limit: 20 }, mockTodoistApi)
+
+            expect(extractTextContent(result)).toContain('system')
+        })
+
+        it('should truncate long content', async () => {
+            const longContent = 'A'.repeat(100)
+            const mockEvents: ActivityEvent[] = [
+                createMockActivityEvent({
+                    extraData: { content: longContent },
+                }),
+            ]
+
+            mockTodoistApi.getActivityLogs.mockResolvedValue({
+                results: mockEvents,
+                nextCursor: null,
+            })
+
+            const result = await findActivity.execute({ limit: 20 }, mockTodoistApi)
+
+            expect(extractTextContent(result)).toContain('...')
+            expect(extractTextContent(result)).not.toContain(longContent)
+        })
+    })
+})

--- a/src/tools/find-activity.ts
+++ b/src/tools/find-activity.ts
@@ -1,0 +1,261 @@
+import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TodoistTool } from '../todoist-tool.js'
+import { mapActivityEvent } from '../tool-helpers.js'
+import { ApiLimits } from '../utils/constants.js'
+import { summarizeList } from '../utils/response-builders.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const { FIND_TASKS, USER_INFO } = ToolNames
+
+const ArgsSchema = {
+    objectType: z
+        .enum(['task', 'project', 'comment'])
+        .optional()
+        .describe('Type of object to filter by.'),
+
+    objectId: z
+        .string()
+        .optional()
+        .describe('Filter by specific object ID (task, project, or comment).'),
+
+    eventType: z
+        .enum([
+            'added',
+            'updated',
+            'deleted',
+            'completed',
+            'uncompleted',
+            'archived',
+            'unarchived',
+            'shared',
+            'left',
+        ])
+        .optional()
+        .describe('Type of event to filter by.'),
+
+    projectId: z.string().optional().describe('Filter events by parent project ID.'),
+
+    taskId: z.string().optional().describe('Filter events by parent task ID (for subtask events).'),
+
+    initiatorId: z.string().optional().describe('Filter by the user ID who initiated the event.'),
+
+    limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(ApiLimits.ACTIVITY_MAX)
+        .default(ApiLimits.ACTIVITY_DEFAULT)
+        .describe('Maximum number of activity events to return.'),
+
+    cursor: z
+        .string()
+        .optional()
+        .describe('Pagination cursor for retrieving the next page of results.'),
+}
+
+const findActivity = {
+    name: ToolNames.FIND_ACTIVITY,
+    description:
+        'Retrieve recent activity logs to monitor and audit changes in Todoist. Shows events from all users by default (use initiatorId to filter by specific user). Track task completions, updates, deletions, project changes, and more with flexible filtering. Note: Date-based filtering is not supported by the Todoist API.',
+    parameters: ArgsSchema,
+    async execute(args, client) {
+        const { objectType, objectId, eventType, projectId, taskId, initiatorId, limit, cursor } =
+            args
+
+        // Build API arguments
+        const apiArgs: Parameters<typeof client.getActivityLogs>[0] = {
+            limit,
+            cursor: cursor ?? null,
+        }
+
+        // Add optional filters
+        if (objectType) apiArgs.objectType = objectType
+        if (objectId) apiArgs.objectId = objectId
+        if (eventType) apiArgs.eventType = eventType
+        if (projectId) apiArgs.parentProjectId = projectId
+        if (taskId) apiArgs.parentItemId = taskId
+        if (initiatorId) apiArgs.initiatorId = initiatorId
+
+        // Fetch activity logs from API
+        const { results, nextCursor } = await client.getActivityLogs(apiArgs)
+        const events = results.map(mapActivityEvent)
+
+        // Generate text content
+        const textContent = generateTextContent({
+            events,
+            args,
+            nextCursor,
+        })
+
+        return getToolOutput({
+            textContent,
+            structuredContent: {
+                events,
+                nextCursor,
+                totalCount: events.length,
+                hasMore: Boolean(nextCursor),
+                appliedFilters: args,
+            },
+        })
+    },
+} satisfies TodoistTool<typeof ArgsSchema>
+
+function generateTextContent({
+    events,
+    args,
+    nextCursor,
+}: {
+    events: ReturnType<typeof mapActivityEvent>[]
+    args: z.infer<z.ZodObject<typeof ArgsSchema>>
+    nextCursor: string | null
+}) {
+    // Generate subject description
+    let subject = 'Activity events'
+
+    // Build subject based on filters
+    const subjectParts: string[] = []
+    if (args.eventType) {
+        subjectParts.push(`${args.eventType}`)
+    }
+    if (args.objectType) {
+        const objectLabel = args.objectType === 'task' ? 'tasks' : `${args.objectType}s`
+        subjectParts.push(objectLabel)
+    }
+
+    if (subjectParts.length > 0) {
+        subject = `Activity: ${subjectParts.join(' ')}`
+    }
+
+    // Generate filter hints
+    const filterHints: string[] = []
+
+    if (args.objectId) {
+        filterHints.push(`object ID: ${args.objectId}`)
+    }
+    if (args.projectId) {
+        filterHints.push(`project: ${args.projectId}`)
+    }
+    if (args.taskId) {
+        filterHints.push(`task: ${args.taskId}`)
+    }
+    if (args.initiatorId) {
+        filterHints.push(`initiator: ${args.initiatorId}`)
+    }
+
+    // Generate helpful suggestions for empty results
+    const zeroReasonHints: string[] = []
+    if (events.length === 0) {
+        zeroReasonHints.push('No activity events match the specified filters')
+        zeroReasonHints.push('Note: Activity logs only show recent events')
+
+        if (args.eventType) {
+            zeroReasonHints.push(`Try removing the eventType filter (${args.eventType})`)
+        }
+        if (args.objectType) {
+            zeroReasonHints.push(`Try removing the objectType filter (${args.objectType})`)
+        }
+        if (args.objectId || args.projectId || args.taskId) {
+            zeroReasonHints.push('Verify the object ID is correct')
+        }
+    }
+
+    // Generate contextual next steps
+    const nextSteps: string[] = []
+    if (events.length > 0) {
+        // Suggest related tools based on what was found
+        const hasTaskEvents = events.some((e) => e.objectType === 'task' || e.objectType === 'item')
+        const hasCompletions = events.some((e) => e.eventType === 'completed')
+
+        if (hasTaskEvents) {
+            nextSteps.push(`Use ${FIND_TASKS} to view current task details`)
+        }
+        if (hasCompletions) {
+            nextSteps.push('Review completed tasks to track productivity')
+        }
+        if (args.initiatorId) {
+            nextSteps.push(`Use ${USER_INFO} to get details about the user`)
+        }
+
+        // Suggest narrowing down if too many results
+        if (events.length >= args.limit && !nextCursor) {
+            nextSteps.push('Add more specific filters to narrow down results')
+        }
+    }
+
+    return summarizeList({
+        subject,
+        count: events.length,
+        limit: args.limit,
+        nextCursor: nextCursor ?? undefined,
+        filterHints,
+        previewLines: previewActivityEvents(events, Math.min(events.length, args.limit)),
+        zeroReasonHints,
+        nextSteps,
+    })
+}
+
+/**
+ * Formats activity events into readable preview lines
+ */
+function previewActivityEvents(events: ReturnType<typeof mapActivityEvent>[], limit = 10): string {
+    const previewEvents = events.slice(0, limit)
+    const lines = previewEvents.map(formatActivityEventPreview).join('\n')
+
+    // If we're showing fewer events than the total, add an indicator
+    if (events.length > limit) {
+        const remaining = events.length - limit
+        return `${lines}\n    ... and ${remaining} more event${remaining === 1 ? '' : 's'}`
+    }
+
+    return lines
+}
+
+/**
+ * Formats a single activity event into a readable preview line
+ */
+function formatActivityEventPreview(event: ReturnType<typeof mapActivityEvent>): string {
+    const date = formatEventDate(event.eventDate)
+    const eventLabel = `${event.eventType} ${event.objectType}`
+
+    // Extract useful content from extraData if available
+    let contentInfo = ''
+    if (event.extraData) {
+        const content =
+            event.extraData.content || event.extraData.name || event.extraData.last_content
+        if (content && typeof content === 'string') {
+            // Truncate long content
+            const truncated = content.length > 50 ? `${content.substring(0, 47)}...` : content
+            contentInfo = ` • "${truncated}"`
+        }
+    }
+
+    const objectId = event.objectId ? ` • id=${event.objectId}` : ''
+    const initiator = event.initiatorId ? ` • by=${event.initiatorId}` : ' • system'
+    const projectInfo = event.parentProjectId ? ` • project=${event.parentProjectId}` : ''
+
+    return `    [${date}] ${eventLabel}${contentInfo}${objectId}${initiator}${projectInfo}`
+}
+
+/**
+ * Formats an ISO date string to a more readable format
+ */
+function formatEventDate(isoDate: string): string {
+    try {
+        const date = new Date(isoDate)
+        // Format as: Oct 23, 14:30 (in UTC for deterministic snapshots)
+        const month = date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' })
+        const day = date.toLocaleDateString('en-US', { day: 'numeric', timeZone: 'UTC' })
+        const time = date.toLocaleTimeString('en-US', {
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false,
+            timeZone: 'UTC',
+        })
+        return `${month} ${day}, ${time}`
+    } catch {
+        return isoDate
+    }
+}
+
+export { findActivity }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -25,6 +25,10 @@ export const ApiLimits = {
     COMMENTS_DEFAULT: 10,
     /** Maximum limit for comment search and list operations */
     COMMENTS_MAX: 10,
+    /** Default limit for activity log listings */
+    ACTIVITY_DEFAULT: 20,
+    /** Maximum limit for activity log search and list operations */
+    ACTIVITY_MAX: 100,
 } as const
 
 // UI Display Limits

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -33,6 +33,9 @@ export const ToolNames = {
     FIND_PROJECT_COLLABORATORS: 'find-project-collaborators',
     MANAGE_ASSIGNMENTS: 'manage-assignments',
 
+    // Activity and audit tools
+    FIND_ACTIVITY: 'find-activity',
+
     // General tools
     GET_OVERVIEW: 'get-overview',
     DELETE_OBJECT: 'delete-object',


### PR DESCRIPTION
## Short description
Adds `find-activity` tool to retrieve activity logs from Todoist, enabling users to track who did what and when.

## Features
- Filter by object type (task/project/comment)
- Filter by event type (added/updated/deleted/completed/etc.)
- Filter by specific objects (objectId, projectId, taskId)
- Filter by initiator (user who performed the action)
- Cursor-based pagination for large result sets
- Extracts and displays actual content from events
- Shows all users' activity by default

## Limitations
- Date-based filtering not supported (API limitation)
- Shows recent events only (API doesn't specify exact time window)

## Testing
```bash
npm test -- src/tools/__tests__/find-activity.test.ts
```
All tests passing ✅