### PR TITLE
chore: Update todoist-typescript-sdk to 5.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "4.14.0",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-api-typescript": "5.7.0",
+                "@doist/todoist-api-typescript": "5.7.1",
                 "@modelcontextprotocol/sdk": "^1.11.1",
                 "date-fns": "^4.1.0",
                 "dotenv": "^17.0.0",
@@ -81,7 +81,6 @@
             "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -791,9 +790,9 @@
             }
         },
         "node_modules/@doist/todoist-api-typescript": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-5.7.0.tgz",
-            "integrity": "sha512-d/pz7BBJguXxTuesR+CziwhmW9GjY8FtpbbgJtzCCbDxbioCgTqphE1Dc3PiqKMdxt+faInx2IXYUmFf8R+TiA==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-5.7.1.tgz",
+            "integrity": "sha512-tFPMpePW81MZprgtPs099mLS6b4qg8r2b/7bITe3L3CYujslOnRfBPGlIfRZLz/j/VksAYGIi7y8EOMG7sleyg==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.0.0",
@@ -2188,7 +2187,6 @@
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
             "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.4",
@@ -2448,7 +2446,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001733",
                 "electron-to-chromium": "^1.5.199",
@@ -3373,7 +3370,6 @@
             "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
             "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.0",
@@ -4289,7 +4285,6 @@
             "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "30.2.0",
                 "@jest/types": "30.2.0",
@@ -6910,7 +6905,6 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
             "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "license": "(MIT OR CC0-1.0)",
-            "peer": true,
             "engines": {
                 "node": ">=16"
             },
@@ -6959,7 +6953,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7415,7 +7408,6 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-api-typescript": "5.7.0",
+        "@doist/todoist-api-typescript": "5.7.1",
         "@modelcontextprotocol/sdk": "^1.11.1",
         "date-fns": "^4.1.0",
         "dotenv": "^17.0.0",


### PR DESCRIPTION
## Context

Updates todoist-typescript-sdk to 5.7.1, which includes a critical fix for `find-activity`:

```json
{
  "message": "Step getCompletedTasks failed: Tool 'find_activity' failed due to an invalid type in the response from the Todoist API. The 'id' field was expected to be a string but received a number. This is an issue with the tool's internal handling of the API response.",
  "source": "TypeScriptSDK",
  "stackTrace": ...
  }
}
```