### PR TITLE
fix: prevent task creation in archived projects

### DIFF
--- a/src/tools/add-tasks.ts
+++ b/src/tools/add-tasks.ts
@@ -124,6 +124,16 @@ async function processTask(task: z.infer<typeof TaskSchema>, client: TodoistApi)
         resolvedProjectId = todoistUser.inboxProjectId
     }
 
+    // Validate project is not archived
+    if (resolvedProjectId) {
+        const project = await client.getProject(resolvedProjectId)
+        if (project.isArchived) {
+            throw new Error(
+                `Task "${task.content}": Cannot create task in archived project "${project.name}"`,
+            )
+        }
+    }
+
     let taskArgs: AddTaskArgs = {
         ...otherTaskArgs,
         projectId: resolvedProjectId,


### PR DESCRIPTION
## Short description

Adds validation to the `add-tasks` tool to prevent silent failures when creating tasks in archived projects. Previously, tasks would be silently created in archived projects, causing confusion in automation systems. Now returns `isError: true` with a clear message. Deleted projects already return errors from the API.

## PR Checklist

- [x] Added tests for bugs / new features