### PR TITLE
fix: Allow `inbox` as a project id

### DIFF
--- a/src/tools/find-tasks.ts
+++ b/src/tools/find-tasks.ts
@@ -24,7 +24,12 @@ const { FIND_COMPLETED_TASKS, ADD_TASKS } = ToolNames
 
 const ArgsSchema = {
     searchText: z.string().optional().describe('The text to search for in tasks.'),
-    projectId: z.string().optional().describe('Find tasks in this project.'),
+    projectId: z
+        .string()
+        .optional()
+        .describe(
+            'Find tasks in this project. Project ID should be an ID string, or the text "inbox", for inbox tasks.',
+        ),
     sectionId: z.string().optional().describe('Find tasks in this section.'),
     parentId: z.string().optional().describe('Find subtasks of this parent task.'),
     responsibleUser: z
@@ -101,7 +106,10 @@ const findTasks = {
                 cursor: cursor ?? null,
             }
 
-            if (projectId) taskParams.projectId = projectId
+            if (projectId) {
+                taskParams.projectId =
+                    projectId === 'inbox' ? todoistUser.inboxProjectId : projectId
+            }
             if (sectionId) taskParams.sectionId = sectionId
             if (parentId) taskParams.parentId = parentId
 


### PR DESCRIPTION
# Pull Request

## Short description

If you were to say to an agent "What tasks do I have in my inbox?", it will try calling `find-tasks` with the projectId as `inbox`. This will fail and it will have to make a request to get-overview to get the inbox project id. What a faff. 

I have included `inbox` as a project id, and if set, we swap in the user's actual inbox id. 

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (README, etc.)
-   [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->