### PR TITLE
chore: Clarify assignee scoping guidance in query tools

### DIFF
--- a/src/tools/find-completed-tasks.ts
+++ b/src/tools/find-completed-tasks.ts
@@ -40,7 +40,7 @@ const ArgsSchema = {
         .string()
         .optional()
         .describe(
-            'Find tasks assigned to this user. Can be a user ID, name, or email address. Defaults to all collaborators when omitted.',
+            'Filter completed tasks assigned to this user. User ID, name, or email. For personal queries (summaries, plans, reports), set to current user from user-info to exclude collaborators. Defaults to all collaborators.',
         ),
 
     limit: z
@@ -72,7 +72,7 @@ const OutputSchema = {
 const findCompletedTasks = {
     name: ToolNames.FIND_COMPLETED_TASKS,
     description:
-        'Get completed tasks (includes all collaborators by default—use responsibleUser to narrow).',
+        'Get completed tasks. Includes all collaborators by default. Person-specific queries (summaries, plans, reports) require responsibleUser.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },

--- a/src/tools/find-tasks-by-date.ts
+++ b/src/tools/find-tasks-by-date.ts
@@ -58,12 +58,14 @@ const ArgsSchema = {
     responsibleUser: z
         .string()
         .optional()
-        .describe('Find tasks assigned to this user. Can be a user ID, name, or email address.'),
+        .describe(
+            'Filter tasks assigned to this user. User ID, name, or email. For personal queries (summaries, plans, reports), set to current user from user-info to exclude collaborators.',
+        ),
     responsibleUserFiltering: z
         .enum(RESPONSIBLE_USER_FILTERING)
         .optional()
         .describe(
-            'How to filter by responsible user when responsibleUser is not provided. "assigned" = only tasks assigned to others; "unassignedOrMe" = only unassigned tasks or tasks assigned to me; "all" = all tasks regardless of assignment. Default is "unassignedOrMe".',
+            "Filter when responsibleUser is omitted. 'assigned'=assigned to others; 'unassignedOrMe'=unassigned+mine; 'all'=everyone. Default: 'unassignedOrMe'.",
         ),
     ...LabelsSchema,
 }
@@ -81,7 +83,7 @@ const OutputSchema = {
 const findTasksByDate = {
     name: ToolNames.FIND_TASKS_BY_DATE,
     description:
-        "Get tasks by date range. Use startDate 'today' to get today's tasks including overdue items, or provide a specific date/date range.",
+        "Get tasks by date range. startDate='today' includes overdue items. Default responsibleUserFiltering='unassignedOrMe' excludes others' tasks. Person-specific queries (summaries, plans, reports) require responsibleUser.",
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },


### PR DESCRIPTION
## Short description

This updates assignee-scoping wording for `find-tasks-by-date` and `find-completed-tasks` (tool descriptions + `responsibleUser` / `responsibleUserFiltering` parameter descriptions).

This tweaked formulation improves accuracy in some internal usage scenarios while keeping tool behavior and surface area unchanged.

## PR Checklist

-   [x] Added tests for bugs / new features
-   [x] Updated docs (README, etc.) -- N/A
-   [x] New tools added to `getMcpServer` AND exported in `src/index.ts` -- N/A
