### PR TITLE
chore: Uses correct token for deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,5 +64,5 @@ jobs:
             -f event_type='todoist-ai-updated' \
             -f client_payload='{"version":"${{ env.PACKAGE_VERSION }}","npm_tag":"latest"}'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         continue-on-error: true


### PR DESCRIPTION
Updates the publish workflow to use the new `DEPLOY_TOKEN`