### PR TITLE
chore: Stops renovate updating to newer major node versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,7 @@
         },
         {
             "matchPackageNames": ["@types/node"],
-            "allowedVersions": "< 23"        
+            "allowedVersions": "< 23"
         }
     ],
     "vulnerabilityAlerts": {


### PR DESCRIPTION
As per the description. basically, if you look at #288, it's trying to update to v24 of `@types/node`, even though we are at 22 in this project. 

<img width="1466" height="542" alt="CleanShot 2026-02-28 at 22 17 56@2x" src="https://github.com/user-attachments/assets/91a87b32-d5bf-4cb6-98f5-41486a6688c7" />
