### PR TITLE
fix: clarify priority input format in task tools

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -59,8 +59,8 @@ You have access to comprehensive Todoist management tools for personal productiv
 ### Tool Usage Guidelines:
 
 **Task Management:**
-- **add-tasks**: Create tasks with content, description, priority (p1=highest, p2=high, p3=medium, p4=lowest/default), dueString (natural language like "tomorrow", "next Friday", "2024-12-25"), deadlineDate (ISO 8601 format like "2025-12-31" for immovable constraints), duration (formats like "2h", "90m", "2h30m"), and assignments to project collaborators
-- **update-tasks**: Modify existing tasks - get task IDs from search results first, only include fields that need changes. Supports deadlineDate (ISO 8601 format like "2025-12-31") updates and removals (use "remove" to clear)
+- **add-tasks**: Create tasks with content, description, priority (\`p1\`, \`p2\`, \`p3\`, \`p4\` strings only; \`p1\` highest and \`p4\` lowest/default; integers are not accepted), dueString (natural language like "tomorrow", "next Friday", "2024-12-25"), deadlineDate (ISO 8601 format like "2025-12-31" for immovable constraints), duration (formats like "2h", "90m", "2h30m"), and assignments to project collaborators
+- **update-tasks**: Modify existing tasks - get task IDs from search results first, only include fields that need changes. Supports priority updates using \`p1\`/\`p2\`/\`p3\`/\`p4\` string values (\`p1\` highest, \`p4\` lowest/default; integers are not accepted), plus deadlineDate (ISO 8601 format like "2025-12-31") updates and removals (use "remove" to clear)
 - **complete-tasks**: Mark tasks as done using task IDs
 - **find-tasks**: Search by text, project/section/parent container, responsible user, or labels. Requires at least one search parameter
 - **find-tasks-by-date**: Get tasks by date range (startDate: YYYY-MM-DD or 'today' which includes overdue tasks) or specific day counts

--- a/src/tools/add-tasks.ts
+++ b/src/tools/add-tasks.ts
@@ -5,7 +5,11 @@ import { mapTask, resolveInboxProjectId } from '../tool-helpers.js'
 import { assignmentValidator } from '../utils/assignment-validator.js'
 import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
 import { TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
-import { convertPriorityToNumber, PrioritySchema } from '../utils/priorities.js'
+import {
+    convertPriorityToNumber,
+    PRIORITY_INPUT_DESCRIPTION,
+    PrioritySchema,
+} from '../utils/priorities.js'
 import { summarizeTaskOperation } from '../utils/response-builders.js'
 import { ToolNames } from '../utils/tool-names.js'
 
@@ -22,9 +26,7 @@ const TaskSchema = z.object({
         .describe(
             'Additional details, notes, or context for the task. Use this for longer content rather than putting it in the task name. Supports Markdown.',
         ),
-    priority: PrioritySchema.optional().describe(
-        'The priority of the task: p1 (highest), p2 (high), p3 (medium), p4 (lowest/default).',
-    ),
+    priority: PrioritySchema.optional().describe(PRIORITY_INPUT_DESCRIPTION),
     dueString: z.string().optional().describe('The due date for the task, in natural language.'),
     deadlineDate: z
         .string()

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -5,7 +5,11 @@ import { createMoveTaskArgs, mapTask, resolveInboxProjectId } from '../tool-help
 import { assignmentValidator } from '../utils/assignment-validator.js'
 import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
 import { TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
-import { convertPriorityToNumber, PrioritySchema } from '../utils/priorities.js'
+import {
+    convertPriorityToNumber,
+    PRIORITY_INPUT_DESCRIPTION,
+    PrioritySchema,
+} from '../utils/priorities.js'
 import { summarizeTaskOperation } from '../utils/response-builders.js'
 import { ToolNames } from '../utils/tool-names.js'
 
@@ -32,9 +36,7 @@ const TasksUpdateSchema = z.object({
     sectionId: z.string().optional().describe('The new section ID for the task.'),
     parentId: z.string().optional().describe('The new parent task ID (for subtasks).'),
     order: z.number().optional().describe('The new order of the task within its parent/section.'),
-    priority: PrioritySchema.optional().describe(
-        'The new priority of the task: p1 (highest), p2 (high), p3 (medium), p4 (lowest/default).',
-    ),
+    priority: PrioritySchema.optional().describe(PRIORITY_INPUT_DESCRIPTION),
     dueString: z
         .string()
         .optional()

--- a/src/utils/priorities.ts
+++ b/src/utils/priorities.ts
@@ -3,9 +3,10 @@ import { z } from 'zod'
 const PRIORITY_VALUES = ['p1', 'p2', 'p3', 'p4'] as const
 export type Priority = (typeof PRIORITY_VALUES)[number]
 
-export const PrioritySchema = z
-    .enum(PRIORITY_VALUES)
-    .describe('Task priority: p1 (highest), p2 (high), p3 (medium), p4 (lowest/default)')
+export const PRIORITY_INPUT_DESCRIPTION =
+    'Task priority as a string: "p1" (highest), "p2" (high), "p3" (medium), or "p4" (lowest/default). Integers like 1, 2, 3, or 4 are not accepted.'
+
+export const PrioritySchema = z.enum(PRIORITY_VALUES).describe(PRIORITY_INPUT_DESCRIPTION)
 
 export function convertPriorityToNumber(priority: Priority): number {
     // Todoist API uses inverse mapping: p1=4 (highest), p2=3, p3=2, p4=1 (lowest)


### PR DESCRIPTION
# Pull Request

Closes #338

## Short description

Clarifies priority input format before execution errors by documenting that accepted values are the strings `p1`, `p2`, `p3`, and `p4` (`p1` highest, `p4` lowest/default).
Reuses a shared `PRIORITY_INPUT_DESCRIPTION` in `add-tasks` and `update-tasks` schema metadata, and updates MCP server guidance text to explicitly state that integer inputs are not accepted.

