### PR TITLE
docs: add AGENTS/CONTRIBUTING and improve run-tool docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# Todoist AI MCP Server - Development Guidelines
+
+## Tool Schema Design Rules
+
+### Removing/Clearing Optional Fields
+
+When you need to support clearing an optional field:
+
+1. **Use a special string value** (not `null` - avoids LLM provider compatibility issues, with Gemini in particular)
+   - For assignments: use `"unassign"`
+   - For other fields: use `"remove"` or similar descriptive string
+
+2. **Handle both legacy and new patterns in runtime logic** for backward compatibility:
+   ```typescript
+   if (fieldValue === null || fieldValue === 'remove') {
+       // Convert to null for API call
+       updateArgs = { ...updateArgs, fieldName: null }
+   }
+   ```
+
+3. **Update schema description** to document the special string value
+
+### Examples from Codebase
+
+- **PR #181**: Fixed `responsibleUser` field - changed from `.nullable()` to using `"unassign"` string
+- **Latest commit**: Fixed `deadlineDate` field - changed from `.nullable()` to using `"remove"` string
+
+### Why This Matters
+
+- Ensures compatibility with **all LLM providers** (OpenAI, Anthropic, Gemini, etc.)
+- Maintains backward compatibility through dual handling
+- Creates self-documenting APIs with explicit action strings
+
+## Testing Requirements
+
+When adding new tool parameters:
+
+1. Add comprehensive test coverage for new fields
+2. Test setting values
+3. Test clearing values (if applicable)
+4. Verify build and type checking pass
+5. Run full test suite (all 333+ tests must pass)
+
+## Documentation Requirements
+
+When adding new tool features:
+
+1. Update tool schema descriptions in the source file
+2. Update `src/mcp-server.ts` tool usage guidelines
+3. Add tests demonstrating the feature
+4. Include examples in descriptions where helpful
+
+## Running Tools Directly
+
+Use `scripts/run-tool.ts` to execute any tool without the MCP server:
+
+```bash
+npx tsx scripts/run-tool.ts <tool-name> '<json-args>'
+npx tsx scripts/run-tool.ts --list  # list all tools
+```
+
+Examples:
+```bash
+npx tsx scripts/run-tool.ts add-tasks '{"tasks":[{"content":"Test task"}]}'
+npx tsx scripts/run-tool.ts find-tasks '{"query":"meeting"}'
+npx tsx scripts/run-tool.ts get-overview '{}'
+```
+
+Requires `TODOIST_API_KEY` in `.env` (and optionally `TODOIST_BASE_URL`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing
+
+## Development Setup
+
+For full local setup instructions (dependencies, `.env`, and MCP inspector workflow), see [docs/dev-setup.md](docs/dev-setup.md).
+
+## Run Tools Directly (Without MCP)
+
+Use `scripts/run-tool.ts` to execute tools directly during development.
+When using `npm run tool`, include `--` before tool arguments so npm forwards them to `scripts/run-tool.ts`.
+
+`run-tool` authenticates with `TODOIST_API_KEY` from your `.env` file (created from `.env.example` via `npm run setup`).
+Use a test account or a temporary project for write operations so you do not modify real Todoist data.
+Before running write tools, you can verify which Todoist account is connected:
+`npm run tool -- user-info '{}'`
+
+```sh
+npm run tool:list
+npm run tool -- <tool-name> '<json-args>'
+npm run tool -- <tool-name> --file <args.json>
+```
+
+Examples:
+
+```sh
+npm run tool -- add-tasks '{"tasks":[{"content":"Test task"}]}'
+npm run tool -- find-tasks '{"query":"meeting"}'
+npm run tool -- get-overview '{}'
+```
+
+## Quality Checks
+
+Run these before opening a PR:
+
+- `npm run test`
+- `npm run type-check`
+- `npm run check`
+
+## Tool Changes
+
+When adding or changing tool behavior:
+
+1. Update tool schema descriptions in the source file.
+2. Update `src/mcp-server.ts` guidance when relevant.
+3. Add or update tests covering the change.
+4. Include usage examples where helpful.
+
+## Commit Conventions
+
+This repository uses Conventional Commits:
+
+- `feat:` new features
+- `fix:` bug fixes
+- `feat!:` or `fix!:` breaking changes
+- `docs:` documentation
+- `chore:` maintenance
+- `ci:` CI changes

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Ernesto García
+Copyright (c) 2025 Doist
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ See [docs/mcp-server.md](docs/mcp-server.md) for full instructions on setting up
 
 ## Local Development Setup
 
-See [docs/dev-setup.md](docs/dev-setup.md) for full instructions on setting up this repository locally for development and contributing.
+See [docs/dev-setup.md](docs/dev-setup.md) for full setup instructions and [CONTRIBUTING.md](CONTRIBUTING.md) for contributor workflows and quality checks.
 
 ### Widgets
 
@@ -166,6 +166,25 @@ After cloning and setting up the repository:
 
 - `npm start` - Build and run the MCP inspector for testing
 - `npm run dev` - Development mode with auto-rebuild and restart
+- `npm run tool:list` - List available tools for direct execution
+- `npm run tool -- <tool-name> '<json-args>'` - Run a tool directly without MCP
+
+When using `npm run tool`, include `--` before tool arguments so npm forwards them to `scripts/run-tool.ts`.
+
+Example check before write operations:
+`npm run tool -- user-info '{}'`
+This confirms which Todoist account the current `TODOIST_API_KEY` is connected to.
+
+`run-tool` uses `TODOIST_API_KEY` from your `.env` file (created from `.env.example` by `npm run setup`). Use a test account or a temporary project when running write operations to avoid modifying real data.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for:
+
+- Development workflow
+- Running tools directly with `scripts/run-tool.ts`
+- Testing and quality checks
+- Commit conventions
 
 ## Releasing
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "!dist/dev",
         "scripts",
         "package.json",
-        "LICENSE.txt",
+        "LICENSE",
         "README.md"
     ],
     "license": "MIT",
@@ -40,6 +40,8 @@
         "start:http": "npm run build && node dist/main-http.js",
         "dev:widget": "vite build --watch --minify false",
         "setup": "cp .env.example .env && npm install && npm run build",
+        "tool": "tsx scripts/run-tool.ts",
+        "tool:list": "tsx scripts/run-tool.ts --list",
         "test:executable": "npm run build && node scripts/test-executable.cjs",
         "type-check": "npx tsc --noEmit",
         "biome:sort-imports": "biome check --formatter-enabled=false --linter-enabled=false --organize-imports-enabled=true --write .",


### PR DESCRIPTION
## Summary
- add `AGENTS.md` mirroring existing `CLAUDE.md` guidance
- add `CONTRIBUTING.md` with contributor workflow, quality checks, and direct tool usage
- improve `README.md` discoverability for `run-tool` and add safety guidance
- add canonical `LICENSE` file (no extension), remove `LICENSE.txt`, and set copyright holder to Doist
- add `npm run tool` and `npm run tool:list` scripts for direct tool execution

## Notes
- use `npm run tool -- ...` so npm forwards args to the script
- verify account/token before writes with: `npm run tool -- user-info '{}'`

## Validation
- pre-push hook ran and passed tests (`vitest`: 32 files, 454 tests)
