### PR TITLE
fix: Trigger publish workflow automatically from release-please

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 name: Release @doist/todoist-ai package
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -12,8 +10,6 @@ permissions:
 
 jobs:
   publish:
-    # Only run if a release was published or workflow was manually triggered
-    if: ${{ github.event.action == 'published' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     # Based on historical data
     timeout-minutes: 60

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,11 +22,8 @@ jobs:
                   config-file: .github/release-please-config.json
                   manifest-file: .github/release-please-manifest.json
 
-            - name: Publish draft release
+            - name: Trigger publish workflow
               if: ${{ steps.release.outputs.release_created }}
-              run: |
-                  RELEASE_TAG="${{ steps.release.outputs.tag_name }}"
-                  echo "Publishing release $RELEASE_TAG"
-                  gh release edit "$RELEASE_TAG" --draft=false
+              run: gh workflow run publish.yml
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Changes

- Remove problematic `gh release edit --draft=false` step that was causing intermittent workflow failures
- Trigger publish workflow automatically using `gh workflow run publish.yml` when a release is created
- Simplify publish workflow to only use `workflow_dispatch` trigger

## Problem

1. The `gh release edit` step was intermittently failing when release PRs were merged
2. The publish workflow never triggered automatically because event-based triggers (`release: published`) don't work with `GITHUB_TOKEN` (GitHub security design)

## Solution

Use `gh workflow run` to trigger the publish workflow when a release is created. Unlike event-based triggers, `workflow_dispatch` triggers ARE allowed with `GITHUB_TOKEN`. This keeps workflows separate and maintainable without code duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (README, etc.)
-   [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->