### PR TITLE
docs: fix Vercel AI SDK example to show required client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,28 @@ Here's an example using [Vercel's AI SDK](https://ai-sdk.dev/docs/ai-sdk-core/ge
 
 ```js
 import { findTasksByDate, addTasks } from "@doist/todoist-ai";
+import { TodoistApi } from "@doist/todoist-api-typescript";
 import { streamText } from "ai";
+
+// Create Todoist API client
+const client = new TodoistApi(process.env.TODOIST_API_KEY);
+
+// Helper to wrap tools with the client
+function wrapTool(tool, todoistClient) {
+    return {
+        ...tool,
+        execute(args) {
+            return tool.execute(args, todoistClient);
+        },
+    };
+}
 
 const result = streamText({
     model: yourModel,
     system: "You are a helpful Todoist assistant",
     tools: {
-        findTasksByDate,
-        addTasks,
+        findTasksByDate: wrapTool(findTasksByDate, client),
+        addTasks: wrapTool(addTasks, client),
     },
 });
 ```


### PR DESCRIPTION
## Summary

- Fixes the Vercel AI SDK example in the README to include proper TodoistApi client initialization
- Adds a `wrapTool` helper function that injects the client as the second argument to tool execute methods
- Shows complete working example that prevents `client.getUser is not a function` errors

## Context

The previous example was incomplete and caused errors when users tried to follow it. Tools require a TodoistApi client to be passed as the second argument to their execute function, but this wasn't shown in the documentation.

## Changes

- Import `TodoistApi` from `@doist/todoist-api-typescript`
- Create client instance with API key
- Add `wrapTool` helper to inject client into tools
- Update example to use wrapped tools

## Test plan

- [x] Created and ran test script to verify the wrapping pattern works correctly
- [x] Verified the pattern matches how the MCP server internally wraps tools

Fixes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)