### PR TITLE
feat!: Make MCP SDK a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "@doist/todoist-api-typescript": "6.2.1",
-                "@modelcontextprotocol/sdk": "1.25.1",
                 "date-fns": "4.1.0",
                 "dompurify": "3.3.1",
                 "dotenv": "17.2.3",
@@ -42,6 +41,9 @@
                 "vite": "7.3.0",
                 "vite-plugin-dts": "4.5.4",
                 "vitest": "3.2.4"
+            },
+            "peerDependencies": {
+                "@modelcontextprotocol/sdk": "^1.25.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
@@ -734,6 +736,7 @@
             "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.7.tgz",
             "integrity": "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.14.1"
             },
@@ -910,6 +913,7 @@
             "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
             "integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@hono/node-server": "^1.19.7",
                 "ajv": "^8.17.1",
@@ -2494,6 +2498,7 @@
             "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
             "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "object-assign": "^4",
                 "vary": "^1"
@@ -2507,6 +2512,7 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -2815,6 +2821,7 @@
             "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
             "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "eventsource-parser": "^3.0.1"
             },
@@ -2827,6 +2834,7 @@
             "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
             "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.0.0"
             }
@@ -2889,6 +2897,7 @@
             "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
             "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 16"
             },
@@ -3436,7 +3445,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/jju": {
             "version": "1.4.0",
@@ -3450,6 +3460,7 @@
             "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
             "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/panva"
             }
@@ -3471,7 +3482,8 @@
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
             "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-            "license": "BSD-2-Clause"
+            "license": "BSD-2-Clause",
+            "peer": true
         },
         "node_modules/jsonfile": {
             "version": "6.2.0",
@@ -3913,6 +3925,7 @@
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4004,6 +4017,7 @@
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4097,6 +4111,7 @@
             "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
             "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=16.20.0"
             }
@@ -4515,6 +4530,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -4527,6 +4543,7 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5380,6 +5397,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -5593,6 +5611,7 @@
             "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
             "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
             "license": "ISC",
+            "peer": true,
             "peerDependencies": {
                 "zod": "^3.25 || ^4"
             }

--- a/package.json
+++ b/package.json
@@ -8,25 +8,14 @@
     "bin": {
         "todoist-ai": "dist/main.js"
     },
-    "files": [
-        "dist",
-        "!dist/dev",
-        "scripts",
-        "package.json",
-        "LICENSE.txt",
-        "README.md"
-    ],
+    "files": ["dist", "!dist/dev", "scripts", "package.json", "LICENSE.txt", "README.md"],
     "license": "MIT",
     "description": "A collection of tools for Todoist using AI",
     "repository": {
         "type": "git",
         "url": "https://github.com/Doist/todoist-ai"
     },
-    "keywords": [
-        "todoist",
-        "ai",
-        "tools"
-    ],
+    "keywords": ["todoist", "ai", "tools"],
     "scripts": {
         "test": "vitest run",
         "test:watch": "vitest",
@@ -51,11 +40,13 @@
     },
     "dependencies": {
         "@doist/todoist-api-typescript": "6.2.1",
-        "@modelcontextprotocol/sdk": "1.25.1",
         "date-fns": "4.1.0",
         "dompurify": "3.3.1",
         "dotenv": "17.2.3",
         "zod": "4.1.13"
+    },
+    "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.0"
     },
     "devDependencies": {
         "@biomejs/biome": "2.3.10",
@@ -82,17 +73,9 @@
         "vitest": "3.2.4"
     },
     "lint-staged": {
-        "*": [
-            "biome check --write --no-errors-on-unmatched --files-ignore-unknown=true"
-        ],
-        "src/tools/*.ts": [
-            "npm run lint:schemas"
-        ],
-        "src/index.ts": [
-            "npm run lint:schemas"
-        ],
-        "scripts/validate-schemas.ts": [
-            "npm run lint:schemas"
-        ]
+        "*": ["biome check --write --no-errors-on-unmatched --files-ignore-unknown=true"],
+        "src/tools/*.ts": ["npm run lint:schemas"],
+        "src/index.ts": ["npm run lint:schemas"],
+        "scripts/validate-schemas.ts": ["npm run lint:schemas"]
     }
 }


### PR DESCRIPTION
# Pull Request

Similar to https://github.com/Doist/twist-ai/pull/70, this makes the MCP SDK a peer dependency. 

- Move @modelcontextprotocol/sdk from dependencies to peerDependencies
- Update version range to ^1.25.0 

## Breaking Change
This is a **breaking change** that requires consumers to explicitly install the MCP SDK:

```bash
npm install @modelcontextprotocol/sdk@^1.25.0
```

## Benefits
- Forces consumers to explicitly choose MCP SDK version
- Ensures compatibility between consumer code and SDK version
- Follows peer dependency best practices for libraries

## Short description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (README, etc.)
-   [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->