### PR TITLE
feat(mcp): add ToolAnnotations hints

### DIFF
--- a/src/todoist-tool.ts
+++ b/src/todoist-tool.ts
@@ -1,4 +1,5 @@
 import type { TodoistApi } from '@doist/todoist-api-typescript'
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js'
 import type { z } from 'zod'
 
 type ExecuteResult<Output extends z.ZodRawShape> = Promise<{
@@ -6,14 +7,11 @@ type ExecuteResult<Output extends z.ZodRawShape> = Promise<{
     structuredContent?: z.infer<z.ZodObject<Output>>
 }>
 
-/**
- * Categorization of tool behavior for MCP annotation hints.
- *
- * - **readonly**: Tool only reads data, doesn't modify state (e.g., find-*, get-*, search)
- * - **additive**: Tool creates new resources but doesn't modify existing ones (e.g., add-*)
- * - **mutating**: Tool modifies or destroys existing data (e.g., update-*, delete-*, complete-*)
- */
-type ToolMutability = 'readonly' | 'additive' | 'mutating'
+type RequiredToolAnnotations = ToolAnnotations & {
+    readOnlyHint: boolean
+    destructiveHint: boolean
+    idempotentHint: boolean
+}
 
 /**
  * A Todoist tool that can be used in an MCP server or other conversational AI interfaces.
@@ -46,11 +44,9 @@ type TodoistTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape> = {
     outputSchema: Output
 
     /**
-     * The mutability level of this tool.
-     *
-     * This is used to generate appropriate MCP annotation hints (readOnlyHint, destructiveHint).
+     * MCP ToolAnnotations hints for this tool.
      */
-    mutability: ToolMutability
+    annotations: RequiredToolAnnotations
 
     /**
      * The meta data of the tool.
@@ -71,4 +67,4 @@ type TodoistTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape> = {
     execute: (args: z.infer<z.ZodObject<Params>>, client: TodoistApi) => ExecuteResult<Output>
 }
 
-export type { TodoistTool, ToolMutability }
+export type { RequiredToolAnnotations, TodoistTool }

--- a/src/tools/add-comments.ts
+++ b/src/tools/add-comments.ts
@@ -32,7 +32,7 @@ const addComments = {
         'Add multiple comments to tasks or projects. Each comment must specify either taskId or projectId.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'additive' as const,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     async execute(args, client) {
         const { comments } = args
 

--- a/src/tools/add-projects.ts
+++ b/src/tools/add-projects.ts
@@ -35,7 +35,7 @@ const addProjects = {
     description: 'Add one or more new projects.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'additive' as const,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     async execute({ projects }, client) {
         const newProjects = await Promise.all(projects.map((project) => client.addProject(project)))
         const textContent = generateTextContent({ projects: newProjects })

--- a/src/tools/add-sections.ts
+++ b/src/tools/add-sections.ts
@@ -29,7 +29,7 @@ const addSections = {
     description: 'Add one or more new sections to projects.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'additive' as const,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     async execute({ sections }, client) {
         // Check if any section needs inbox resolution
         const needsInboxResolution = sections.some((section) => isInboxProjectId(section.projectId))

--- a/src/tools/add-tasks.ts
+++ b/src/tools/add-tasks.ts
@@ -80,7 +80,7 @@ const addTasks = {
         'Add one or more tasks to a project, section, or parent. Supports assignment to project collaborators.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'additive' as const,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     async execute({ tasks }, client) {
         const newTasks: Task[] = []
         for (const task of tasks) {

--- a/src/tools/complete-tasks.ts
+++ b/src/tools/complete-tasks.ts
@@ -21,7 +21,7 @@ const completeTasks = {
     description: 'Complete one or more tasks by their IDs.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'mutating' as const,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
     async execute(args, client) {
         const completed: string[] = []
         const failures: Array<{ item: string; error: string; code?: string }> = []

--- a/src/tools/delete-object.ts
+++ b/src/tools/delete-object.ts
@@ -26,7 +26,7 @@ const deleteObject = {
     description: 'Delete a project, section, task, or comment by its ID.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'mutating' as const,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
     async execute(args, client) {
         switch (args.type) {
             case 'project':

--- a/src/tools/fetch-object.ts
+++ b/src/tools/fetch-object.ts
@@ -25,7 +25,7 @@ const fetchObject = {
         'Fetch a single task, project, comment, or section by its ID. Use this when you have a specific object ID and want to retrieve its full details.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'readonly' as const,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         const { type, id } = args
 

--- a/src/tools/fetch.ts
+++ b/src/tools/fetch.ts
@@ -44,7 +44,7 @@ const fetch = {
         'Fetch the full contents of a task or project by its ID. The ID should be in the format "task:{id}" or "project:{id}".',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'readonly' as const,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         const { id } = args
 

--- a/src/tools/find-activity.ts
+++ b/src/tools/find-activity.ts
@@ -68,7 +68,7 @@ const findActivity = {
         'Retrieve recent activity logs to monitor and audit changes in Todoist. Shows events from all users by default (use initiatorId to filter by specific user). Track task completions, updates, deletions, project changes, and more with flexible filtering. Note: Date-based filtering is not supported by the Todoist API.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'readonly' as const,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         const { objectType, objectId, eventType, projectId, taskId, initiatorId, limit, cursor } =
             args

--- a/src/tools/find-comments.ts
+++ b/src/tools/find-comments.ts
@@ -45,7 +45,7 @@ const findComments = {
         'Find comments by task, project, or get a specific comment by ID. Exactly one of taskId, projectId, or commentId must be provided.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'readonly' as const,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         // Validate that exactly one search parameter is provided
         const searchParams = [args.taskId, args.projectId, args.commentId].filter(Boolean)

--- a/src/tools/find-completed-tasks.ts
+++ b/src/tools/find-completed-tasks.ts
@@ -75,7 +75,7 @@ const findCompletedTasks = {
         'Get completed tasks (includes all collaborators by default—use responsibleUser to narrow).',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'readonly' as const,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         const { getBy, labels, labelsOperator, since, until, responsibleUser, projectId, ...rest } =
             args

--- a/src/tools/find-project-collaborators.ts
+++ b/src/tools/find-project-collaborators.ts
@@ -43,7 +43,7 @@ const findProjectCollaborators = {
     description: 'Search for collaborators by name or other criteria in a project.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'readonly' as const,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         const { projectId, searchTerm } = args
 

--- a/src/tools/find-projects.ts
+++ b/src/tools/find-projects.ts
@@ -46,7 +46,7 @@ const findProjects = {
         'List all projects or search for projects by name. When searching, all matching projects are returned (pagination is ignored). When not searching, projects are returned with pagination.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'readonly' as const,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         let results: Awaited<ReturnType<typeof client.getProjects>>['results']
         let nextCursor = null

--- a/src/tools/find-sections.ts
+++ b/src/tools/find-sections.ts
@@ -42,7 +42,7 @@ const findSections = {
         'Search for sections by name or other criteria in a project. When searching, uses server-side search to avoid fetching all sections.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'readonly' as const,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         // Resolve "inbox" to actual inbox project ID if needed
         const resolvedProjectId = await resolveInboxProjectId({

--- a/src/tools/find-tasks-by-date.ts
+++ b/src/tools/find-tasks-by-date.ts
@@ -77,7 +77,7 @@ const findTasksByDate = {
         "Get tasks by date range. Use startDate 'today' to get today's tasks including overdue items, or provide a specific date/date range.",
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'readonly' as const,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         if (!args.startDate && args.overdueOption !== 'overdue-only') {
             throw new Error(

--- a/src/tools/find-tasks.ts
+++ b/src/tools/find-tasks.ts
@@ -73,7 +73,7 @@ const findTasks = {
         'Find tasks by text search, or by project/section/parent container/responsible user. At least one filter must be provided.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'readonly' as const,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         const {
             searchText,

--- a/src/tools/get-overview.ts
+++ b/src/tools/get-overview.ts
@@ -365,7 +365,7 @@ const getOverview = {
         'Get a Markdown overview. If no projectId is provided, shows all projects with hierarchy and sections (useful for navigation). If projectId is provided, shows detailed overview of that specific project including all tasks grouped by sections.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'readonly' as const,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         const result = args.projectId
             ? await generateProjectOverview(client, args.projectId)

--- a/src/tools/manage-assignments.ts
+++ b/src/tools/manage-assignments.ts
@@ -85,7 +85,7 @@ const manageAssignments = {
         'Bulk assignment operations for multiple tasks. Supports assign, unassign, and reassign operations with atomic rollback on failures.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'mutating' as const,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
     async execute(args, client) {
         const { operation, taskIds, responsibleUser, fromAssigneeUser, dryRun } = args
 

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -40,7 +40,7 @@ const search = {
         'Search across tasks and projects in Todoist. Returns a list of relevant results with IDs, titles, and URLs.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'readonly' as const,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         const { query } = args
 

--- a/src/tools/update-comments.ts
+++ b/src/tools/update-comments.ts
@@ -29,7 +29,7 @@ const updateComments = {
     description: 'Update multiple existing comments with new content.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'mutating' as const,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
     async execute(args, client) {
         const { comments } = args
 

--- a/src/tools/update-projects.ts
+++ b/src/tools/update-projects.ts
@@ -35,7 +35,7 @@ const updateProjects = {
     description: 'Update multiple existing projects with new values.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'mutating' as const,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
     async execute(args, client) {
         const { projects } = args
         const updateProjectsPromises = projects.map(async (project) => {

--- a/src/tools/update-sections.ts
+++ b/src/tools/update-sections.ts
@@ -24,7 +24,7 @@ const updateSections = {
     description: 'Update multiple existing sections with new values.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'mutating' as const,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
     async execute({ sections }, client) {
         const updatedSections = await Promise.all(
             sections.map((section) => client.updateSection(section.id, { name: section.name })),

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -92,7 +92,7 @@ const updateTasks = {
     description: 'Update existing tasks including content, dates, priorities, and assignments.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'mutating' as const,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
     async execute(args, client) {
         const { tasks } = args
         const updateTasksPromises = tasks.map(async (task) => {

--- a/src/tools/user-info.ts
+++ b/src/tools/user-info.ts
@@ -195,7 +195,7 @@ const userInfo = {
         'Get comprehensive user information including user ID, full name, email, timezone with current local time, week start day preferences, current week dates, daily/weekly goal progress, and user plan (Free/Pro/Business).',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
-    mutability: 'readonly' as const,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(_args, client) {
         const result = await generateUserInfo(client)
 


### PR DESCRIPTION
Adds MCP tool annotation hints to all registered tools.

- `title`: prefix with "Todoist:" to disambiguate generic names (e.g. search/fetch) in multi-server clients.
- `openWorldHint`: `false` for all tools since they only operate within the user's Todoist account.
- `idempotentHint`:
  - `true` for read-only tools and `delete-object` (repeat calls should have no additional effect)
  - `false` otherwise (additive tools duplicate on retry; mutating tools can have additional effects, e.g., recurring task completions)

Equivalent to https://github.com/Doist/twist-ai/pull/80
