### PR TITLE
fix: include current user in user resolution

### DIFF
--- a/src/utils/user-resolver.ts
+++ b/src/utils/user-resolver.ts
@@ -65,6 +65,30 @@ export class UserResolver {
             return result
         }
 
+        // Check if input matches the current authenticated user
+        try {
+            const currentUser = await client.getUser()
+            if (currentUser) {
+                const searchTerm = trimmedInput.toLowerCase()
+                if (
+                    currentUser.id === trimmedInput ||
+                    currentUser.email.toLowerCase() === searchTerm ||
+                    currentUser.fullName.toLowerCase() === searchTerm ||
+                    currentUser.fullName.toLowerCase().includes(searchTerm)
+                ) {
+                    const result = {
+                        userId: currentUser.id,
+                        displayName: currentUser.fullName,
+                        email: currentUser.email,
+                    }
+                    userResolutionCache.set(trimmedInput, { result, timestamp: Date.now() })
+                    return result
+                }
+            }
+        } catch (_error) {
+            // Continue to collaborator search if getUser fails
+        }
+
         try {
             // Get all collaborators from shared projects
             const allCollaborators = await this.getAllCollaborators(client)


### PR DESCRIPTION
## Summary
- Fix user resolution to check the current authenticated user before searching collaborators
- This allows `responsibleUser` to be resolved by name/email even when the user has no shared projects

## Test plan
- [x] Added tests for resolving current user by exact full name
- [x] Added tests for resolving current user by email
- [x] Added tests for resolving current user by partial name
- [x] Added tests for resolving current user by user ID
- [x] Added test for error when user doesn't match and no collaborators exist
- [x] All 409 tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)