### PR TITLE
fix: skip auto-review-request workflow for fork PRs

### DIFF
--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -10,7 +10,8 @@ jobs:
     if: |
       !github.event.pull_request.draft &&
       github.actor != 'dependabot[bot]' &&
-      github.actor != 'renovate[bot]'
+      github.actor != 'renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Automatically request reviews from Frontend Product
         uses: doist/auto-request-reviews-action@v1


### PR DESCRIPTION
## Summary
- Skip the `request-reviews.yml` workflow for fork PRs by checking `github.event.pull_request.head.repo.full_name == github.repository`
- Fork PRs don't have access to `secrets.GH_PROJECTS_TOKEN`, causing the workflow to fail with `Input required and not supplied: token`
- Requesting reviews from `Doist/frontend-product` doesn't apply to external contributors (maybe, will need to discuss this)

## Test plan
- [ ] Verify internal PRs still trigger the auto-review-request workflow
- [ ] Verify fork PRs skip the workflow cleanly instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)