### PR TITLE
feat: add read-only and destructive hints to all tools

### DIFF
--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -1,7 +1,7 @@
 import type { TodoistApi } from '@doist/todoist-api-typescript'
 import type { McpServer, ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { ZodTypeAny, z } from 'zod'
-import type { TodoistTool } from './todoist-tool.js'
+import type { TodoistTool, ToolMutability } from './todoist-tool.js'
 import { removeNullFields } from './utils/sanitize-data.js'
 
 /**
@@ -67,6 +67,23 @@ function getErrorOutput(error: string) {
 }
 
 /**
+ * Convert tool mutability level to MCP annotation hints.
+ *
+ * @param mutability - The mutability level of the tool.
+ * @returns MCP annotations with readOnlyHint and destructiveHint set appropriately.
+ */
+function getMcpAnnotations(mutability: ToolMutability) {
+    switch (mutability) {
+        case 'readonly':
+            return { readOnlyHint: true, destructiveHint: false }
+        case 'additive':
+            return { readOnlyHint: false, destructiveHint: false }
+        case 'mutating':
+            return { readOnlyHint: false, destructiveHint: true }
+    }
+}
+
+/**
  * Register a Todoist tool in an MCP server.
  * @param tool - The tool to register.
  * @param server - The server to register the tool on.
@@ -102,7 +119,7 @@ function registerTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape
             description: tool.description,
             inputSchema: tool.parameters,
             outputSchema: tool.outputSchema as Output,
-            annotations: tool.annotations,
+            annotations: getMcpAnnotations(tool.mutability),
         },
         cb,
     )

--- a/src/todoist-tool.ts
+++ b/src/todoist-tool.ts
@@ -7,6 +7,15 @@ type ExecuteResult<Output extends z.ZodRawShape> = Promise<{
 }>
 
 /**
+ * Categorization of tool behavior for MCP annotation hints.
+ *
+ * - **readonly**: Tool only reads data, doesn't modify state (e.g., find-*, get-*, search)
+ * - **additive**: Tool creates new resources but doesn't modify existing ones (e.g., add-*)
+ * - **mutating**: Tool modifies or destroys existing data (e.g., update-*, delete-*, complete-*)
+ */
+type ToolMutability = 'readonly' | 'additive' | 'mutating'
+
+/**
  * A Todoist tool that can be used in an MCP server or other conversational AI interfaces.
  */
 type TodoistTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape> = {
@@ -37,16 +46,11 @@ type TodoistTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape> = {
     outputSchema: Output
 
     /**
-     * Optional annotations for the tool.
+     * The mutability level of this tool.
      *
-     * These annotations provide metadata about the tool's behavior, such as whether it's read-only.
+     * This is used to generate appropriate MCP annotation hints (readOnlyHint, destructiveHint).
      */
-    annotations?: {
-        /**
-         * Indicates whether this tool only reads data and doesn't modify the environment.
-         */
-        readOnlyHint?: boolean
-    }
+    mutability: ToolMutability
 
     /**
      * The function that executes the tool.
@@ -60,4 +64,4 @@ type TodoistTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape> = {
     execute: (args: z.infer<z.ZodObject<Params>>, client: TodoistApi) => ExecuteResult<Output>
 }
 
-export type { TodoistTool }
+export type { TodoistTool, ToolMutability }

--- a/src/tools/add-comments.ts
+++ b/src/tools/add-comments.ts
@@ -32,6 +32,7 @@ const addComments = {
         'Add multiple comments to tasks or projects. Each comment must specify either taskId or projectId.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
+    mutability: 'additive' as const,
     async execute(args, client) {
         const { comments } = args
 

--- a/src/tools/add-projects.ts
+++ b/src/tools/add-projects.ts
@@ -34,6 +34,7 @@ const addProjects = {
     description: 'Add one or more new projects.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
+    mutability: 'additive' as const,
     async execute({ projects }, client) {
         const newProjects = await Promise.all(projects.map((project) => client.addProject(project)))
         const textContent = generateTextContent({ projects: newProjects })

--- a/src/tools/add-sections.ts
+++ b/src/tools/add-sections.ts
@@ -28,6 +28,7 @@ const addSections = {
     description: 'Add one or more new sections to projects.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
+    mutability: 'additive' as const,
     async execute({ sections }, client) {
         // Check if any section needs inbox resolution
         const needsInboxResolution = sections.some((section) => section.projectId === 'inbox')

--- a/src/tools/add-tasks.ts
+++ b/src/tools/add-tasks.ts
@@ -70,6 +70,7 @@ const addTasks = {
         'Add one or more tasks to a project, section, or parent. Supports assignment to project collaborators.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
+    mutability: 'additive' as const,
     async execute({ tasks }, client) {
         const addTaskPromises = tasks.map((task) => processTask(task, client))
         const newTasks = await Promise.all(addTaskPromises)

--- a/src/tools/complete-tasks.ts
+++ b/src/tools/complete-tasks.ts
@@ -21,6 +21,7 @@ const completeTasks = {
     description: 'Complete one or more tasks by their IDs.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
+    mutability: 'mutating' as const,
     async execute(args, client) {
         const completed: string[] = []
         const failures: Array<{ item: string; error: string; code?: string }> = []

--- a/src/tools/delete-object.ts
+++ b/src/tools/delete-object.ts
@@ -26,6 +26,7 @@ const deleteObject = {
     description: 'Delete a project, section, task, or comment by its ID.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
+    mutability: 'mutating' as const,
     async execute(args, client) {
         switch (args.type) {
             case 'project':

--- a/src/tools/fetch.ts
+++ b/src/tools/fetch.ts
@@ -41,9 +41,7 @@ const fetch = {
         'Fetch the full contents of a task or project by its ID. The ID should be in the format "task:{id}" or "project:{id}".',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    annotations: {
-        readOnlyHint: true,
-    },
+    mutability: 'readonly' as const,
     async execute(args, client) {
         const { id } = args
 

--- a/src/tools/find-activity.ts
+++ b/src/tools/find-activity.ts
@@ -66,9 +66,7 @@ const findActivity = {
         'Retrieve recent activity logs to monitor and audit changes in Todoist. Shows events from all users by default (use initiatorId to filter by specific user). Track task completions, updates, deletions, project changes, and more with flexible filtering. Note: Date-based filtering is not supported by the Todoist API.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    annotations: {
-        readOnlyHint: true,
-    },
+    mutability: 'readonly' as const,
     async execute(args, client) {
         const { objectType, objectId, eventType, projectId, taskId, initiatorId, limit, cursor } =
             args

--- a/src/tools/find-comments.ts
+++ b/src/tools/find-comments.ts
@@ -38,9 +38,7 @@ const findComments = {
         'Find comments by task, project, or get a specific comment by ID. Exactly one of taskId, projectId, or commentId must be provided.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    annotations: {
-        readOnlyHint: true,
-    },
+    mutability: 'readonly' as const,
     async execute(args, client) {
         // Validate that exactly one search parameter is provided
         const searchParams = [args.taskId, args.projectId, args.commentId].filter(Boolean)

--- a/src/tools/find-completed-tasks.ts
+++ b/src/tools/find-completed-tasks.ts
@@ -73,9 +73,7 @@ const findCompletedTasks = {
         'Get completed tasks (includes all collaborators by default—use responsibleUser to narrow).',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    annotations: {
-        readOnlyHint: true,
-    },
+    mutability: 'readonly' as const,
     async execute(args, client) {
         const { getBy, labels, labelsOperator, since, until, responsibleUser, projectId, ...rest } =
             args

--- a/src/tools/find-project-collaborators.ts
+++ b/src/tools/find-project-collaborators.ts
@@ -41,9 +41,7 @@ const findProjectCollaborators = {
     description: 'Search for collaborators by name or other criteria in a project.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    annotations: {
-        readOnlyHint: true,
-    },
+    mutability: 'readonly' as const,
     async execute(args, client) {
         const { projectId, searchTerm } = args
 

--- a/src/tools/find-projects.ts
+++ b/src/tools/find-projects.ts
@@ -44,9 +44,7 @@ const findProjects = {
         'List all projects or search for projects by name. If search parameter is omitted, all projects are returned.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    annotations: {
-        readOnlyHint: true,
-    },
+    mutability: 'readonly' as const,
     async execute(args, client) {
         const { results, nextCursor } = await client.getProjects({
             limit: args.limit,

--- a/src/tools/find-sections.ts
+++ b/src/tools/find-sections.ts
@@ -38,9 +38,7 @@ const findSections = {
     description: 'Search for sections by name or other criteria in a project.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    annotations: {
-        readOnlyHint: true,
-    },
+    mutability: 'readonly' as const,
     async execute(args, client) {
         // Resolve "inbox" to actual inbox project ID if needed
         const resolvedProjectId =

--- a/src/tools/find-tasks-by-date.ts
+++ b/src/tools/find-tasks-by-date.ts
@@ -75,9 +75,7 @@ const findTasksByDate = {
         "Get tasks by date range. Use startDate 'today' to get today's tasks including overdue items, or provide a specific date/date range.",
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    annotations: {
-        readOnlyHint: true,
-    },
+    mutability: 'readonly' as const,
     async execute(args, client) {
         if (!args.startDate && args.overdueOption !== 'overdue-only') {
             throw new Error(

--- a/src/tools/find-tasks.ts
+++ b/src/tools/find-tasks.ts
@@ -66,9 +66,7 @@ const findTasks = {
         'Find tasks by text search, or by project/section/parent container/responsible user. At least one filter must be provided.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    annotations: {
-        readOnlyHint: true,
-    },
+    mutability: 'readonly' as const,
     async execute(args, client) {
         const {
             searchText,

--- a/src/tools/get-overview.ts
+++ b/src/tools/get-overview.ts
@@ -365,9 +365,7 @@ const getOverview = {
         'Get a Markdown overview. If no projectId is provided, shows all projects with hierarchy and sections (useful for navigation). If projectId is provided, shows detailed overview of that specific project including all tasks grouped by sections.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    annotations: {
-        readOnlyHint: true,
-    },
+    mutability: 'readonly' as const,
     async execute(args, client) {
         const result = args.projectId
             ? await generateProjectOverview(client, args.projectId)

--- a/src/tools/manage-assignments.ts
+++ b/src/tools/manage-assignments.ts
@@ -85,6 +85,7 @@ const manageAssignments = {
         'Bulk assignment operations for multiple tasks. Supports assign, unassign, and reassign operations with atomic rollback on failures.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
+    mutability: 'mutating' as const,
     async execute(args, client) {
         const { operation, taskIds, responsibleUser, fromAssigneeUser, dryRun } = args
 

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -40,9 +40,7 @@ const search = {
         'Search across tasks and projects in Todoist. Returns a list of relevant results with IDs, titles, and URLs.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    annotations: {
-        readOnlyHint: true,
-    },
+    mutability: 'readonly' as const,
     async execute(args, client) {
         const { query } = args
 

--- a/src/tools/update-comments.ts
+++ b/src/tools/update-comments.ts
@@ -29,6 +29,7 @@ const updateComments = {
     description: 'Update multiple existing comments with new content.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
+    mutability: 'mutating' as const,
     async execute(args, client) {
         const { comments } = args
 

--- a/src/tools/update-projects.ts
+++ b/src/tools/update-projects.ts
@@ -34,6 +34,7 @@ const updateProjects = {
     description: 'Update multiple existing projects with new values.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
+    mutability: 'mutating' as const,
     async execute(args, client) {
         const { projects } = args
         const updateProjectsPromises = projects.map(async (project) => {

--- a/src/tools/update-sections.ts
+++ b/src/tools/update-sections.ts
@@ -24,6 +24,7 @@ const updateSections = {
     description: 'Update multiple existing sections with new values.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
+    mutability: 'mutating' as const,
     async execute({ sections }, client) {
         const updatedSections = await Promise.all(
             sections.map((section) => client.updateSection(section.id, { name: section.name })),

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -86,6 +86,7 @@ const updateTasks = {
     description: 'Update existing tasks including content, dates, priorities, and assignments.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
+    mutability: 'mutating' as const,
     async execute(args, client) {
         const { tasks } = args
         const updateTasksPromises = tasks.map(async (task) => {

--- a/src/tools/user-info.ts
+++ b/src/tools/user-info.ts
@@ -195,9 +195,7 @@ const userInfo = {
         'Get comprehensive user information including user ID, full name, email, timezone with current local time, week start day preferences, current week dates, daily/weekly goal progress, and user plan (Free/Pro/Business).',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    annotations: {
-        readOnlyHint: true,
-    },
+    mutability: 'readonly' as const,
     async execute(_args, client) {
         const result = await generateUserInfo(client)
 


### PR DESCRIPTION
# Pull Request

This is based on a feature request that a user send to the CX team.

## Short description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

This adds a mutability field to the tool metadata, which is then translated into `readOnlyHint` and `destructiveHint` in the MCP server. These annotations allow clients to offer a better UX.

Spec: https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [x] Added tests for bugs / new features
-   [ ] Updated docs (README, etc.)
-   [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->