### PR TITLE
docs: fix find-tasks argument in examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ npx tsx scripts/run-tool.ts --list  # list all tools
 Examples:
 ```bash
 npx tsx scripts/run-tool.ts add-tasks '{"tasks":[{"content":"Test task"}]}'
-npx tsx scripts/run-tool.ts find-tasks '{"query":"meeting"}'
+npx tsx scripts/run-tool.ts find-tasks '{"searchText":"meeting"}'
 npx tsx scripts/run-tool.ts get-overview '{}'
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ npx tsx scripts/run-tool.ts --list  # list all tools
 Examples:
 ```bash
 npx tsx scripts/run-tool.ts add-tasks '{"tasks":[{"content":"Test task"}]}'
-npx tsx scripts/run-tool.ts find-tasks '{"query":"meeting"}'
+npx tsx scripts/run-tool.ts find-tasks '{"searchText":"meeting"}'
 npx tsx scripts/run-tool.ts get-overview '{}'
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Examples:
 
 ```sh
 npm run tool -- add-tasks '{"tasks":[{"content":"Test task"}]}'
-npm run tool -- find-tasks '{"query":"meeting"}'
+npm run tool -- find-tasks '{"searchText":"meeting"}'
 npm run tool -- get-overview '{}'
 ```
 

--- a/scripts/run-tool.ts
+++ b/scripts/run-tool.ts
@@ -9,7 +9,7 @@
  *
  * Examples:
  *   npx tsx scripts/run-tool.ts add-tasks '{"tasks":[{"content":"Test task","order":1}]}'
- *   npx tsx scripts/run-tool.ts find-tasks '{"query":"meeting"}'
+ *   npx tsx scripts/run-tool.ts find-tasks '{"searchText":"meeting"}'
  *   npx tsx scripts/run-tool.ts get-overview '{}'
  *
  * Requires TODOIST_API_KEY in .env file (and optionally TODOIST_BASE_URL).


### PR DESCRIPTION
## Short description

Updated `find-tasks` examples to use `searchText` instead of `query` in `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, and the header examples in `scripts/run-tool.ts`.
This matches the actual tool schema and prevents the validation error users hit when running the old example.
