### PR TITLE
feat: Add isUncompletable parameter support to add/update tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "5.1.1",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-api-typescript": "6.1.12",
+                "@doist/todoist-api-typescript": "6.2.0",
                 "@modelcontextprotocol/sdk": "1.22.0",
                 "date-fns": "4.1.0",
                 "dotenv": "17.2.3",
@@ -250,9 +250,9 @@
             }
         },
         "node_modules/@doist/todoist-api-typescript": {
-            "version": "6.1.12",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-6.1.12.tgz",
-            "integrity": "sha512-GkrvP4ts4M/68WwBhZLGblTHzxcR1AbVU3zdPjYqCGmSqJ0xN1Wa9F8AsRklImy7x18UARNF0/meiivcJ0Ya+w==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-6.2.0.tgz",
+            "integrity": "sha512-rxQTq+ZysYTRnoruN5PWR6TqQ/gwzZ7FxeuIO9fFBYERf/tkdCxor3A/F01CmC4UuEEH3GiU9VWaiU6iu913hg==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-api-typescript": "6.1.12",
+        "@doist/todoist-api-typescript": "6.2.0",
         "@modelcontextprotocol/sdk": "1.22.0",
         "date-fns": "4.1.0",
         "dotenv": "17.2.3",

--- a/src/tools/__tests__/add-tasks.test.ts
+++ b/src/tools/__tests__/add-tasks.test.ts
@@ -786,4 +786,38 @@ describe(`${ADD_TASKS} tool`, () => {
             })
         })
     })
+
+    describe('isUncompletable parameter', () => {
+        it('should pass isUncompletable parameter to SDK', async () => {
+            // Mock API response - minimal mock just to prevent errors
+            const mockApiResponse: Task = createMockTask({
+                id: '8485093999',
+                content: 'Project Header',
+            })
+
+            mockTodoistApi.addTask.mockResolvedValueOnce(mockApiResponse)
+
+            await addTasks.execute(
+                {
+                    tasks: [
+                        {
+                            content: 'Project Header',
+                            isUncompletable: true,
+                        },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            // Verify the parameter was passed to the SDK - this is the key test
+            expect(mockTodoistApi.addTask).toHaveBeenCalledWith({
+                content: 'Project Header',
+                projectId: undefined,
+                sectionId: undefined,
+                parentId: undefined,
+                labels: undefined,
+                isUncompletable: true,
+            })
+        })
+    })
 })

--- a/src/tools/__tests__/update-tasks.test.ts
+++ b/src/tools/__tests__/update-tasks.test.ts
@@ -1031,4 +1031,33 @@ describe(`${UPDATE_TASKS} tool`, () => {
             })
         })
     })
+
+    describe('isUncompletable parameter', () => {
+        it('should pass isUncompletable parameter to SDK', async () => {
+            // Mock API response - minimal mock just to prevent errors
+            const mockUpdatedTask: Task = createMockTask({
+                id: 'task123',
+                content: 'Updated Header',
+            })
+
+            mockTodoistApi.updateTask.mockResolvedValueOnce(mockUpdatedTask)
+
+            await updateTasks.execute(
+                {
+                    tasks: [
+                        {
+                            id: 'task123',
+                            isUncompletable: true,
+                        },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            // Verify the parameter was passed to the SDK - this is the key test
+            expect(mockTodoistApi.updateTask).toHaveBeenCalledWith('task123', {
+                isUncompletable: true,
+            })
+        })
+    })
 })

--- a/src/tools/add-tasks.ts
+++ b/src/tools/add-tasks.ts
@@ -53,6 +53,12 @@ const TaskSchema = z.object({
         .describe(
             'Assign task to this user. Can be a user ID, name, or email address. User must be a collaborator on the target project.',
         ),
+    isUncompletable: z
+        .boolean()
+        .optional()
+        .describe(
+            'Whether this task should be uncompletable (organizational header). Tasks with isUncompletable: true appear as organizational headers and cannot be completed.',
+        ),
 })
 
 const ArgsSchema = {

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -61,6 +61,12 @@ const TasksUpdateSchema = z.object({
         .array(z.string())
         .optional()
         .describe('The new labels for the task. Replaces all existing labels.'),
+    isUncompletable: z
+        .boolean()
+        .optional()
+        .describe(
+            'Whether this task should be uncompletable (organizational header). Tasks with isUncompletable: true appear as organizational headers and cannot be completed.',
+        ),
 })
 
 type TaskUpdate = z.infer<typeof TasksUpdateSchema>

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -28,6 +28,10 @@ const TaskSchema = z.object({
         .string()
         .optional()
         .describe('The UID of the user responsible for this task.'),
+    isUncompletable: z
+        .boolean()
+        .optional()
+        .describe('Whether the task is uncompletable (organizational header).'),
     assignedByUid: z.string().optional().describe('The UID of the user who assigned this task.'),
     checked: z.boolean().describe('Whether the task is checked/completed.'),
     completedAt: z.string().optional().describe('When the task was completed (ISO 8601 format).'),

--- a/src/utils/test-helpers.ts
+++ b/src/utils/test-helpers.ts
@@ -41,6 +41,7 @@ export function createMockTask({
         dayOrder: 0,
         userId: '713437',
         priority: convertPriorityToNumber(priority),
+        isUncompletable: false,
         ...overrides,
     }
 }


### PR DESCRIPTION
## Summary
Adds support for the `isUncompletable` parameter to both add-tasks and update-tasks tools, enabling creation of organizational header tasks that cannot be completed.

## What Changed
- **New Parameter**: Added optional `isUncompletable?: boolean` to add-tasks and update-tasks tool schemas
- **Output Schema**: Updated TaskSchema in output-schemas.ts to include isUncompletable field
- **SDK Upgrade**: Updated @doist/todoist-api-typescript to 6.2.0 for isUncompletable support  
- **Integration Tests**: Added minimal tests to verify parameter passing to SDK
- **Test Helpers**: Updated createMockTask to include isUncompletable field

## Behavior
- When `isUncompletable: true` → SDK automatically adds `* ` prefix to content
- Tasks appear as organizational headers in Todoist and cannot be completed
- Fully backward compatible - optional parameter with sensible defaults
- Follows existing codebase patterns for optional parameters

## Usage Examples
```typescript
// Add uncompletable task
await addTasks.execute({
    tasks: [{
        content: 'Project planning session',
        isUncompletable: true
    }]
})
// Result: content becomes "* Project planning session"

// Update existing task to be uncompletable  
await updateTasks.execute({
    tasks: [{
        id: 'task123',
        isUncompletable: true
    }]
})
```

## Testing
- ✅ All 346 existing tests pass (no regressions)
- ✅ 2 new integration tests verify parameter passing to SDK
- ✅ Minimal test approach - relies on SDK's comprehensive test suite (43 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)