### PR TITLE
fix: add structured content to fetch tool output

### DIFF
--- a/src/tools/fetch.ts
+++ b/src/tools/fetch.ts
@@ -124,7 +124,10 @@ const fetch = {
             }
         }
 
-        return { textContent: JSON.stringify(result) }
+        return {
+            textContent: JSON.stringify(result),
+            structuredContent: result,
+        }
     },
 } satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
 


### PR DESCRIPTION
## Summary

Fixes MCP validation error in the fetch tool by adding `structuredContent` to the return value. The tool was only returning `textContent`, which caused validation errors when an `outputSchema` was defined.

## Changes

- Matches the pattern used by the search tool (also OpenAI MCP-specific)
- The `structuredContent` field now properly matches the defined `OutputSchema`

## Error Fixed

```
MCP error -32602: Output validation error: Tool fetch has an output schema but no structured content was provided
```

## Test Plan

- [x] All 362 tests pass (including 18 fetch tool tests)
- [x] TypeScript type checking passes
- [x] Build completes successfully
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)