### PR TITLE
refactor: use shared mapProject helper in add/update-projects

### DIFF
--- a/src/tools/__tests__/add-projects.test.ts
+++ b/src/tools/__tests__/add-projects.test.ts
@@ -1,5 +1,6 @@
 import type { PersonalProject, TodoistApi, WorkspaceProject } from '@doist/todoist-api-typescript'
 import { type Mocked, vi } from 'vitest'
+import { ProjectSchema } from '../../utils/output-schemas.js'
 import { createMockProject, TEST_IDS } from '../../utils/test-helpers.js'
 import { ToolNames } from '../../utils/tool-names.js'
 import { addProjects } from '../add-projects.js'
@@ -198,6 +199,122 @@ describe(`${ADD_PROJECTS} tool`, () => {
                     totalCount: 3,
                 }),
             )
+        })
+    })
+
+    describe('output schema validation', () => {
+        it('should return structured content that strictly matches ProjectSchema (no extra API properties)', async () => {
+            // Mock API response includes ALL properties from Todoist API
+            // This simulates the real API response which has many extra fields
+            const mockApiResponse = createMockProject({
+                id: TEST_IDS.PROJECT_TEST,
+                name: 'Schema Test Project',
+                color: 'blue',
+                isFavorite: true,
+                isShared: false,
+                parentId: 'parent-123',
+                inboxProject: false,
+                viewStyle: 'board',
+                // Extra properties that should NOT appear in structured output:
+                childOrder: 5,
+                createdAt: '2024-01-01T00:00:00Z',
+                updatedAt: '2024-06-15T12:00:00Z',
+                defaultOrder: 10,
+                description: 'This should not appear in output',
+                isArchived: false,
+                isCollapsed: true,
+                isDeleted: false,
+                isFrozen: false,
+                canAssignTasks: true,
+                url: 'https://todoist.com/projects/test',
+            })
+
+            mockTodoistApi.addProject.mockResolvedValue(mockApiResponse)
+
+            const result = await addProjects.execute(
+                { projects: [{ name: 'Schema Test Project' }] },
+                mockTodoistApi,
+            )
+
+            const structuredContent = result.structuredContent
+            expect(structuredContent.projects).toHaveLength(1)
+
+            const project = structuredContent.projects.at(0)
+            expect(project).toBeDefined()
+            if (!project) return // Type narrowing
+
+            // Verify ONLY the schema-allowed properties are present
+            const allowedKeys = [
+                'id',
+                'name',
+                'color',
+                'isFavorite',
+                'isShared',
+                'parentId',
+                'inboxProject',
+                'viewStyle',
+            ]
+            const actualKeys = Object.keys(project)
+            expect(actualKeys.sort()).toEqual(allowedKeys.sort())
+
+            // Verify NO extra API properties leaked through
+            const disallowedKeys = [
+                'childOrder',
+                'createdAt',
+                'updatedAt',
+                'defaultOrder',
+                'description',
+                'isArchived',
+                'isCollapsed',
+                'isDeleted',
+                'isFrozen',
+                'canAssignTasks',
+                'url',
+            ]
+            for (const key of disallowedKeys) {
+                expect(project).not.toHaveProperty(key)
+            }
+
+            // Validate against the actual Zod schema (strict mode rejects extra properties)
+            const parseResult = ProjectSchema.strict().safeParse(project)
+            expect(parseResult.success).toBe(true)
+        })
+
+        it('should produce output that passes strict schema validation for multiple projects', async () => {
+            type Project = PersonalProject | WorkspaceProject
+            const mockProjects: [Project, Project] = [
+                createMockProject({
+                    id: 'project-1',
+                    name: 'First',
+                    childOrder: 1,
+                    url: 'https://todoist.com/1',
+                }),
+                createMockProject({
+                    id: 'project-2',
+                    name: 'Second',
+                    childOrder: 2,
+                    url: 'https://todoist.com/2',
+                }),
+            ]
+
+            const [project1, project2] = mockProjects
+            mockTodoistApi.addProject
+                .mockResolvedValueOnce(project1)
+                .mockResolvedValueOnce(project2)
+
+            const result = await addProjects.execute(
+                { projects: [{ name: 'First' }, { name: 'Second' }] },
+                mockTodoistApi,
+            )
+
+            // Validate each project in structured content against strict schema
+            for (const project of result.structuredContent.projects) {
+                const parseResult = ProjectSchema.strict().safeParse(project)
+                expect(parseResult.success).toBe(true)
+                if (!parseResult.success) {
+                    console.error('Schema validation failed:', parseResult.error.format())
+                }
+            }
         })
     })
 

--- a/src/tools/__tests__/find-tasks-by-date.test.ts
+++ b/src/tools/__tests__/find-tasks-by-date.test.ts
@@ -15,7 +15,7 @@ import { findTasksByDate } from '../find-tasks-by-date.js'
 vi.mock('../../tool-helpers', async () => {
     const actual = (await vi.importActual(
         '../../tool-helpers',
-    )) as typeof import('../../tool-helpers')
+    )) as typeof import('../../tool-helpers.js')
     return {
         ...actual,
         getTasksByFilter: vi.fn(),

--- a/src/tools/__tests__/find-tasks.test.ts
+++ b/src/tools/__tests__/find-tasks.test.ts
@@ -17,7 +17,7 @@ import { findTasks } from '../find-tasks.js'
 vi.mock('../../tool-helpers', async () => {
     const actual = (await vi.importActual(
         '../../tool-helpers',
-    )) as typeof import('../../tool-helpers')
+    )) as typeof import('../../tool-helpers.js')
     return {
         getTasksByFilter: vi.fn(),
         mapTask: actual.mapTask,

--- a/src/tools/__tests__/search.test.ts
+++ b/src/tools/__tests__/search.test.ts
@@ -13,7 +13,7 @@ import { search } from '../search.js'
 vi.mock('../../tool-helpers', async () => {
     const actual = (await vi.importActual(
         '../../tool-helpers',
-    )) as typeof import('../../tool-helpers')
+    )) as typeof import('../../tool-helpers.js')
     return {
         ...actual,
         getTasksByFilter: vi.fn(),

--- a/src/tools/__tests__/update-projects.test.ts
+++ b/src/tools/__tests__/update-projects.test.ts
@@ -1,5 +1,6 @@
 import type { PersonalProject, TodoistApi, WorkspaceProject } from '@doist/todoist-api-typescript'
 import { type Mocked, vi } from 'vitest'
+import { ProjectSchema } from '../../utils/output-schemas.js'
 import { createMockProject } from '../../utils/test-helpers.js'
 import { ToolNames } from '../../utils/tool-names.js'
 import { updateProjects } from '../update-projects.js'
@@ -234,6 +235,126 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
                     },
                 }),
             )
+        })
+    })
+
+    describe('output schema validation', () => {
+        it('should return structured content that strictly matches ProjectSchema (no extra API properties)', async () => {
+            // Mock API response includes ALL properties from Todoist API
+            const mockApiResponse: PersonalProject = {
+                id: 'project-schema-test',
+                name: 'Schema Test Project',
+                color: 'blue',
+                isFavorite: true,
+                isShared: false,
+                parentId: 'parent-123',
+                inboxProject: false,
+                viewStyle: 'board',
+                // Extra properties that should NOT appear in structured output:
+                childOrder: 5,
+                createdAt: '2024-01-01T00:00:00Z',
+                updatedAt: '2024-06-15T12:00:00Z',
+                defaultOrder: 10,
+                description: 'This should not appear in output',
+                isArchived: false,
+                isCollapsed: true,
+                isDeleted: false,
+                isFrozen: false,
+                canAssignTasks: true,
+                url: 'https://todoist.com/projects/test',
+            }
+
+            mockTodoistApi.updateProject.mockResolvedValue(mockApiResponse)
+
+            const result = await updateProjects.execute(
+                { projects: [{ id: 'project-schema-test', name: 'Schema Test Project' }] },
+                mockTodoistApi,
+            )
+
+            const structuredContent = result.structuredContent
+            expect(structuredContent.projects).toHaveLength(1)
+
+            const project = structuredContent.projects.at(0)
+            expect(project).toBeDefined()
+            if (!project) return // Type narrowing
+
+            // Verify ONLY the schema-allowed properties are present
+            const allowedKeys = [
+                'id',
+                'name',
+                'color',
+                'isFavorite',
+                'isShared',
+                'parentId',
+                'inboxProject',
+                'viewStyle',
+            ]
+            const actualKeys = Object.keys(project)
+            expect(actualKeys.sort()).toEqual(allowedKeys.sort())
+
+            // Verify NO extra API properties leaked through
+            const disallowedKeys = [
+                'childOrder',
+                'createdAt',
+                'updatedAt',
+                'defaultOrder',
+                'description',
+                'isArchived',
+                'isCollapsed',
+                'isDeleted',
+                'isFrozen',
+                'canAssignTasks',
+                'url',
+            ]
+            for (const key of disallowedKeys) {
+                expect(project).not.toHaveProperty(key)
+            }
+
+            // Validate against the actual Zod schema (strict mode rejects extra properties)
+            const parseResult = ProjectSchema.strict().safeParse(project)
+            expect(parseResult.success).toBe(true)
+        })
+
+        it('should produce output that passes strict schema validation for multiple projects', async () => {
+            type Project = PersonalProject | WorkspaceProject
+            const mockProjects: [Project, Project] = [
+                createMockProject({
+                    id: 'project-1',
+                    name: 'First',
+                    childOrder: 1,
+                    url: 'https://todoist.com/1',
+                }),
+                createMockProject({
+                    id: 'project-2',
+                    name: 'Second',
+                    childOrder: 2,
+                    url: 'https://todoist.com/2',
+                }),
+            ]
+
+            const [project1, project2] = mockProjects
+            mockTodoistApi.updateProject
+                .mockResolvedValueOnce(project1)
+                .mockResolvedValueOnce(project2)
+
+            const result = await updateProjects.execute(
+                {
+                    projects: [
+                        { id: 'project-1', name: 'First' },
+                        { id: 'project-2', name: 'Second' },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            // Validate each project in structured content against strict schema
+            for (const project of result.structuredContent.projects) {
+                const parseResult = ProjectSchema.strict().safeParse(project)
+                expect(parseResult.success).toBe(true)
+                if (!parseResult.success) {
+                    console.error('Schema validation failed:', parseResult.error.format())
+                }
+            }
         })
     })
 

--- a/src/tools/add-projects.ts
+++ b/src/tools/add-projects.ts
@@ -1,6 +1,7 @@
 import type { PersonalProject, WorkspaceProject } from '@doist/todoist-api-typescript'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
+import { mapProject } from '../tool-helpers.js'
 import { ProjectSchema as ProjectOutputSchema } from '../utils/output-schemas.js'
 import { ToolNames } from '../utils/tool-names.js'
 
@@ -38,11 +39,7 @@ const addProjects = {
     async execute({ projects }, client) {
         const newProjects = await Promise.all(projects.map((project) => client.addProject(project)))
         const textContent = generateTextContent({ projects: newProjects })
-        const mappedProjects = newProjects.map((project) => ({
-            ...project,
-            parentId: 'parentId' in project ? (project.parentId ?? undefined) : undefined,
-            inboxProject: 'inboxProject' in project ? project.inboxProject : false,
-        }))
+        const mappedProjects = newProjects.map(mapProject)
 
         return {
             textContent,

--- a/src/tools/update-projects.ts
+++ b/src/tools/update-projects.ts
@@ -1,6 +1,7 @@
 import type { PersonalProject, WorkspaceProject } from '@doist/todoist-api-typescript'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
+import { mapProject } from '../tool-helpers.js'
 import { ProjectSchema as ProjectOutputSchema } from '../utils/output-schemas.js'
 import { ToolNames } from '../utils/tool-names.js'
 
@@ -50,11 +51,7 @@ const updateProjects = {
             .filter(
                 (project): project is PersonalProject | WorkspaceProject => project !== undefined,
             )
-            .map((project) => ({
-                ...project,
-                parentId: 'parentId' in project ? (project.parentId ?? undefined) : undefined,
-                inboxProject: 'inboxProject' in project ? project.inboxProject : false,
-            }))
+            .map(mapProject)
 
         const textContent = generateTextContent({
             projects: updatedProjects,


### PR DESCRIPTION
## Short description

This PR refactors `add-projects` and `update-projects` tools to use the centralized `mapProject` helper function from `tool-helpers.js`, ensuring consistent project mapping across the codebase.

### Changes

- **Refactored project mapping**: Replaced inline mapping logic in `add-projects.ts` and `update-projects.ts` with the shared `mapProject` helper
- **Added schema validation tests**: Comprehensive tests ensuring structured output strictly matches `ProjectSchema` with no extra API properties leaking through
- **Fixed import paths**: Added missing `.js` extensions to module imports in test files

### Why

The inline mapping logic was duplicated and could drift out of sync. Using the centralized `mapProject` helper:
- Ensures consistency across all project-related tools
- Makes it easier to update the mapping logic in one place
- Prevents extra API properties from leaking into structured output

## PR Checklist

- [x] Added tests for bugs / new features
- [ ] Updated docs (README, etc.) - N/A, no API changes
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts` - N/A, refactoring only