### PR TITLE
feat(ci): add automated cross-repository trigger for todoist-ai-integrations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,3 +43,26 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Get published version
+        id: get-version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "PACKAGE_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Trigger todoist-ai-integrations update
+        if: success()
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/Doist/todoist-ai-integrations/dispatches \
+            -f event_type='todoist-ai-updated' \
+            -f client_payload='{"version":"${{ env.PACKAGE_VERSION }}","npm_tag":"latest"}'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true


### PR DESCRIPTION
## Summary

- Adds automated triggering of `todoist-ai-integrations` repository when a new version is published to npm
- Captures the published version and sends it via `repository_dispatch` event
- Uses `continue-on-error: true` so publishing succeeds even if the trigger fails

This mirrors the implementation in [twist-ai PR #93](https://github.com/Doist/twist-ai/pull/93).

## Related PR

- Companion PR in todoist-ai-integrations: https://github.com/Doist/todoist-ai-integrations/pull/128

## Test plan

- [ ] Verify YAML is valid
- [ ] Test end-to-end after merge: publish → trigger → update → test → deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)