### PR TITLE
feat: add file attachment support to add-comments

### DIFF
--- a/src/tools/__tests__/add-comments.test.ts
+++ b/src/tools/__tests__/add-comments.test.ts
@@ -8,6 +8,7 @@ import { addComments } from '../add-comments.js'
 const mockTodoistApi = {
     addComment: vi.fn(),
     getUser: vi.fn(),
+    uploadFile: vi.fn(),
 } as unknown as Mocked<TodoistApi>
 
 const { ADD_COMMENTS } = ToolNames
@@ -292,6 +293,73 @@ describe(`${ADD_COMMENTS} tool`, () => {
                     addedCommentIds: ['55555', '66666'],
                 }),
             )
+        })
+    })
+
+    describe('file attachments', () => {
+        it('should upload file and attach to comment when filePath is provided', async () => {
+            const mockUpload = {
+                fileUrl: 'https://cdn.todoist.com/uploads/test.pdf',
+                fileName: 'invoice.pdf',
+                fileType: 'application/pdf',
+                resourceType: 'file',
+            }
+
+            mockTodoistApi.uploadFile.mockResolvedValue(mockUpload)
+
+            const mockComment = createMockComment({
+                id: '77777',
+                content: 'See attached invoice',
+                taskId: 'task123',
+            })
+            mockTodoistApi.addComment.mockResolvedValue(mockComment)
+
+            await addComments.execute(
+                {
+                    comments: [
+                        {
+                            taskId: 'task123',
+                            content: 'See attached invoice',
+                            filePath: '/path/to/invoice.pdf',
+                        },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.uploadFile).toHaveBeenCalledWith({
+                file: '/path/to/invoice.pdf',
+            })
+            expect(mockTodoistApi.addComment).toHaveBeenCalledWith({
+                content: 'See attached invoice',
+                taskId: 'task123',
+                attachment: {
+                    fileUrl: 'https://cdn.todoist.com/uploads/test.pdf',
+                    fileName: 'invoice.pdf',
+                    fileType: 'application/pdf',
+                    resourceType: 'file',
+                },
+            })
+        })
+
+        it('should not upload file when filePath is not provided', async () => {
+            const mockComment = createMockComment({
+                id: '88888',
+                content: 'No attachment',
+                taskId: 'task456',
+            })
+            mockTodoistApi.addComment.mockResolvedValue(mockComment)
+
+            await addComments.execute(
+                { comments: [{ taskId: 'task456', content: 'No attachment' }] },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.uploadFile).not.toHaveBeenCalled()
+            expect(mockTodoistApi.addComment).toHaveBeenCalledWith({
+                content: 'No attachment',
+                taskId: 'task456',
+            })
         })
     })
 

--- a/src/tools/add-comments.ts
+++ b/src/tools/add-comments.ts
@@ -14,6 +14,12 @@ const CommentSchema = z.object({
             'The ID of the project to comment on. Project ID should be an ID string, or the text "inbox", for inbox tasks.',
         ),
     content: z.string().min(1).describe('The content of the comment.'),
+    filePath: z
+        .string()
+        .optional()
+        .describe(
+            'Absolute path to a file to attach to the comment. The file will be uploaded to Todoist and attached to the comment.',
+        ),
 })
 
 const ArgsSchema = {
@@ -54,19 +60,37 @@ const addComments = {
         const needsInboxResolution = comments.some((comment) => isInboxProjectId(comment.projectId))
         const todoistUser = needsInboxResolution ? await client.getUser() : undefined
 
-        const addCommentPromises = comments.map(async ({ content, taskId, projectId }) => {
-            // Resolve "inbox" to actual inbox project ID if needed
-            const resolvedProjectId = await resolveInboxProjectId({
-                projectId,
-                user: todoistUser,
-                client: todoistUser ? undefined : client,
-            })
+        const addCommentPromises = comments.map(
+            async ({ content, taskId, projectId, filePath }) => {
+                // Resolve "inbox" to actual inbox project ID if needed
+                const resolvedProjectId = await resolveInboxProjectId({
+                    projectId,
+                    user: todoistUser,
+                    client: todoistUser ? undefined : client,
+                })
 
-            return await client.addComment({
-                content,
-                ...(taskId ? { taskId } : { projectId: resolvedProjectId }),
-            } as AddCommentArgs)
-        })
+                // Upload file and create attachment if filePath is provided
+                let attachment: AddCommentArgs['attachment'] | undefined
+                if (filePath) {
+                    const upload = await client.uploadFile({ file: filePath })
+                    if (!upload.fileUrl) {
+                        throw new Error(`File upload failed for: ${filePath}`)
+                    }
+                    attachment = {
+                        fileUrl: upload.fileUrl,
+                        fileName: upload.fileName ?? undefined,
+                        fileType: upload.fileType ?? undefined,
+                        resourceType: upload.resourceType,
+                    }
+                }
+
+                return await client.addComment({
+                    content,
+                    ...(taskId ? { taskId } : { projectId: resolvedProjectId }),
+                    ...(attachment ? { attachment } : {}),
+                } as AddCommentArgs)
+            },
+        )
 
         const newComments = await Promise.all(addCommentPromises)
         const mappedComments = newComments.map(mapComment)


### PR DESCRIPTION
## Summary
- Adds optional `filePath` parameter to the `add-comments` tool
- When provided, the file is uploaded via the existing `uploadFile()` API and attached to the comment
- The `@doist/todoist-api-typescript` client already supports both `uploadFile()` and the `attachment` field on `AddCommentArgs` — this simply exposes that capability through the MCP tool

## Use case
AI agents managing tasks (e.g. filing invoices, attaching documents) can now attach files directly to Todoist comments, rather than only providing text references to files stored elsewhere.

## Changes
- `src/tools/add-comments.ts` — added `filePath` field to `CommentSchema`, upload logic in `execute`
- `src/tools/__tests__/add-comments.test.ts` — 2 new tests for attachment upload + no-attachment case

## Test plan
- [x] All 468 existing tests pass
- [x] 2 new tests for file attachment flow
- [x] Type checking passes
- [x] Build succeeds