### PR TITLE
feat: add project-management tool for archive/unarchive

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -30,6 +30,7 @@ import { createFindTasksByDateResource } from './tools/find-tasks-by-date.resour
 import { getOverview } from './tools/get-overview.js'
 import { listWorkspaces } from './tools/list-workspaces.js'
 import { manageAssignments } from './tools/manage-assignments.js'
+import { projectManagement } from './tools/project-management.js'
 import { search } from './tools/search.js'
 import { updateComments } from './tools/update-comments.js'
 import { updateProjects } from './tools/update-projects.js'
@@ -66,6 +67,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 
 **Project & Organization:**
 - **add-projects/update-projects/find-projects**: Manage project lifecycle with names, favorites, and view styles (list/board/calendar)
+- **project-management**: Archive or unarchive projects by ID
 - **add-sections/update-sections/find-sections**: Organize tasks within projects using sections
 - **get-overview**: Get comprehensive Markdown overview of entire account or specific project with task hierarchies
 - **list-workspaces**: Get all workspaces for the user with details like plan type, role, and settings
@@ -175,6 +177,7 @@ function getMcpServer({
     registerTool({ tool: addProjects, ...toolArgs })
     registerTool({ tool: updateProjects, ...toolArgs })
     registerTool({ tool: findProjects, ...toolArgs })
+    registerTool({ tool: projectManagement, ...toolArgs })
 
     // Section management tools
     registerTool({ tool: addSections, ...toolArgs })

--- a/src/tools/__tests__/__snapshots__/project-management.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/project-management.test.ts.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`project-management tool > archiving projects > should archive a project by ID 1`] = `"Archived project: My Project (id=6cfCcrrCFg2xP94Q)"`;
+
+exports[`project-management tool > unarchiving projects > should unarchive a project by ID 1`] = `"Unarchived project: Archived Project (id=proj-archived)"`;

--- a/src/tools/__tests__/project-management.test.ts
+++ b/src/tools/__tests__/project-management.test.ts
@@ -1,0 +1,100 @@
+import type { TodoistApi } from '@doist/todoist-api-typescript'
+import { type Mocked, vi } from 'vitest'
+import { createMockProject } from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { projectManagement } from '../project-management.js'
+
+const mockTodoistApi = {
+    archiveProject: vi.fn(),
+    unarchiveProject: vi.fn(),
+} as unknown as Mocked<TodoistApi>
+
+const { PROJECT_MANAGEMENT } = ToolNames
+
+describe(`${PROJECT_MANAGEMENT} tool`, () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    describe('archiving projects', () => {
+        it('should archive a project by ID', async () => {
+            const mockProject = createMockProject({
+                id: '6cfCcrrCFg2xP94Q',
+                name: 'My Project',
+            })
+            mockTodoistApi.archiveProject.mockResolvedValue(mockProject)
+
+            const result = await projectManagement.execute(
+                { action: 'archive', projectId: '6cfCcrrCFg2xP94Q' },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.archiveProject).toHaveBeenCalledWith('6cfCcrrCFg2xP94Q')
+            expect(mockTodoistApi.unarchiveProject).not.toHaveBeenCalled()
+
+            const textContent = result.textContent
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Archived project: My Project (id=6cfCcrrCFg2xP94Q)')
+            expect(result.structuredContent).toEqual({
+                project: expect.objectContaining({
+                    id: '6cfCcrrCFg2xP94Q',
+                    name: 'My Project',
+                }),
+                success: true,
+            })
+        })
+
+        it('should propagate archive errors', async () => {
+            const apiError = new Error('API Error: Project not found')
+            mockTodoistApi.archiveProject.mockRejectedValue(apiError)
+
+            await expect(
+                projectManagement.execute(
+                    { action: 'archive', projectId: 'non-existent' },
+                    mockTodoistApi,
+                ),
+            ).rejects.toThrow('API Error: Project not found')
+        })
+    })
+
+    describe('unarchiving projects', () => {
+        it('should unarchive a project by ID', async () => {
+            const mockProject = createMockProject({
+                id: 'proj-archived',
+                name: 'Archived Project',
+            })
+            mockTodoistApi.unarchiveProject.mockResolvedValue(mockProject)
+
+            const result = await projectManagement.execute(
+                { action: 'unarchive', projectId: 'proj-archived' },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.unarchiveProject).toHaveBeenCalledWith('proj-archived')
+            expect(mockTodoistApi.archiveProject).not.toHaveBeenCalled()
+
+            const textContent = result.textContent
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Unarchived project: Archived Project (id=proj-archived)')
+            expect(result.structuredContent).toEqual({
+                project: expect.objectContaining({
+                    id: 'proj-archived',
+                    name: 'Archived Project',
+                }),
+                success: true,
+            })
+        })
+
+        it('should propagate unarchive errors', async () => {
+            const apiError = new Error('API Error: Cannot unarchive project')
+            mockTodoistApi.unarchiveProject.mockRejectedValue(apiError)
+
+            await expect(
+                projectManagement.execute(
+                    { action: 'unarchive', projectId: 'invalid-id' },
+                    mockTodoistApi,
+                ),
+            ).rejects.toThrow('API Error: Cannot unarchive project')
+        })
+    })
+})

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -76,6 +76,13 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         idempotentHint: true,
     },
     {
+        name: ToolNames.PROJECT_MANAGEMENT,
+        title: 'Todoist: Project Management',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    {
         name: ToolNames.ADD_SECTIONS,
         title: 'Todoist: Add Sections',
         readOnlyHint: false,

--- a/src/tools/project-management.ts
+++ b/src/tools/project-management.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod'
+import type { TodoistTool } from '../todoist-tool.js'
+import { mapProject } from '../tool-helpers.js'
+import { ProjectSchema } from '../utils/output-schemas.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    action: z.enum(['archive', 'unarchive']).describe('The action to perform on the project.'),
+    projectId: z.string().min(1).describe('The ID of the project.'),
+}
+
+const OutputSchema = {
+    project: ProjectSchema.describe('The updated project.'),
+    success: z.boolean().describe('Whether the action was successful.'),
+}
+
+const projectManagement = {
+    name: ToolNames.PROJECT_MANAGEMENT,
+    description: 'Archive or unarchive a project by its ID.',
+    parameters: ArgsSchema,
+    outputSchema: OutputSchema,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    async execute(args, client) {
+        const project =
+            args.action === 'archive'
+                ? await client.archiveProject(args.projectId)
+                : await client.unarchiveProject(args.projectId)
+
+        const mappedProject = mapProject(project)
+
+        return {
+            textContent: `${args.action === 'archive' ? 'Archived' : 'Unarchived'} project: ${mappedProject.name} (id=${mappedProject.id})`,
+            structuredContent: {
+                project: mappedProject,
+                success: true,
+            },
+        }
+    },
+} satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
+
+export { projectManagement }

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -18,6 +18,7 @@ export const ToolNames = {
     ADD_PROJECTS: 'add-projects',
     UPDATE_PROJECTS: 'update-projects',
     FIND_PROJECTS: 'find-projects',
+    PROJECT_MANAGEMENT: 'project-management',
 
     // Section management tools
     ADD_SECTIONS: 'add-sections',


### PR DESCRIPTION
## Summary
- Add new `project-management` tool exposing archive/unarchive operations via the Todoist SDK's `archiveProject()` and `unarchiveProject()` methods
- Register the tool in the MCP server and update tool usage guidelines
- Add comprehensive tests (archive, unarchive, error propagation) and tool annotation coverage

## Test plan
- [x] `npm run build` passes
- [x] `npm run check` passes (biome lint/format + schema validation)
- [x] All 423 tests pass (including 4 new tests)
- [ ] Manual test: `npx tsx scripts/run-tool.ts project-management '{"action":"archive","projectId":"<id>"}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)