### PR TITLE
feat: add find-tasks-by-filter tool with order field support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { findProjects } from './tools/find-projects.js'
 import { findSections } from './tools/find-sections.js'
 import { findTasks } from './tools/find-tasks.js'
 import { findTasksByDate } from './tools/find-tasks-by-date.js'
+import { findTasksByFilter } from './tools/find-tasks-by-filter.js'
 import { getOverview } from './tools/get-overview.js'
 import { manageAssignments } from './tools/manage-assignments.js'
 import { search } from './tools/search.js'
@@ -37,6 +38,7 @@ const tools = {
     updateTasks,
     findTasks,
     findTasksByDate,
+    findTasksByFilter,
     findCompletedTasks,
     // Project management tools
     addProjects,
@@ -73,6 +75,7 @@ export {
     updateTasks,
     findTasks,
     findTasksByDate,
+    findTasksByFilter,
     findCompletedTasks,
     // Project management tools
     addProjects,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -19,6 +19,7 @@ import { findSections } from './tools/find-sections.js'
 import { findTasks } from './tools/find-tasks.js'
 import { findTasksByDate } from './tools/find-tasks-by-date.js'
 import { createFindTasksByDateResource } from './tools/find-tasks-by-date.resource.js'
+import { findTasksByFilter } from './tools/find-tasks-by-filter.js'
 import { getOverview } from './tools/get-overview.js'
 import { manageAssignments } from './tools/manage-assignments.js'
 import { search } from './tools/search.js'
@@ -53,6 +54,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 - **complete-tasks**: Mark tasks as done using task IDs
 - **find-tasks**: Search by text, project/section/parent container, responsible user, or labels. Requires at least one search parameter
 - **find-tasks-by-date**: Get tasks by date range (startDate: YYYY-MM-DD or 'today' which includes overdue tasks) or specific day counts
+- **find-tasks-by-filter**: Execute raw Todoist filter queries for advanced searches. Supports "##Project" (project hierarchy including sub-projects), "(today | overdue) & p1" (complex filters), and client-side sorting by priority, due_date, project, or created
 - **find-completed-tasks**: View completed tasks by completion date or original due date (returns all collaborators unless filtered)
 
 **Project & Organization:**
@@ -148,6 +150,7 @@ function getMcpServer({ todoistApiKey, baseUrl }: { todoistApiKey: string; baseU
     registerTool(updateTasks, server, todoist)
     registerTool(findTasks, server, todoist)
     registerTool(enhancedFindTasksByDateTool, server, todoist)
+    registerTool(findTasksByFilter, server, todoist)
     registerTool(findCompletedTasks, server, todoist)
 
     // Project management tools

--- a/src/tool-helpers.test.ts
+++ b/src/tool-helpers.test.ts
@@ -58,6 +58,7 @@ describe('shared utilities', () => {
                 completedAt: undefined,
                 deadlineDate: undefined,
                 responsibleUid: undefined,
+                order: 1,
             })
         })
 

--- a/src/tool-helpers.ts
+++ b/src/tool-helpers.ts
@@ -179,6 +179,7 @@ function mapTask(task: Task) {
         assignedByUid: task.assignedByUid ?? undefined,
         checked: task.checked,
         completedAt: task.completedAt ?? undefined,
+        order: task.childOrder,
     }
 }
 

--- a/src/tools/__tests__/__snapshots__/find-tasks-by-filter.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/find-tasks-by-filter.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`find-tasks-by-filter tool > basic filter queries > should execute a basic project hierarchy filter (##Work) 1`] = `
+"Tasks matching filter "##Work": 2 (limit 10).
+Filter: query: ##Work.
+Preview:
+    Task in Work project • P4 • id=8485093748
+    Task in sub-project • P4 • id=8485093749"
+`;
+
+exports[`find-tasks-by-filter tool > basic filter queries > should execute a complex filter with logical operators 1`] = `
+"Tasks matching filter "(today | overdue) & p1": 1 (limit 50).
+Filter: query: (today | overdue) & p1.
+Preview:
+    High priority overdue task • due 2025-08-10 • P1 • id=8485093748"
+`;
+
+exports[`find-tasks-by-filter tool > basic filter queries > should execute a single project filter (#Inbox) 1`] = `
+"Tasks matching filter "#Inbox": 1 (limit 10).
+Filter: query: #Inbox.
+Preview:
+    Inbox task • P4 • id=8485093748"
+`;
+
+exports[`find-tasks-by-filter tool > combining filter with labels > should combine filter with multiple labels using AND operator 1`] = `
+"Tasks matching filter "##Work": 1 (limit 10).
+Filter: query: ##Work & (@important  &  @urgent); labels: @important & @urgent.
+Preview:
+    Important urgent task • P4 • id=8485093748"
+`;
+
+exports[`find-tasks-by-filter tool > combining filter with labels > should combine filter with single label 1`] = `
+"Tasks matching filter "##Work": 1 (limit 10).
+Filter: query: ##Work & (@urgent); labels: @urgent.
+Preview:
+    Urgent work task • P4 • id=8485093748"
+`;
+
+exports[`find-tasks-by-filter tool > combining filter with responsible user > should combine filter with specific user 1`] = `
+"Tasks matching filter "##Work" assigned to john@example.com: 1 (limit 10).
+Filter: query: ##Work & assigned to: john@example.com; assigned to: john@example.com.
+Preview:
+    Task assigned to John • P4 • id=8485093748"
+`;
+
+exports[`find-tasks-by-filter tool > empty results handling > should handle empty results gracefully 1`] = `
+"Tasks matching filter "##NonExistent": 0 (limit 10).
+Filter: query: ##NonExistent.
+No results. Verify filter syntax is correct; Try a simpler filter to confirm project/label names; Ensure the parent project exists and has sub-projects."
+`;
+
+exports[`find-tasks-by-filter tool > pagination > should handle pagination with cursor 1`] = `
+"Tasks matching filter "##Work": 1 (limit 10), more available.
+Filter: query: ##Work.
+Preview:
+    Page 2 task • P4 • id=8485093748
+Possible suggested next step:
+- Pass cursor 'next-page-cursor' to fetch more results."
+`;

--- a/src/tools/__tests__/find-tasks-by-filter.test.ts
+++ b/src/tools/__tests__/find-tasks-by-filter.test.ts
@@ -1,0 +1,583 @@
+import type { TodoistApi } from '@doist/todoist-api-typescript'
+import { type Mocked, type MockedFunction, vi } from 'vitest'
+import { getTasksByFilter, MappedTask } from '../../tool-helpers.js'
+import {
+    createMappedTask,
+    createMockUser,
+    TEST_ERRORS,
+    TEST_IDS,
+} from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { resolveUserNameToId } from '../../utils/user-resolver.js'
+import { findTasksByFilter } from '../find-tasks-by-filter.js'
+
+// Mock only getTasksByFilter, use actual implementations for everything else
+vi.mock('../../tool-helpers', async () => {
+    const actual = (await vi.importActual(
+        '../../tool-helpers',
+    )) as typeof import('../../tool-helpers.js')
+    return {
+        ...actual,
+        getTasksByFilter: vi.fn(),
+    }
+})
+
+// Mock user resolver
+vi.mock('../../utils/user-resolver', () => ({
+    resolveUserNameToId: vi.fn(),
+}))
+
+const mockGetTasksByFilter = getTasksByFilter as MockedFunction<typeof getTasksByFilter>
+const mockResolveUserNameToId = resolveUserNameToId as MockedFunction<typeof resolveUserNameToId>
+
+// Mock the Todoist API
+const mockTodoistApi = {
+    getUser: vi.fn(),
+} as unknown as Mocked<TodoistApi>
+
+// Mock the Todoist User
+const mockTodoistUser = createMockUser()
+
+const { FIND_TASKS_BY_FILTER } = ToolNames
+
+describe(`${FIND_TASKS_BY_FILTER} tool`, () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockTodoistApi.getUser.mockResolvedValue(mockTodoistUser)
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    describe('basic filter queries', () => {
+        it('should execute a basic project hierarchy filter (##Work)', async () => {
+            const mockTasks = [
+                createMappedTask({ content: 'Task in Work project', projectId: 'work-project' }),
+                createMappedTask({
+                    id: TEST_IDS.TASK_2,
+                    content: 'Task in sub-project',
+                    projectId: 'sub-project',
+                }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', limit: 10 },
+                mockTodoistApi,
+            )
+
+            expect(mockGetTasksByFilter).toHaveBeenCalledWith({
+                client: mockTodoistApi,
+                query: '##Work',
+                cursor: undefined,
+                limit: 10,
+            })
+
+            expect(result.structuredContent.tasks).toHaveLength(2)
+            expect(result.structuredContent.appliedFilter).toBe('##Work')
+            expect(result.textContent).toMatchSnapshot()
+        })
+
+        it('should execute a complex filter with logical operators', async () => {
+            const mockTasks = [
+                createMappedTask({
+                    content: 'High priority overdue task',
+                    priority: 'p1',
+                    dueDate: '2025-08-10',
+                }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '(today | overdue) & p1', limit: 50 },
+                mockTodoistApi,
+            )
+
+            expect(mockGetTasksByFilter).toHaveBeenCalledWith({
+                client: mockTodoistApi,
+                query: '(today | overdue) & p1',
+                cursor: undefined,
+                limit: 50,
+            })
+
+            expect(result.structuredContent.tasks).toHaveLength(1)
+            expect(result.textContent).toMatchSnapshot()
+        })
+
+        it('should execute a single project filter (#Inbox)', async () => {
+            const mockTasks = [
+                createMappedTask({ content: 'Inbox task', projectId: TEST_IDS.PROJECT_INBOX }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '#Inbox', limit: 10 },
+                mockTodoistApi,
+            )
+
+            expect(mockGetTasksByFilter).toHaveBeenCalledWith({
+                client: mockTodoistApi,
+                query: '#Inbox',
+                cursor: undefined,
+                limit: 10,
+            })
+
+            expect(result.structuredContent.tasks).toHaveLength(1)
+            expect(result.textContent).toMatchSnapshot()
+        })
+    })
+
+    describe('pagination', () => {
+        it('should handle pagination with cursor', async () => {
+            const mockTasks = [createMappedTask({ content: 'Page 2 task' })]
+            const mockResponse = { tasks: mockTasks, nextCursor: 'next-page-cursor' }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', limit: 10, cursor: 'current-cursor' },
+                mockTodoistApi,
+            )
+
+            expect(mockGetTasksByFilter).toHaveBeenCalledWith({
+                client: mockTodoistApi,
+                query: '##Work',
+                cursor: 'current-cursor',
+                limit: 10,
+            })
+
+            expect(result.structuredContent.nextCursor).toBe('next-page-cursor')
+            expect(result.structuredContent.hasMore).toBe(true)
+            expect(result.textContent).toMatchSnapshot()
+        })
+    })
+
+    describe('combining filter with labels', () => {
+        it('should combine filter with single label', async () => {
+            const mockTasks = [
+                createMappedTask({
+                    content: 'Urgent work task',
+                    labels: ['urgent'],
+                }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', labels: ['urgent'], limit: 10 },
+                mockTodoistApi,
+            )
+
+            expect(mockGetTasksByFilter).toHaveBeenCalledWith({
+                client: mockTodoistApi,
+                query: '##Work & (@urgent)',
+                cursor: undefined,
+                limit: 10,
+            })
+
+            expect(result.structuredContent.appliedFilter).toBe('##Work & (@urgent)')
+            expect(result.textContent).toMatchSnapshot()
+        })
+
+        it('should combine filter with multiple labels using AND operator', async () => {
+            const mockTasks = [
+                createMappedTask({
+                    content: 'Important urgent task',
+                    labels: ['important', 'urgent'],
+                }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                {
+                    filter: '##Work',
+                    labels: ['important', 'urgent'],
+                    labelsOperator: 'and',
+                    limit: 10,
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockGetTasksByFilter).toHaveBeenCalledWith({
+                client: mockTodoistApi,
+                query: '##Work & (@important  &  @urgent)',
+                cursor: undefined,
+                limit: 10,
+            })
+
+            expect(result.textContent).toMatchSnapshot()
+        })
+    })
+
+    describe('combining filter with responsible user', () => {
+        it('should combine filter with specific user', async () => {
+            mockResolveUserNameToId.mockResolvedValue({
+                userId: 'user-123',
+                displayName: 'John Doe',
+                email: 'john@example.com',
+            })
+
+            const mockTasks = [
+                createMappedTask({
+                    content: 'Task assigned to John',
+                    responsibleUid: 'user-123',
+                }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', responsibleUser: 'john@example.com', limit: 10 },
+                mockTodoistApi,
+            )
+
+            expect(mockResolveUserNameToId).toHaveBeenCalledWith(mockTodoistApi, 'john@example.com')
+            expect(mockGetTasksByFilter).toHaveBeenCalledWith({
+                client: mockTodoistApi,
+                query: '##Work & assigned to: john@example.com',
+                cursor: undefined,
+                limit: 10,
+            })
+
+            expect(result.textContent).toContain('assigned to: john@example.com')
+            expect(result.textContent).toMatchSnapshot()
+        })
+
+        it('should default responsibleUserFiltering to "all" to preserve filter behavior', async () => {
+            const mockTasks = [createMappedTask({ content: 'Task 1' })]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            await findTasksByFilter.execute({ filter: '##Work', limit: 10 }, mockTodoistApi)
+
+            // Should not add any assignment filter when responsibleUserFiltering defaults to 'all'
+            expect(mockGetTasksByFilter).toHaveBeenCalledWith({
+                client: mockTodoistApi,
+                query: '##Work',
+                cursor: undefined,
+                limit: 10,
+            })
+        })
+
+        it('should allow overriding responsibleUserFiltering', async () => {
+            const mockTasks = [createMappedTask({ content: 'My task or unassigned' })]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            await findTasksByFilter.execute(
+                { filter: '##Work', responsibleUserFiltering: 'unassignedOrMe', limit: 10 },
+                mockTodoistApi,
+            )
+
+            expect(mockGetTasksByFilter).toHaveBeenCalledWith({
+                client: mockTodoistApi,
+                query: '##Work & !assigned to: others',
+                cursor: undefined,
+                limit: 10,
+            })
+        })
+    })
+
+    describe('sorting', () => {
+        it('should sort by priority (p1 first by default)', async () => {
+            const mockTasks = [
+                createMappedTask({ id: '1', content: 'Low priority', priority: 'p4' }),
+                createMappedTask({ id: '2', content: 'High priority', priority: 'p1' }),
+                createMappedTask({ id: '3', content: 'Medium priority', priority: 'p2' }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', sortBy: 'priority', limit: 10 },
+                mockTodoistApi,
+            )
+
+            const tasks = result.structuredContent.tasks as MappedTask[]
+            // Default desc order for priority: p1 first (lowest number = highest priority)
+            // With desc multiplier, lower values come first
+            expect(tasks).toHaveLength(3)
+            expect(tasks[0]?.priority).toBe('p1')
+            expect(tasks[1]?.priority).toBe('p2')
+            expect(tasks[2]?.priority).toBe('p4')
+            expect(result.textContent).toContain('sorted by: priority (desc)')
+        })
+
+        it('should sort by priority ascending (p4 first)', async () => {
+            const mockTasks = [
+                createMappedTask({ id: '1', content: 'Low priority', priority: 'p4' }),
+                createMappedTask({ id: '2', content: 'High priority', priority: 'p1' }),
+                createMappedTask({ id: '3', content: 'Medium priority', priority: 'p2' }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', sortBy: 'priority', sortOrder: 'asc', limit: 10 },
+                mockTodoistApi,
+            )
+
+            const tasks = result.structuredContent.tasks as MappedTask[]
+            expect(tasks).toHaveLength(3)
+            expect(tasks[0]?.priority).toBe('p4')
+            expect(tasks[1]?.priority).toBe('p2')
+            expect(tasks[2]?.priority).toBe('p1')
+        })
+
+        it('should sort by due_date (soonest first by default, no-date at end)', async () => {
+            const mockTasks = [
+                createMappedTask({ id: '1', content: 'No due date', dueDate: undefined }),
+                createMappedTask({ id: '2', content: 'Later task', dueDate: '2025-08-25' }),
+                createMappedTask({ id: '3', content: 'Earlier task', dueDate: '2025-08-15' }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', sortBy: 'due_date', limit: 10 },
+                mockTodoistApi,
+            )
+
+            const tasks = result.structuredContent.tasks as MappedTask[]
+            expect(tasks).toHaveLength(3)
+            expect(tasks[0]?.dueDate).toBe('2025-08-15')
+            expect(tasks[1]?.dueDate).toBe('2025-08-25')
+            expect(tasks[2]?.dueDate).toBeUndefined()
+            expect(result.textContent).toContain('sorted by: due_date (asc)')
+        })
+
+        it('should sort by due_date descending (latest first)', async () => {
+            const mockTasks = [
+                createMappedTask({ id: '1', content: 'No due date', dueDate: undefined }),
+                createMappedTask({ id: '2', content: 'Earlier task', dueDate: '2025-08-15' }),
+                createMappedTask({ id: '3', content: 'Later task', dueDate: '2025-08-25' }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', sortBy: 'due_date', sortOrder: 'desc', limit: 10 },
+                mockTodoistApi,
+            )
+
+            const tasks = result.structuredContent.tasks as MappedTask[]
+            expect(tasks).toHaveLength(3)
+            expect(tasks[0]?.dueDate).toBe('2025-08-25')
+            expect(tasks[1]?.dueDate).toBe('2025-08-15')
+            expect(tasks[2]?.dueDate).toBeUndefined()
+        })
+
+        it('should sort by project (alphabetical by default)', async () => {
+            const mockTasks = [
+                createMappedTask({ id: '1', content: 'Task C', projectId: 'project-c' }),
+                createMappedTask({ id: '2', content: 'Task A', projectId: 'project-a' }),
+                createMappedTask({ id: '3', content: 'Task B', projectId: 'project-b' }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', sortBy: 'project', limit: 10 },
+                mockTodoistApi,
+            )
+
+            const tasks = result.structuredContent.tasks as MappedTask[]
+            expect(tasks).toHaveLength(3)
+            expect(tasks[0]?.projectId).toBe('project-a')
+            expect(tasks[1]?.projectId).toBe('project-b')
+            expect(tasks[2]?.projectId).toBe('project-c')
+            expect(result.textContent).toContain('sorted by: project (asc)')
+        })
+
+        it('should sort by created (newest first by default)', async () => {
+            const mockTasks = [
+                createMappedTask({ id: 'aaa', content: 'Older task' }),
+                createMappedTask({ id: 'zzz', content: 'Newer task' }),
+                createMappedTask({ id: 'mmm', content: 'Middle task' }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', sortBy: 'created', limit: 10 },
+                mockTodoistApi,
+            )
+
+            const tasks = result.structuredContent.tasks as MappedTask[]
+            // Descending order: highest/latest ID first
+            expect(tasks).toHaveLength(3)
+            expect(tasks[0]?.id).toBe('zzz')
+            expect(tasks[1]?.id).toBe('mmm')
+            expect(tasks[2]?.id).toBe('aaa')
+            expect(result.textContent).toContain('sorted by: created (desc)')
+        })
+
+        it('should not sort when sortBy is "default"', async () => {
+            const mockTasks = [
+                createMappedTask({ id: '3', content: 'Task 3' }),
+                createMappedTask({ id: '1', content: 'Task 1' }),
+                createMappedTask({ id: '2', content: 'Task 2' }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', sortBy: 'default', limit: 10 },
+                mockTodoistApi,
+            )
+
+            const tasks = result.structuredContent.tasks as MappedTask[]
+            // Order should be preserved
+            expect(tasks).toHaveLength(3)
+            expect(tasks[0]?.id).toBe('3')
+            expect(tasks[1]?.id).toBe('1')
+            expect(tasks[2]?.id).toBe('2')
+            expect(result.textContent).not.toContain('sorted by')
+        })
+
+        it('should not sort when sortBy is not provided', async () => {
+            const mockTasks = [
+                createMappedTask({ id: '3', content: 'Task 3' }),
+                createMappedTask({ id: '1', content: 'Task 1' }),
+            ]
+            const mockResponse = { tasks: mockTasks, nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', limit: 10 },
+                mockTodoistApi,
+            )
+
+            const tasks = result.structuredContent.tasks as MappedTask[]
+            // Order should be preserved
+            expect(tasks).toHaveLength(2)
+            expect(tasks[0]?.id).toBe('3')
+            expect(tasks[1]?.id).toBe('1')
+        })
+    })
+
+    describe('empty results handling', () => {
+        it('should handle empty results gracefully', async () => {
+            const mockResponse = { tasks: [], nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##NonExistent', limit: 10 },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.tasks).toHaveLength(0)
+            expect(result.structuredContent.totalCount).toBe(0)
+            expect(result.structuredContent.hasMore).toBe(false)
+            expect(result.textContent).toContain('Verify filter syntax is correct')
+            expect(result.textContent).toMatchSnapshot()
+        })
+
+        it('should provide helpful hints for empty ## filter results', async () => {
+            const mockResponse = { tasks: [], nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', limit: 10 },
+                mockTodoistApi,
+            )
+
+            expect(result.textContent).toContain(
+                'Ensure the parent project exists and has sub-projects',
+            )
+        })
+
+        it('should provide helpful hints for empty # filter results', async () => {
+            const mockResponse = { tasks: [], nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '#InvalidProject', limit: 10 },
+                mockTodoistApi,
+            )
+
+            expect(result.textContent).toContain('Verify the project name is correct')
+        })
+    })
+
+    describe('error handling', () => {
+        it('should propagate invalid filter error', async () => {
+            mockGetTasksByFilter.mockRejectedValue(new Error(TEST_ERRORS.INVALID_FILTER))
+
+            await expect(
+                findTasksByFilter.execute({ filter: 'invalid((syntax', limit: 10 }, mockTodoistApi),
+            ).rejects.toThrow(TEST_ERRORS.INVALID_FILTER)
+        })
+
+        it('should propagate API rate limit error', async () => {
+            mockGetTasksByFilter.mockRejectedValue(new Error(TEST_ERRORS.API_RATE_LIMIT))
+
+            await expect(
+                findTasksByFilter.execute({ filter: '##Work', limit: 10 }, mockTodoistApi),
+            ).rejects.toThrow(TEST_ERRORS.API_RATE_LIMIT)
+        })
+
+        it('should throw error when responsible user cannot be resolved', async () => {
+            mockResolveUserNameToId.mockResolvedValue(null)
+
+            await expect(
+                findTasksByFilter.execute(
+                    { filter: '##Work', responsibleUser: 'nonexistent@example.com', limit: 10 },
+                    mockTodoistApi,
+                ),
+            ).rejects.toThrow(
+                'Could not find user: "nonexistent@example.com". Make sure the user is a collaborator on a shared project.',
+            )
+        })
+    })
+
+    describe('output format', () => {
+        it('should return correct structured content', async () => {
+            const mockTasks = [createMappedTask({ content: 'Test task' })]
+            const mockResponse = { tasks: mockTasks, nextCursor: 'next-cursor' }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                { filter: '##Work', limit: 10 },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent).toEqual({
+                tasks: mockTasks,
+                nextCursor: 'next-cursor',
+                totalCount: 1,
+                hasMore: true,
+                appliedFilter: '##Work',
+            })
+        })
+
+        it('should include appliedFilter showing the final constructed query', async () => {
+            mockResolveUserNameToId.mockResolvedValue({
+                userId: 'user-123',
+                displayName: 'John Doe',
+                email: 'john@example.com',
+            })
+
+            const mockResponse = { tasks: [], nextCursor: null }
+            mockGetTasksByFilter.mockResolvedValue(mockResponse)
+
+            const result = await findTasksByFilter.execute(
+                {
+                    filter: '##Work',
+                    labels: ['urgent'],
+                    responsibleUser: 'john@example.com',
+                    limit: 10,
+                },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.appliedFilter).toBe(
+                '##Work & (@urgent) & assigned to: john@example.com',
+            )
+        })
+    })
+})

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -9,6 +9,7 @@ const TOOL_MUTABILITY_CATEGORIZATION: Record<string, ToolMutability> = {
     'find-projects': 'readonly',
     'find-tasks': 'readonly',
     'find-tasks-by-date': 'readonly',
+    'find-tasks-by-filter': 'readonly',
     'find-completed-tasks': 'readonly',
     'find-sections': 'readonly',
     'find-comments': 'readonly',

--- a/src/tools/find-tasks-by-filter.ts
+++ b/src/tools/find-tasks-by-filter.ts
@@ -1,0 +1,278 @@
+import { z } from 'zod'
+import {
+    appendToQuery,
+    buildResponsibleUserQueryFilter,
+    RESPONSIBLE_USER_FILTERING,
+    resolveResponsibleUser,
+} from '../filter-helpers.js'
+import type { TodoistTool } from '../todoist-tool.js'
+import { getTasksByFilter, type MappedTask } from '../tool-helpers.js'
+import { ApiLimits } from '../utils/constants.js'
+import { generateLabelsFilter, LabelsSchema } from '../utils/labels.js'
+import { TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
+import { previewTasks, summarizeList } from '../utils/response-builders.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const SORT_BY_OPTIONS = ['priority', 'due_date', 'project', 'created', 'order', 'default'] as const
+type SortByOption = (typeof SORT_BY_OPTIONS)[number]
+
+const SORT_ORDER_OPTIONS = ['asc', 'desc'] as const
+type SortOrderOption = (typeof SORT_ORDER_OPTIONS)[number]
+
+const ArgsSchema = {
+    filter: z
+        .string()
+        .min(1)
+        .describe(
+            'Raw Todoist filter query string. Examples: "##Work" (tasks from Work project and all sub-projects), "(today | overdue) & p1" (high-priority due/overdue tasks), "#Inbox" (tasks in Inbox).',
+        ),
+    limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(ApiLimits.TASKS_MAX)
+        .default(ApiLimits.TASKS_DEFAULT)
+        .describe('The maximum number of tasks to return.'),
+    cursor: z
+        .string()
+        .optional()
+        .describe(
+            'The cursor to get the next page of tasks (cursor is obtained from the previous call to this tool, with the same parameters).',
+        ),
+    sortBy: z
+        .enum(SORT_BY_OPTIONS)
+        .optional()
+        .describe(
+            'Sort results by field. "priority" (p1 first by default), "due_date" (soonest first by default), "project" (alphabetical), "created" (newest first by default), "order" (task order position, lowest first by default), "default" (Todoist natural order).',
+        ),
+    sortOrder: z
+        .enum(SORT_ORDER_OPTIONS)
+        .optional()
+        .describe(
+            'Sort direction: "asc" (ascending) or "desc" (descending). Default varies by sortBy: priority=desc, due_date=asc, project=asc, created=desc.',
+        ),
+    responsibleUser: z
+        .string()
+        .optional()
+        .describe('Find tasks assigned to this user. Can be a user ID, name, or email address.'),
+    responsibleUserFiltering: z
+        .enum(RESPONSIBLE_USER_FILTERING)
+        .optional()
+        .describe(
+            'How to filter by responsible user when responsibleUser is not provided. "assigned" = only tasks assigned to others; "unassignedOrMe" = only unassigned tasks or tasks assigned to me; "all" = all tasks regardless of assignment. Default is "all" to preserve the filter behavior.',
+        ),
+    ...LabelsSchema,
+}
+
+const OutputSchema = {
+    tasks: z.array(TaskOutputSchema).describe('The found tasks.'),
+    nextCursor: z.string().optional().describe('Cursor for the next page of results.'),
+    totalCount: z.number().describe('The total number of tasks in this page.'),
+    hasMore: z.boolean().describe('Whether there are more results available.'),
+    appliedFilter: z.string().describe('The final filter query that was executed (for debugging).'),
+}
+
+/**
+ * Get the default sort order for a given sortBy option
+ */
+function getDefaultSortOrder(sortBy: SortByOption): SortOrderOption {
+    switch (sortBy) {
+        case 'priority':
+            return 'desc' // p1 (highest) first
+        case 'due_date':
+            return 'asc' // soonest first
+        case 'project':
+            return 'asc' // alphabetical
+        case 'created':
+            return 'desc' // newest first
+        case 'order':
+            return 'asc' // lowest order first
+        default:
+            return 'asc'
+    }
+}
+
+/**
+ * Sort tasks based on the specified sortBy and sortOrder options
+ */
+function sortTasks(
+    tasks: MappedTask[],
+    sortBy: SortByOption | undefined,
+    sortOrder: SortOrderOption | undefined,
+): MappedTask[] {
+    if (!sortBy || sortBy === 'default') {
+        return tasks
+    }
+
+    const order = sortOrder ?? getDefaultSortOrder(sortBy)
+    const multiplier = order === 'asc' ? 1 : -1
+
+    return [...tasks].sort((a, b) => {
+        switch (sortBy) {
+            case 'priority': {
+                // p1 > p2 > p3 > p4 (p1 is highest priority)
+                // Priority values: p1=1, p2=2, p3=3, p4=4
+                const priorityA = parseInt(a.priority.replace('p', ''), 10)
+                const priorityB = parseInt(b.priority.replace('p', ''), 10)
+                // For priority, "desc" means highest priority (p1) first
+                // Since p1=1 is numerically lower, we need to invert the multiplier
+                // desc (high priority first): ascending numeric sort (1,2,3,4)
+                // asc (low priority first): descending numeric sort (4,3,2,1)
+                return (priorityA - priorityB) * -multiplier
+            }
+            case 'due_date': {
+                // Tasks without due dates go to the end
+                if (!a.dueDate && !b.dueDate) return 0
+                if (!a.dueDate) return 1 // a goes after b
+                if (!b.dueDate) return -1 // b goes after a
+                return a.dueDate.localeCompare(b.dueDate) * multiplier
+            }
+            case 'project': {
+                // Sort by project ID (alphabetical)
+                return a.projectId.localeCompare(b.projectId) * multiplier
+            }
+            case 'created': {
+                // Sort by task ID (as a proxy for creation time, since IDs are sequential)
+                return a.id.localeCompare(b.id) * multiplier
+            }
+            case 'order': {
+                // Sort by task order position within project
+                return (a.order - b.order) * multiplier
+            }
+            default:
+                return 0
+        }
+    })
+}
+
+const findTasksByFilter = {
+    name: ToolNames.FIND_TASKS_BY_FILTER,
+    description:
+        'Find tasks using a raw Todoist filter query. Enables advanced queries like "##Work" (project hierarchy including sub-projects), "(today | overdue) & p1" (complex filters), or "#Project" (single project). Use this when you need full Todoist filter syntax.',
+    parameters: ArgsSchema,
+    outputSchema: OutputSchema,
+    mutability: 'readonly' as const,
+    async execute(args, client) {
+        // Resolve assignee name to user ID if provided
+        const resolved = await resolveResponsibleUser(client, args.responsibleUser)
+        const resolvedAssigneeId = resolved?.userId
+        const assigneeEmail = resolved?.email
+
+        // Start with the user's filter query
+        let query = args.filter
+
+        // Add labels filter if provided
+        const labelsFilter = generateLabelsFilter(args.labels, args.labelsOperator)
+        if (labelsFilter.length > 0) {
+            query = appendToQuery(query, labelsFilter)
+        }
+
+        // Add responsible user filtering to the query
+        // Default to 'all' to preserve the user's filter behavior
+        const responsibleUserFilter = buildResponsibleUserQueryFilter({
+            resolvedAssigneeId,
+            assigneeEmail,
+            responsibleUserFiltering: args.responsibleUserFiltering ?? 'all',
+        })
+        query = appendToQuery(query, responsibleUserFilter)
+
+        const { tasks, nextCursor } = await getTasksByFilter({
+            client,
+            query,
+            cursor: args.cursor,
+            limit: args.limit,
+        })
+
+        // Apply client-side sorting
+        const sortedTasks = sortTasks(tasks, args.sortBy, args.sortOrder)
+
+        const textContent = generateTextContent({
+            tasks: sortedTasks,
+            args,
+            nextCursor,
+            assigneeEmail,
+            appliedFilter: query,
+        })
+
+        return {
+            textContent,
+            structuredContent: {
+                tasks: sortedTasks,
+                nextCursor: nextCursor ?? undefined,
+                totalCount: sortedTasks.length,
+                hasMore: Boolean(nextCursor),
+                appliedFilter: query,
+            },
+        }
+    },
+} satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
+
+function generateTextContent({
+    tasks,
+    args,
+    nextCursor,
+    assigneeEmail,
+    appliedFilter,
+}: {
+    tasks: MappedTask[]
+    args: z.infer<z.ZodObject<typeof ArgsSchema>>
+    nextCursor: string | null
+    assigneeEmail?: string
+    appliedFilter: string
+}) {
+    const filterHints: string[] = []
+    const zeroReasonHints: string[] = []
+
+    // Add the filter query as a hint
+    filterHints.push(`query: ${appliedFilter}`)
+
+    // Add label filter information
+    if (args.labels && args.labels.length > 0) {
+        const labelText = args.labels
+            .map((label) => `@${label}`)
+            .join(args.labelsOperator === 'and' ? ' & ' : ' | ')
+        filterHints.push(`labels: ${labelText}`)
+    }
+
+    // Add responsible user filter information
+    if (args.responsibleUser) {
+        const email = assigneeEmail || args.responsibleUser
+        filterHints.push(`assigned to: ${email}`)
+    }
+
+    // Add sorting information
+    if (args.sortBy && args.sortBy !== 'default') {
+        const order = args.sortOrder ?? getDefaultSortOrder(args.sortBy)
+        filterHints.push(`sorted by: ${args.sortBy} (${order})`)
+    }
+
+    // Generate subject description
+    let subject = `Tasks matching filter "${args.filter}"`
+    if (args.responsibleUser) {
+        const email = assigneeEmail || args.responsibleUser
+        subject += ` assigned to ${email}`
+    }
+
+    // Generate helpful suggestions for empty results
+    if (tasks.length === 0) {
+        zeroReasonHints.push('Verify filter syntax is correct')
+        zeroReasonHints.push('Try a simpler filter to confirm project/label names')
+        if (args.filter.startsWith('##')) {
+            zeroReasonHints.push('Ensure the parent project exists and has sub-projects')
+        } else if (args.filter.startsWith('#')) {
+            zeroReasonHints.push('Verify the project name is correct (case-sensitive)')
+        }
+    }
+
+    return summarizeList({
+        subject,
+        count: tasks.length,
+        limit: args.limit,
+        nextCursor: nextCursor ?? undefined,
+        filterHints,
+        previewLines: previewTasks(tasks, Math.min(tasks.length, args.limit)),
+        zeroReasonHints,
+    })
+}
+
+export { findTasksByFilter }

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -35,6 +35,7 @@ const TaskSchema = z.object({
     assignedByUid: z.string().optional().describe('The UID of the user who assigned this task.'),
     checked: z.boolean().describe('Whether the task is checked/completed.'),
     completedAt: z.string().optional().describe('When the task was completed (ISO 8601 format).'),
+    order: z.number().describe('The order/position of the task within its project.'),
 })
 
 /**

--- a/src/utils/test-helpers.ts
+++ b/src/utils/test-helpers.ts
@@ -176,6 +176,7 @@ export function createMappedTask(overrides: Partial<MappedTask> = {}): MappedTas
         assignedByUid: undefined,
         checked: false,
         completedAt: undefined,
+        order: 1,
         ...overrides,
     }
 }

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -12,6 +12,7 @@ export const ToolNames = {
     UPDATE_TASKS: 'update-tasks',
     FIND_TASKS: 'find-tasks',
     FIND_TASKS_BY_DATE: 'find-tasks-by-date',
+    FIND_TASKS_BY_FILTER: 'find-tasks-by-filter',
     FIND_COMPLETED_TASKS: 'find-completed-tasks',
 
     // Project management tools


### PR DESCRIPTION
## Summary

- Adds `find-tasks-by-filter` tool for executing raw Todoist filter queries
- Enables project hierarchy queries (`##Work` returns tasks from parent + all sub-projects)
- Adds `order` field to task output schema for global task positioning
- Implements client-side sorting by multiple criteria including order

## Motivation

The existing `find-tasks` tool requires specific parameters (projectId, sectionId, etc.) but doesn't support:
1. **Project hierarchy queries**: Getting tasks from a parent project AND all its sub-projects in one call
2. **Complex filter syntax**: Using Todoist's native filter language with logical operators
3. **Global ordering**: Sorting tasks by their order field across multiple projects

## Changes

### New Tool: find-tasks-by-filter

**Parameters:**
- `filter` (required): Raw Todoist filter query string
- `limit`, `cursor`: Standard pagination
- `sortBy`: Client-side sorting (`priority`, `due_date`, `project`, `created`, `order`, `default`)
- `sortOrder`: Sort direction (`asc`/`desc`) with sensible defaults per field
- `responsibleUser`, `responsibleUserFiltering`: User assignment filters (defaults to `all` to preserve filter behavior)
- `labels`, `labelsOperator`: Label filters

**Key features:**
- Project hierarchy support: `##Work` aggregates tasks from Work + all sub-projects
- Complex queries: `(today | overdue) & p1` for high-priority due/overdue tasks
- Client-side sorting: Since REST API doesn't support sorting in filter queries
- Debugging support: Returns `appliedFilter` showing final executed query

### Core Enhancement: order field

- Added `order` (from `task.childOrder`) to `mapTask()` function
- Added `order` to TaskSchema output
- Enables global task ordering across projects when using `sortBy: order`

**Use case:** Users can set order values (1, 3, 4, 5) across different sub-projects and sort globally

## Test plan

- [x] All existing tests pass (388 tests)
- [x] New tests added (25 tests for find-tasks-by-filter)
- [x] TypeScript type-check passes
- [x] Build succeeds
- [x] Biome linting passes
- [x] Schema validation passes (Gemini API compatible)
- [x] Manual testing:
  - ✅ Project hierarchy filter (`##Work`)
  - ✅ Complex filters with operators
  - ✅ Sorting by order field
  - ✅ Label and user filters
  - ✅ Pagination

## Example usage

```typescript
// Project hierarchy
await findTasksByFilter.execute({
  filter: '##Work',
  sortBy: 'order',
  limit: 50
}, client)

// Complex query with sorting
await findTasksByFilter.execute({
  filter: '(today | overdue) & p1',
  sortBy: 'priority',
  limit: 20
}, client)

// With labels
await findTasksByFilter.execute({
  filter: '##Work',
  labels: ['urgent'],
  sortBy: 'due_date'
}, client)
```

## PR Checklist

- [x] Added tests for new features
- [x] Updated docs (src/mcp-server.ts tool instructions)
- [x] New tool added to `getMcpServer` AND exported in `src/index.ts`
- [x] Tool added to tool-annotations test
- [x] All 388 tests pass
- [x] Build and type-check pass

## Design rationale

Follows repository's workflow-centric philosophy:
- **User intent**: Matches how users think about filtering ("get all Work tasks")
- **Rich responses**: Returns structured data + text summaries with helpful hints
- **Context-aware**: Provides debugging info via `appliedFilter` field
- **Batch-friendly**: Supports sorting across multiple projects/sections

🤖 Generated with [Claude Code](https://claude.ai/code)
