### PR TITLE
chore: Revert "feat: Add parentId support to update-projects tool (#1…

### DIFF
--- a/src/tools/__tests__/__snapshots__/update-projects.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/update-projects.test.ts.snap
@@ -16,14 +16,6 @@ Next:
 - Use find-tasks with projectId=project-123 to review existing tasks"
 `;
 
-exports[`update-projects tool updating a single project should update project with parentId to move it to a sub-project 1`] = `
-"Updated 1 project:
-• Child Project (id=project-child)
-Next:
-- Use get-overview with projectId=project-child to see project structure
-- Use find-tasks with projectId=project-child to review existing tasks"
-`;
-
 exports[`update-projects tool updating multiple projects should skip projects with no updates and report correctly 1`] = `
 "Updated 1 project (1 skipped - no changes):
 • Updated Project (id=project-1)

--- a/src/tools/__tests__/update-projects.test.ts
+++ b/src/tools/__tests__/update-projects.test.ts
@@ -131,32 +131,6 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
             expect(textContent).toContain('Updated 1 project:')
             expect(textContent).toContain('Updated Favorite Project (id=project-123)')
         })
-
-        it('should update project with parentId to move it to a sub-project', async () => {
-            const mockApiResponse = createMockProject({
-                id: 'project-child',
-                name: 'Child Project',
-                parentId: 'project-parent',
-            })
-
-            mockTodoistApi.updateProject.mockResolvedValue(mockApiResponse)
-
-            const result = await updateProjects.execute(
-                {
-                    projects: [{ id: 'project-child', parentId: 'project-parent' }],
-                },
-                mockTodoistApi,
-            )
-
-            expect(mockTodoistApi.updateProject).toHaveBeenCalledWith('project-child', {
-                parentId: 'project-parent',
-            })
-
-            const textContent = extractTextContent(result)
-            expect(textContent).toMatchSnapshot()
-            expect(textContent).toContain('Updated 1 project:')
-            expect(textContent).toContain('Child Project (id=project-child)')
-        })
     })
 
     describe('updating multiple projects', () => {

--- a/src/tools/update-projects.ts
+++ b/src/tools/update-projects.ts
@@ -10,12 +10,6 @@ const { FIND_PROJECTS, FIND_TASKS, GET_OVERVIEW } = ToolNames
 const ProjectUpdateSchema = z.object({
     id: z.string().min(1).describe('The ID of the project to update.'),
     name: z.string().min(1).optional().describe('The new name of the project.'),
-    parentId: z
-        .string()
-        .optional()
-        .describe(
-            'The ID of the parent project. If provided, moves this project to be a sub-project.',
-        ),
     isFavorite: z.boolean().optional().describe('Whether the project is a favorite.'),
     viewStyle: z.enum(['list', 'board', 'calendar']).optional().describe('The project view style.'),
 })


### PR DESCRIPTION


# Pull Request

## Short description

This PR reverts #184 because there are limitations with the Todoist API that prevent moving a project in this way. 

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (README, etc.)
-   [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->