### PR TITLE
feat: Add parentId support to update-projects tool

### DIFF
--- a/src/tools/__tests__/__snapshots__/update-projects.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/update-projects.test.ts.snap
@@ -16,6 +16,14 @@ Next:
 - Use find-tasks with projectId=project-123 to review existing tasks"
 `;
 
+exports[`update-projects tool updating a single project should update project with parentId to move it to a sub-project 1`] = `
+"Updated 1 project:
+• Child Project (id=project-child)
+Next:
+- Use get-overview with projectId=project-child to see project structure
+- Use find-tasks with projectId=project-child to review existing tasks"
+`;
+
 exports[`update-projects tool updating multiple projects should skip projects with no updates and report correctly 1`] = `
 "Updated 1 project (1 skipped - no changes):
 • Updated Project (id=project-1)

--- a/src/tools/__tests__/update-projects.test.ts
+++ b/src/tools/__tests__/update-projects.test.ts
@@ -131,6 +131,32 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
             expect(textContent).toContain('Updated 1 project:')
             expect(textContent).toContain('Updated Favorite Project (id=project-123)')
         })
+
+        it('should update project with parentId to move it to a sub-project', async () => {
+            const mockApiResponse = createMockProject({
+                id: 'project-child',
+                name: 'Child Project',
+                parentId: 'project-parent',
+            })
+
+            mockTodoistApi.updateProject.mockResolvedValue(mockApiResponse)
+
+            const result = await updateProjects.execute(
+                {
+                    projects: [{ id: 'project-child', parentId: 'project-parent' }],
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.updateProject).toHaveBeenCalledWith('project-child', {
+                parentId: 'project-parent',
+            })
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Updated 1 project:')
+            expect(textContent).toContain('Child Project (id=project-child)')
+        })
     })
 
     describe('updating multiple projects', () => {

--- a/src/tools/update-projects.ts
+++ b/src/tools/update-projects.ts
@@ -10,6 +10,12 @@ const { FIND_PROJECTS, FIND_TASKS, GET_OVERVIEW } = ToolNames
 const ProjectUpdateSchema = z.object({
     id: z.string().min(1).describe('The ID of the project to update.'),
     name: z.string().min(1).optional().describe('The new name of the project.'),
+    parentId: z
+        .string()
+        .optional()
+        .describe(
+            'The ID of the parent project. If provided, moves this project to be a sub-project.',
+        ),
     isFavorite: z.boolean().optional().describe('Whether the project is a favorite.'),
     viewStyle: z.enum(['list', 'board', 'calendar']).optional().describe('The project view style.'),
 })


### PR DESCRIPTION
## Summary

This PR adds `parentId` support to the `update-projects` tool, enabling users to move projects and change their parent relationship. This brings feature parity with the `add-projects` tool, which already supports `parentId` for creating sub-projects.

Previously, users could only set a project's parent when creating it via `add-projects`. With this change, they can now reorganize their project hierarchy by updating existing projects.

## Changes

- Added `parentId` field to `ProjectUpdateSchema` in `src/tools/update-projects.ts`
- Added test case validating `parentId` updates in `src/tools/__tests__/update-projects.test.ts`
- Updated snapshot for new test case

## Test Plan

- [x] All existing tests pass (330 tests)
- [x] New test case validates `parentId` parameter is correctly passed to the API
- [x] TypeScript compilation successful
- [x] Pre-commit hooks (biome, type-check) pass
- [x] Pre-push tests pass

## Related Issue

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)