### PR TITLE
feat: add project-move tool for moving projects between personal and workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "7.9.0",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-api-typescript": "6.4.0",
+                "@doist/todoist-api-typescript": "6.5.0",
                 "date-fns": "4.1.0",
                 "dompurify": "3.3.1",
                 "dotenv": "17.2.3",
@@ -261,9 +261,9 @@
             }
         },
         "node_modules/@doist/todoist-api-typescript": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-6.4.0.tgz",
-            "integrity": "sha512-p3LR2XZhcxFLltmJgLUGHlVxh+zeXNQjKoSCYKWdDgOr0PFO1yh84cWXz5IDXvG0/tpbOmUsqOYX7Ta7e5V/HA==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-6.5.0.tgz",
+            "integrity": "sha512-Hvtqb0EsBTN4gz4xsQ+VbYasZeEhNxuNa+CrCcGB+YWoRJipMmm4dXmzceYXKT8gx8UgVdyV7CDIEXrFQC/hFw==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-api-typescript": "6.4.0",
+        "@doist/todoist-api-typescript": "6.5.0",
         "date-fns": "4.1.0",
         "dompurify": "3.3.1",
         "dotenv": "17.2.3",

--- a/scripts/run-tool.ts
+++ b/scripts/run-tool.ts
@@ -36,6 +36,8 @@ import { findTasksByDate } from '../src/tools/find-tasks-by-date.js'
 import { getOverview } from '../src/tools/get-overview.js'
 import { listWorkspaces } from '../src/tools/list-workspaces.js'
 import { manageAssignments } from '../src/tools/manage-assignments.js'
+import { projectManagement } from '../src/tools/project-management.js'
+import { projectMove } from '../src/tools/project-move.js'
 import { search } from '../src/tools/search.js'
 import { updateComments } from '../src/tools/update-comments.js'
 import { updateProjects } from '../src/tools/update-projects.js'
@@ -76,6 +78,8 @@ const tools: Record<string, ExecutableTool> = {
     'get-overview': getOverview,
     'list-workspaces': listWorkspaces,
     'manage-assignments': manageAssignments,
+    'project-management': projectManagement,
+    'project-move': projectMove,
     search: search,
     'update-comments': updateComments,
     'update-projects': updateProjects,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -31,6 +31,7 @@ import { getOverview } from './tools/get-overview.js'
 import { listWorkspaces } from './tools/list-workspaces.js'
 import { manageAssignments } from './tools/manage-assignments.js'
 import { projectManagement } from './tools/project-management.js'
+import { projectMove } from './tools/project-move.js'
 import { search } from './tools/search.js'
 import { updateComments } from './tools/update-comments.js'
 import { updateProjects } from './tools/update-projects.js'
@@ -68,6 +69,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 **Project & Organization:**
 - **add-projects/update-projects/find-projects**: Manage project lifecycle with names, favorites, and view styles (list/board/calendar)
 - **project-management**: Archive or unarchive projects by ID
+- **project-move**: Move projects between personal and workspace contexts
 - **add-sections/update-sections/find-sections**: Organize tasks within projects using sections
 - **get-overview**: Get comprehensive Markdown overview of entire account or specific project with task hierarchies
 - **list-workspaces**: Get all workspaces for the user with details like plan type, role, and settings
@@ -178,6 +180,7 @@ function getMcpServer({
     registerTool({ tool: updateProjects, ...toolArgs })
     registerTool({ tool: findProjects, ...toolArgs })
     registerTool({ tool: projectManagement, ...toolArgs })
+    registerTool({ tool: projectMove, ...toolArgs })
 
     // Section management tools
     registerTool({ tool: addSections, ...toolArgs })

--- a/src/tools/__tests__/__snapshots__/project-move.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/project-move.test.ts.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`project-move tool > move to personal > should move a project to personal 1`] = `"Moved to personal: My Project (id=6cfCcrrCFg2xP94Q)"`;
+
+exports[`project-move tool > move to workspace > should move a project to a workspace with projectId and workspaceId only 1`] = `"Moved to workspace: My Project (id=6cfCcrrCFg2xP94Q)"`;

--- a/src/tools/__tests__/project-move.test.ts
+++ b/src/tools/__tests__/project-move.test.ts
@@ -1,0 +1,223 @@
+import type { TodoistApi } from '@doist/todoist-api-typescript'
+import { type Mocked, vi } from 'vitest'
+import {
+    createMockProject,
+    createMockWorkspaceProject,
+    TEST_IDS,
+} from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { projectMove } from '../project-move.js'
+
+const mockTodoistApi = {
+    moveProjectToWorkspace: vi.fn(),
+    moveProjectToPersonal: vi.fn(),
+} as unknown as Mocked<TodoistApi>
+
+const { PROJECT_MOVE } = ToolNames
+
+describe(`${PROJECT_MOVE} tool`, () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    describe('move to workspace', () => {
+        it('should move a project to a workspace with projectId and workspaceId only', async () => {
+            const mockProject = createMockWorkspaceProject({
+                id: '6cfCcrrCFg2xP94Q',
+                name: 'My Project',
+                workspaceId: TEST_IDS.WORKSPACE_1,
+            })
+            mockTodoistApi.moveProjectToWorkspace.mockResolvedValue(mockProject)
+
+            const result = await projectMove.execute(
+                {
+                    action: 'move-to-workspace',
+                    projectId: '6cfCcrrCFg2xP94Q',
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.moveProjectToWorkspace).toHaveBeenCalledWith({
+                projectId: '6cfCcrrCFg2xP94Q',
+                workspaceId: TEST_IDS.WORKSPACE_1,
+            })
+            expect(mockTodoistApi.moveProjectToPersonal).not.toHaveBeenCalled()
+
+            const textContent = result.textContent
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Moved to workspace: My Project (id=6cfCcrrCFg2xP94Q)')
+            expect(result.structuredContent).toEqual({
+                project: expect.objectContaining({
+                    id: '6cfCcrrCFg2xP94Q',
+                    name: 'My Project',
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                }),
+                success: true,
+            })
+        })
+
+        it('should move a project to a workspace with folderId', async () => {
+            const mockProject = createMockWorkspaceProject({
+                id: '6cfCcrrCFg2xP94Q',
+                name: 'My Project',
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                folderId: 'folder-123',
+            })
+            mockTodoistApi.moveProjectToWorkspace.mockResolvedValue(mockProject)
+
+            const result = await projectMove.execute(
+                {
+                    action: 'move-to-workspace',
+                    projectId: '6cfCcrrCFg2xP94Q',
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                    folderId: 'folder-123',
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.moveProjectToWorkspace).toHaveBeenCalledWith({
+                projectId: '6cfCcrrCFg2xP94Q',
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                folderId: 'folder-123',
+            })
+            expect(result.structuredContent?.success).toBe(true)
+        })
+
+        it('should move a project to a workspace with visibility', async () => {
+            const mockProject = createMockWorkspaceProject({
+                id: '6cfCcrrCFg2xP94Q',
+                name: 'My Project',
+                workspaceId: TEST_IDS.WORKSPACE_1,
+            })
+            mockTodoistApi.moveProjectToWorkspace.mockResolvedValue(mockProject)
+
+            const result = await projectMove.execute(
+                {
+                    action: 'move-to-workspace',
+                    projectId: '6cfCcrrCFg2xP94Q',
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                    visibility: 'team',
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.moveProjectToWorkspace).toHaveBeenCalledWith({
+                projectId: '6cfCcrrCFg2xP94Q',
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                access: { visibility: 'team' },
+            })
+            expect(result.structuredContent?.success).toBe(true)
+        })
+
+        it('should move a project to a workspace with folderId and visibility', async () => {
+            const mockProject = createMockWorkspaceProject({
+                id: '6cfCcrrCFg2xP94Q',
+                name: 'My Project',
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                folderId: 'folder-456',
+            })
+            mockTodoistApi.moveProjectToWorkspace.mockResolvedValue(mockProject)
+
+            const result = await projectMove.execute(
+                {
+                    action: 'move-to-workspace',
+                    projectId: '6cfCcrrCFg2xP94Q',
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                    folderId: 'folder-456',
+                    visibility: 'public',
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.moveProjectToWorkspace).toHaveBeenCalledWith({
+                projectId: '6cfCcrrCFg2xP94Q',
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                folderId: 'folder-456',
+                access: { visibility: 'public' },
+            })
+            expect(result.structuredContent?.success).toBe(true)
+        })
+
+        it('should throw error when workspaceId is missing', async () => {
+            await expect(
+                projectMove.execute(
+                    {
+                        action: 'move-to-workspace',
+                        projectId: '6cfCcrrCFg2xP94Q',
+                    },
+                    mockTodoistApi,
+                ),
+            ).rejects.toThrow('workspaceId is required when action is move-to-workspace')
+
+            expect(mockTodoistApi.moveProjectToWorkspace).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('move to personal', () => {
+        it('should move a project to personal', async () => {
+            const mockProject = createMockProject({
+                id: '6cfCcrrCFg2xP94Q',
+                name: 'My Project',
+            })
+            mockTodoistApi.moveProjectToPersonal.mockResolvedValue(mockProject)
+
+            const result = await projectMove.execute(
+                {
+                    action: 'move-to-personal',
+                    projectId: '6cfCcrrCFg2xP94Q',
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.moveProjectToPersonal).toHaveBeenCalledWith({
+                projectId: '6cfCcrrCFg2xP94Q',
+            })
+            expect(mockTodoistApi.moveProjectToWorkspace).not.toHaveBeenCalled()
+
+            const textContent = result.textContent
+            expect(textContent).toMatchSnapshot()
+            expect(textContent).toContain('Moved to personal: My Project (id=6cfCcrrCFg2xP94Q)')
+            expect(result.structuredContent).toEqual({
+                project: expect.objectContaining({
+                    id: '6cfCcrrCFg2xP94Q',
+                    name: 'My Project',
+                }),
+                success: true,
+            })
+        })
+    })
+
+    describe('error handling', () => {
+        it('should propagate errors from move to workspace', async () => {
+            const apiError = new Error('API Error: Project not found')
+            mockTodoistApi.moveProjectToWorkspace.mockRejectedValue(apiError)
+
+            await expect(
+                projectMove.execute(
+                    {
+                        action: 'move-to-workspace',
+                        projectId: 'non-existent',
+                        workspaceId: TEST_IDS.WORKSPACE_1,
+                    },
+                    mockTodoistApi,
+                ),
+            ).rejects.toThrow('API Error: Project not found')
+        })
+
+        it('should propagate errors from move to personal', async () => {
+            const apiError = new Error('API Error: Cannot move project')
+            mockTodoistApi.moveProjectToPersonal.mockRejectedValue(apiError)
+
+            await expect(
+                projectMove.execute(
+                    {
+                        action: 'move-to-personal',
+                        projectId: 'invalid-id',
+                    },
+                    mockTodoistApi,
+                ),
+            ).rejects.toThrow('API Error: Cannot move project')
+        })
+    })
+})

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -83,6 +83,13 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         idempotentHint: true,
     },
     {
+        name: ToolNames.PROJECT_MOVE,
+        title: 'Todoist: Project Move',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    {
         name: ToolNames.ADD_SECTIONS,
         title: 'Todoist: Add Sections',
         readOnlyHint: false,

--- a/src/tools/project-move.ts
+++ b/src/tools/project-move.ts
@@ -1,0 +1,87 @@
+import type {
+    MoveProjectToWorkspaceArgs,
+    PersonalProject,
+    WorkspaceProject,
+} from '@doist/todoist-api-typescript'
+import { z } from 'zod'
+import type { TodoistTool } from '../todoist-tool.js'
+import { mapProject } from '../tool-helpers.js'
+import { ProjectSchema } from '../utils/output-schemas.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    action: z
+        .enum(['move-to-workspace', 'move-to-personal'])
+        .describe('The action to perform on the project.'),
+    projectId: z.string().min(1).describe('The ID of the project to move.'),
+    workspaceId: z
+        .string()
+        .min(1)
+        .optional()
+        .describe('The target workspace ID. Required when action is move-to-workspace.'),
+    folderId: z
+        .string()
+        .min(1)
+        .optional()
+        .describe('Optional target folder ID within the workspace.'),
+    visibility: z
+        .enum(['restricted', 'team', 'public'])
+        .optional()
+        .describe(
+            'Optional access visibility for the project in the workspace (restricted, team, or public).',
+        ),
+}
+
+const OutputSchema = {
+    project: ProjectSchema.describe('The moved project.'),
+    success: z.boolean().describe('Whether the move was successful.'),
+}
+
+const projectMove = {
+    name: ToolNames.PROJECT_MOVE,
+    description: 'Move a project between personal and workspace contexts.',
+    parameters: ArgsSchema,
+    outputSchema: OutputSchema,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    async execute(args, client) {
+        let project: PersonalProject | WorkspaceProject
+
+        if (args.action === 'move-to-workspace') {
+            if (!args.workspaceId) {
+                throw new Error('workspaceId is required when action is move-to-workspace')
+            }
+
+            const moveArgs: MoveProjectToWorkspaceArgs = {
+                projectId: args.projectId,
+                workspaceId: args.workspaceId,
+            }
+
+            if (args.folderId) {
+                moveArgs.folderId = args.folderId
+            }
+
+            if (args.visibility) {
+                moveArgs.access = { visibility: args.visibility }
+            }
+
+            project = await client.moveProjectToWorkspace(moveArgs)
+        } else {
+            project = await client.moveProjectToPersonal({ projectId: args.projectId })
+        }
+
+        const mappedProject = mapProject(project)
+
+        const actionText =
+            args.action === 'move-to-workspace' ? 'Moved to workspace' : 'Moved to personal'
+
+        return {
+            textContent: `${actionText}: ${mappedProject.name} (id=${mappedProject.id})`,
+            structuredContent: {
+                project: mappedProject,
+                success: true,
+            },
+        }
+    },
+} satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
+
+export { projectMove }

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -19,6 +19,7 @@ export const ToolNames = {
     UPDATE_PROJECTS: 'update-projects',
     FIND_PROJECTS: 'find-projects',
     PROJECT_MANAGEMENT: 'project-management',
+    PROJECT_MOVE: 'project-move',
 
     // Section management tools
     ADD_SECTIONS: 'add-sections',


### PR DESCRIPTION
## Summary

- Adds a new `project-move` tool that uses the SDK's `moveProjectToWorkspace` and `moveProjectToPersonal` methods
- Bumps `@doist/todoist-api-typescript` from 6.4.0 to 6.5.0 to access the new move APIs
- Supports optional `folderId` and `visibility` parameters when moving to a workspace
- Registers the tool in the MCP server and adds it to the run-tool CLI script

Inspired by [todoist-cli PR #72](https://github.com/Doist/todoist-cli/pull/72).

## Test plan

- [x] 8 new tests covering all move scenarios (workspace with/without folder/visibility, personal, missing workspaceId error, error propagation)
- [x] All 432 tests pass
- [x] TypeScript type-check passes
- [x] Biome lint/format passes
- [x] Schema validation passes (24 tools, 70 parameters, Gemini compatible)
- [x] `project-move` appears in `run-tool.ts --list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)