### PR TITLE
chore: improve typing and docs for features config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { FEATURE_NAMES, type Feature, type FeatureName, type Features } from './mcp-helpers.js'
 import { getMcpServer } from './mcp-server.js'
 // Comment management tools
 import { addComments } from './tools/add-comments.js'
@@ -64,7 +65,7 @@ const tools = {
     fetch,
 }
 
-export { tools, getMcpServer }
+export { tools, getMcpServer, FEATURE_NAMES, type Feature, type FeatureName, type Features }
 
 export {
     // Task management tools

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -7,19 +7,39 @@ import { removeNullFields } from './utils/sanitize-data.js'
 import { ToolNames } from './utils/tool-names.js'
 
 /**
+ * Supported feature names that modify tool behavior.
+ *
+ * Currently supported:
+ * - `'strip_emails'`: Strips email addresses from collaborator tool outputs
+ *   (affects: find-project-collaborators, find-completed-tasks). Useful for
+ *   clients like ChatGPT that should not have access to user emails.
+ */
+const FEATURE_NAMES = {
+    /**
+     * Strips email addresses from tool outputs that expose user data.
+     * Affects: find-project-collaborators, find-completed-tasks
+     */
+    STRIP_EMAILS: 'strip_emails',
+} as const
+
+/**
+ * Valid feature name values.
+ * @see FEATURE_NAMES for available options with documentation.
+ */
+type FeatureName = (typeof FEATURE_NAMES)[keyof typeof FEATURE_NAMES]
+
+/**
  * A feature that modifies tool behavior.
  */
 type Feature = {
     /**
-     * The feature name. Supported features:
-     * - 'strip_emails': Strips email addresses from collaborator tool outputs
-     *   (affects: find-project-collaborators, find-completed-tasks)
+     * The feature name. Use {@link FEATURE_NAMES} for available options with intellisense.
      */
-    name: string
+    name: FeatureName
 }
 
 /**
- * Array of features to enable.
+ * Array of features to enable when creating the MCP server.
  */
 type Features = Feature[]
 
@@ -235,10 +255,12 @@ function registerResource(server: McpServer, resource: McpTextResource) {
 
 export {
     addMetaToTool,
+    FEATURE_NAMES,
     registerResource,
     registerTool,
     stripEmailsFromObject,
     stripEmailsFromText,
     type Feature,
+    type FeatureName,
     type Features,
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,7 +1,15 @@
 import { TodoistApi } from '@doist/todoist-api-typescript'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-import { addMetaToTool, type Features, registerResource, registerTool } from './mcp-helpers.js'
+import {
+    addMetaToTool,
+    FEATURE_NAMES,
+    type Feature,
+    type FeatureName,
+    type Features,
+    registerResource,
+    registerTool,
+} from './mcp-helpers.js'
 import { addComments } from './tools/add-comments.js'
 import { addProjects } from './tools/add-projects.js'
 import { addSections } from './tools/add-sections.js'
@@ -196,4 +204,4 @@ function getMcpServer({
     return server
 }
 
-export { getMcpServer }
+export { getMcpServer, FEATURE_NAMES, type Feature, type FeatureName, type Features }


### PR DESCRIPTION
## Summary

I merged https://github.com/Doist/todoist-ai/pull/278 a bit too eagerly, this is a fast follow-up to improve typing & Intellisense

- Add `FEATURE_NAMES` constant with documented values for intellisense
- Create `FeatureName` type to restrict feature names to valid values
- Export `Feature`, `FeatureName`, `Features` types and `FEATURE_NAMES` constant from package
- TypeScript will now error on invalid feature names (e.g., `{ name: 'invalid' }`)

## Test plan
- [x] Type checking passes
- [x] All 379 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)