### PR TITLE
fix: add missing fields to find-comments output schema

### DIFF
--- a/src/tools/find-comments.ts
+++ b/src/tools/find-comments.ts
@@ -28,6 +28,13 @@ const ArgsSchema = {
 
 const OutputSchema = {
     comments: z.array(CommentOutputSchema).describe('The found comments.'),
+    searchType: z
+        .string()
+        .describe(
+            'The type of search performed: "single" (comment ID), "task" (task ID), or "project" (project ID).',
+        ),
+    searchId: z.string().describe('The ID that was searched for (comment, task, or project ID).'),
+    hasMore: z.boolean().describe('Whether there are more results available.'),
     nextCursor: z.string().optional().describe('Cursor for the next page of results.'),
     totalCount: z.number().describe('The total number of comments in this page.'),
 }


### PR DESCRIPTION
## Summary
- Fixes validation error in `find-comments` tool caused by schema mismatch
- Added three missing fields to OutputSchema: `searchType`, `searchId`, and `hasMore`
- These fields were already being returned by the tool but not declared in the schema

Fixes https://github.com/Doist/Issues/issues/19089

## Test plan
- [x] All existing tests pass (350 tests)
- [x] Build completes successfully
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)