### PR TITLE
fix(add-tasks): create tasks sequentially to preserve input order

### DIFF
--- a/src/tools/add-tasks.ts
+++ b/src/tools/add-tasks.ts
@@ -82,8 +82,10 @@ const addTasks = {
     outputSchema: OutputSchema,
     mutability: 'additive' as const,
     async execute({ tasks }, client) {
-        const addTaskPromises = tasks.map((task) => processTask(task, client))
-        const newTasks = await Promise.all(addTaskPromises)
+        const newTasks: Task[] = []
+        for (const task of tasks) {
+            newTasks.push(await processTask(task, client))
+        }
         const mappedTasks = newTasks.map(mapTask)
 
         const textContent = generateTextContent({


### PR DESCRIPTION
## Summary
Changes task creation from parallel (`Promise.all`) to sequential execution to ensure tasks are created in the order they're specified in the input array.

## Problem
Previously, tasks were created in parallel which meant the actual creation order was non-deterministic - it depended on which API calls completed first. This caused issues with the `order` parameter where tasks with conflicting orders would be inserted in unpredictable positions.

## Solution
Create tasks sequentially using a `for` loop instead of `Promise.all`. This guarantees:
- Tasks are created in input array order
- The `order` parameter behaves predictably
- Without `order` param, tasks naturally follow input position

## Trade-off
Slightly higher latency for bulk task creation, but negligible for typical use cases (few tasks).

## Test plan
- [x] All 363 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)