### PR TITLE
chore(deps): update @doist/todoist-api-typescript to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "7.11.2",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-api-typescript": "6.10.0",
+                "@doist/todoist-api-typescript": "7.0.0",
                 "date-fns": "4.1.0",
                 "dompurify": "3.3.1",
                 "dotenv": "17.3.1",
@@ -261,9 +261,9 @@
             }
         },
         "node_modules/@doist/todoist-api-typescript": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-6.10.0.tgz",
-            "integrity": "sha512-obSwvJLSA4/8Sw6xbse8OL+Oq7l//+JtwtVissTEZ/9NTjRrdS/jqykgaiviW1wHUWZWf1LY7RVDKfRjCzaghA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-7.0.0.tgz",
+            "integrity": "sha512-TUO0nG1AK1miiTNvOS8HyvCC3neHZBoK84Nq4uRCV9KsN/PJv21DkIqop9GhaYBSSZ4jHHuAMj8nzCwcONeeMw==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-api-typescript": "6.10.0",
+        "@doist/todoist-api-typescript": "7.0.0",
         "date-fns": "4.1.0",
         "dompurify": "3.3.1",
         "dotenv": "17.3.1",

--- a/src/tools/__tests__/find-activity.test.ts
+++ b/src/tools/__tests__/find-activity.test.ts
@@ -126,7 +126,7 @@ describe(`${FIND_ACTIVITY} tool`, () => {
             )
 
             expect(mockTodoistApi.getActivityLogs).toHaveBeenCalledWith({
-                objectType,
+                objectEventTypes: `${objectType}:`,
                 limit: 20,
                 cursor: null,
             })
@@ -170,7 +170,7 @@ describe(`${FIND_ACTIVITY} tool`, () => {
             )
 
             expect(mockTodoistApi.getActivityLogs).toHaveBeenCalledWith({
-                eventType,
+                objectEventTypes: `:${eventType}`,
                 limit: 20,
                 cursor: null,
             })
@@ -233,8 +233,7 @@ describe(`${FIND_ACTIVITY} tool`, () => {
             )
 
             expect(mockTodoistApi.getActivityLogs).toHaveBeenCalledWith({
-                objectType: 'task',
-                eventType: 'completed',
+                objectEventTypes: 'task:completed',
                 parentProjectId: 'project-work',
                 initiatorId: 'user-bob',
                 limit: 50,

--- a/src/tools/__tests__/find-projects.test.ts
+++ b/src/tools/__tests__/find-projects.test.ts
@@ -30,7 +30,7 @@ describe(`${FIND_PROJECTS} tool`, () => {
                 createMockProject({
                     id: TEST_IDS.PROJECT_INBOX,
                     name: 'Inbox',
-                    color: 'gray',
+                    color: 'grey',
                     inboxProject: true,
                     childOrder: 0,
                 }),
@@ -226,8 +226,8 @@ describe(`${FIND_PROJECTS} tool`, () => {
     })
 
     describe('unrecognised color values (issue #343)', () => {
-        // Todoist's API returns color values such as "grey" that are not present in the
-        // 20-key ColorKeySchema enum.  Before this fix both failure modes below would occur:
+        // The Todoist API may return color values not present in the ColorKeySchema enum.
+        // Before this fix both failure modes below would occur:
         //   1. Full list  → loud MCP output-validation error (-32602) when the MCP SDK
         //      validates structuredContent against the outputSchema
         //   2. Name search → silent empty result set (swallowed validation error)
@@ -240,12 +240,12 @@ describe(`${FIND_PROJECTS} tool`, () => {
 
         describe('ColorOutputSchema tolerance', () => {
             it('should coerce an unrecognised color value to undefined', () => {
-                expect(ColorOutputSchema.parse('grey')).toBeUndefined()
+                expect(ColorOutputSchema.parse('gray')).toBeUndefined()
                 expect(ColorOutputSchema.parse('unknown-color')).toBeUndefined()
             })
 
             it('should pass through recognised color values unchanged', () => {
-                expect(ColorOutputSchema.parse('gray')).toBe('gray')
+                expect(ColorOutputSchema.parse('grey')).toBe('grey')
                 expect(ColorOutputSchema.parse('blue')).toBe('blue')
                 expect(ColorOutputSchema.parse('charcoal')).toBe('charcoal')
             })
@@ -254,7 +254,7 @@ describe(`${FIND_PROJECTS} tool`, () => {
                 const project = {
                     id: 'proj-1',
                     name: 'Inbox',
-                    color: 'grey', // unrecognised
+                    color: 'gray', // unrecognised
                     isFavorite: false,
                     isShared: false,
                     inboxProject: true,
@@ -271,7 +271,7 @@ describe(`${FIND_PROJECTS} tool`, () => {
                 const project = {
                     id: 'proj-1',
                     name: 'Inbox',
-                    color: 'grey',
+                    color: 'gray',
                     isFavorite: false,
                     isShared: false,
                     inboxProject: true,
@@ -282,13 +282,12 @@ describe(`${FIND_PROJECTS} tool`, () => {
         })
 
         it('should succeed for a full list when a project has an unrecognised color', async () => {
-            // "grey" is returned by the Todoist API but is not in the 20-key color enum.
-            // Before the fix, the MCP SDK's output validation would throw -32602 here.
+            // An unrecognised color value should not cause output-validation to throw -32602.
             const mockProjects = [
                 createMockProject({
                     id: TEST_IDS.PROJECT_INBOX,
                     name: 'Inbox',
-                    color: 'grey' as unknown as ColorKey,
+                    color: 'gray' as unknown as ColorKey,
                     inboxProject: true,
                 }),
                 createMockProject({ id: TEST_IDS.PROJECT_WORK, name: 'Work', color: 'blue' }),
@@ -310,7 +309,7 @@ describe(`${FIND_PROJECTS} tool`, () => {
             const matchingProject = createMockProject({
                 id: TEST_IDS.PROJECT_INBOX,
                 name: 'Inbox',
-                color: 'grey' as unknown as ColorKey,
+                color: 'gray' as unknown as ColorKey,
                 inboxProject: true,
             })
 

--- a/src/tools/__tests__/get-overview.test.ts
+++ b/src/tools/__tests__/get-overview.test.ts
@@ -31,7 +31,7 @@ describe(`${GET_OVERVIEW} tool`, () => {
                 createMockProject({
                     id: TEST_IDS.PROJECT_INBOX,
                     name: 'Inbox',
-                    color: 'gray',
+                    color: 'grey',
                     inboxProject: true,
                     childOrder: 0,
                 }),

--- a/src/tools/find-activity.ts
+++ b/src/tools/find-activity.ts
@@ -80,9 +80,10 @@ const findActivity = {
         }
 
         // Add optional filters
-        if (objectType) apiArgs.objectType = objectType
+        if (objectType && eventType) apiArgs.objectEventTypes = `${objectType}:${eventType}`
+        else if (objectType) apiArgs.objectEventTypes = `${objectType}:`
+        else if (eventType) apiArgs.objectEventTypes = `:${eventType}`
         if (objectId && objectId !== 'remove') apiArgs.objectId = objectId
-        if (eventType) apiArgs.eventType = eventType
         if (projectId) apiArgs.parentProjectId = projectId
         if (taskId) apiArgs.parentItemId = taskId
         if (initiatorId) apiArgs.initiatorId = initiatorId

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -27,8 +27,7 @@ export const ColorSchema = z
 export const ColorKeySchema = z.enum(colorKeys).describe('The color key of the entity.')
 
 // For OUTPUT (tolerant): accepts valid color keys and silently coerces unrecognised values
-// (e.g. "grey" returned by the Todoist API instead of the expected "gray") to undefined
-// instead of raising a validation error.  Fixes both failure modes described in issue #343:
+// to undefined instead of raising a validation error.  Fixes both failure modes described in issue #343:
 //   1. Full list — loud MCP output-validation error (-32602)
 //   2. Name search — silent empty result set due to swallowed validation error
 // This is the output-side counterpart to ColorSchema, which uses .preprocess()/.catch() for

--- a/src/utils/test-helpers.ts
+++ b/src/utils/test-helpers.ts
@@ -31,8 +31,6 @@ export function createMockTask({
         sectionId: null,
         parentId: null,
         url: 'https://todoist.com/showTask?id=8485093748',
-        // Use correct property names from Task schema
-        noteCount: 0,
         addedByUid: '713437',
         addedAt: '2025-08-13T22:09:56.123456Z',
         deadline: null,


### PR DESCRIPTION
## Summary

- Updates `@doist/todoist-api-typescript` from 6.10.0 to 7.0.0
- Migrates `find-activity` from removed `objectType`/`eventType` API params to the new `objectEventTypes` combined format (e.g. `"task:completed"`, `"task:"`, `":completed"`)
- Removes `noteCount` from mock task fixture (field removed from `Task` type in v7)
- Updates color key references: `gray` → `grey` and `turquoise` → `teal` (renamed in v7 to match Todoist backend)
- Adjusts unrecognised-color tests to use `gray` (now removed) as the unrecognised example, since `grey` is now a valid key

## Test plan

- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] Full test suite passes (466 tests)
- [x] Biome lint/format check passes (`npm run check`)
- [x] Schema validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)