### PR TITLE
chore: Stop renovate grouping dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,16 +17,6 @@
             "groupSlug": "all"
         },
         {
-            "matchDepTypes": ["devDependencies"],
-            "groupName": "dev dependencies",
-            "groupSlug": "dev"
-        },
-        {
-            "matchDepTypes": ["dependencies"],
-            "groupName": "production dependencies",
-            "groupSlug": "prod"
-        },
-        {
             "matchPackageNames": ["zod"],
             "allowedVersions": "<4.0.0",
             "description": "Pin zod to v3 until the @modelcontextprotocol/sdk supports zod v4"


### PR DESCRIPTION
# Pull Request

## Short description

Renovate is currently grouping dev and production dependencies together in PRs, this is making it impossible to see what dpeendencies have been updated at a glance. 

For example:
<img width="743" height="449" alt="image" src="https://github.com/user-attachments/assets/bf3ebfac-01e2-4daa-821e-5635aadc8d5b" />


## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (README, etc.)
-   [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->