### PR TITLE
fix: suppress dotenv@17 stdout logging that breaks stdio MCP transport

### DIFF
--- a/src/main-http.ts
+++ b/src/main-http.ts
@@ -20,7 +20,7 @@ import dotenv from 'dotenv'
 import express, { type Request, type Response } from 'express'
 import { getMcpServer } from './mcp-server.js'
 
-dotenv.config()
+dotenv.config({ quiet: true })
 
 const PORT = Number.parseInt(process.env.PORT || '3000', 10)
 const SESSION_TIMEOUT_MS = Number.parseInt(process.env.SESSION_TIMEOUT_MS || '1800000', 10) // 30 minutes default

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,5 +24,5 @@ function main() {
         })
 }
 
-dotenv.config()
+dotenv.config({ quiet: true })
 main()


### PR DESCRIPTION
## Summary

- `dotenv@17` logs a message to stdout by default when loading `.env` files, which corrupts the MCP stdio protocol (client receives non-JSON data and closes with error `-32002: connection closed`)
- Pass `{ quiet: true }` to `dotenv.config()` in both `main.ts` and `main-http.ts` to suppress the output

Closes #305

## Test plan

- [x] `npm run build` passes
- [x] All 415 tests pass
- [ ] Manual: verify `node -e "require('dotenv').config({ quiet: true })"` produces no stdout output
- [ ] Manual: verify MCP stdio transport connects successfully with a `.env` file present

🤖 Generated with [Claude Code](https://claude.com/claude-code)