### PR TITLE
fix: use human-readable textContent in search and fetch tools

### DIFF
--- a/src/tools/__tests__/fetch.test.ts
+++ b/src/tools/__tests__/fetch.test.ts
@@ -44,9 +44,8 @@ describe(`${FETCH} tool`, () => {
             // Verify API was called correctly
             expect(mockTodoistApi.getTask).toHaveBeenCalledWith(TEST_IDS.TASK_1)
 
-            // Parse the JSON response
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse).toEqual({
+            // Verify structured content
+            expect(result.structuredContent).toMatchObject({
                 id: `task:${TEST_IDS.TASK_1}`,
                 title: 'Important meeting with team',
                 text: 'Important meeting with team\n\nDescription: Discuss project roadmap and timeline\nDue: 2025-10-15\nLabels: work, urgent',
@@ -59,6 +58,11 @@ describe(`${FETCH} tool`, () => {
                     checked: false,
                 },
             })
+
+            // Verify human-readable text
+            expect(result.textContent).toBe(
+                `Fetched task: Important meeting with team • id=task:${TEST_IDS.TASK_1} • url=https://app.todoist.com/app/task/${TEST_IDS.TASK_1}`,
+            )
         })
 
         it('should fetch a task without optional fields', async () => {
@@ -74,10 +78,9 @@ describe(`${FETCH} tool`, () => {
 
             const result = await fetch.execute({ id: `task:${TEST_IDS.TASK_2}` }, mockTodoistApi)
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse.title).toBe('Simple task')
-            expect(jsonResponse.text).toBe('Simple task')
-            expect(jsonResponse.metadata).toEqual({
+            expect(result.structuredContent?.title).toBe('Simple task')
+            expect(result.structuredContent?.text).toBe('Simple task')
+            expect(result.structuredContent?.metadata).toMatchObject({
                 priority: 'p4',
                 projectId: TEST_IDS.PROJECT_TEST,
                 recurring: false,
@@ -103,8 +106,7 @@ describe(`${FETCH} tool`, () => {
 
             const result = await fetch.execute({ id: `task:${TEST_IDS.TASK_3}` }, mockTodoistApi)
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse.metadata.recurring).toBe('every monday')
+            expect(result.structuredContent?.metadata?.recurring).toBe('every monday')
         })
 
         it('should handle tasks with duration', async () => {
@@ -121,8 +123,7 @@ describe(`${FETCH} tool`, () => {
 
             const result = await fetch.execute({ id: `task:${TEST_IDS.TASK_1}` }, mockTodoistApi)
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse.metadata.duration).toBe('1h30m')
+            expect(result.structuredContent?.metadata?.duration).toBe('1h30m')
         })
 
         it('should handle tasks with assignments', async () => {
@@ -137,9 +138,8 @@ describe(`${FETCH} tool`, () => {
 
             const result = await fetch.execute({ id: `task:${TEST_IDS.TASK_1}` }, mockTodoistApi)
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse.metadata.responsibleUid).toBe('user-123')
-            expect(jsonResponse.metadata.assignedByUid).toBe('user-456')
+            expect(result.structuredContent?.metadata?.responsibleUid).toBe('user-123')
+            expect(result.structuredContent?.metadata?.assignedByUid).toBe('user-456')
         })
     })
 
@@ -166,9 +166,8 @@ describe(`${FETCH} tool`, () => {
             // Verify API was called correctly
             expect(mockTodoistApi.getProject).toHaveBeenCalledWith(TEST_IDS.PROJECT_WORK)
 
-            // Parse the JSON response
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse).toEqual({
+            // Verify structured content
+            expect(result.structuredContent).toMatchObject({
                 id: `project:${TEST_IDS.PROJECT_WORK}`,
                 title: 'Work Project',
                 text: 'Work Project\n\nShared project\nFavorite: Yes',
@@ -181,6 +180,11 @@ describe(`${FETCH} tool`, () => {
                     viewStyle: 'board',
                 },
             })
+
+            // Verify human-readable text
+            expect(result.textContent).toBe(
+                `Fetched project: Work Project • id=project:${TEST_IDS.PROJECT_WORK} • url=https://app.todoist.com/app/project/${TEST_IDS.PROJECT_WORK}`,
+            )
         })
 
         it('should fetch a project without optional flags', async () => {
@@ -198,11 +202,10 @@ describe(`${FETCH} tool`, () => {
                 mockTodoistApi,
             )
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse.title).toBe('Simple Project')
-            expect(jsonResponse.text).toBe('Simple Project')
-            expect(jsonResponse.metadata.isFavorite).toBe(false)
-            expect(jsonResponse.metadata.isShared).toBe(false)
+            expect(result.structuredContent?.title).toBe('Simple Project')
+            expect(result.structuredContent?.text).toBe('Simple Project')
+            expect(result.structuredContent?.metadata?.isFavorite).toBe(false)
+            expect(result.structuredContent?.metadata?.isShared).toBe(false)
         })
 
         it('should fetch inbox project', async () => {
@@ -219,8 +222,7 @@ describe(`${FETCH} tool`, () => {
                 mockTodoistApi,
             )
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse.metadata.inboxProject).toBe(true)
+            expect(result.structuredContent?.metadata?.inboxProject).toBe(true)
         })
 
         it('should fetch project with parent ID', async () => {
@@ -234,8 +236,7 @@ describe(`${FETCH} tool`, () => {
 
             const result = await fetch.execute({ id: 'project:sub-project-id' }, mockTodoistApi)
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse.metadata.parentId).toBe(TEST_IDS.PROJECT_WORK)
+            expect(result.structuredContent?.metadata?.parentId).toBe(TEST_IDS.PROJECT_WORK)
         })
     })
 
@@ -281,42 +282,61 @@ describe(`${FETCH} tool`, () => {
         })
     })
 
-    describe('OpenAI MCP spec compliance', () => {
-        it('should return valid JSON string in text field', async () => {
-            const mockTask = createMockTask({ id: TEST_IDS.TASK_1, content: 'Test' })
+    describe('human-readable text content', () => {
+        it('should return human-readable text for a task', async () => {
+            const mockTask = createMockTask({ id: TEST_IDS.TASK_1, content: 'Test Task' })
             mockTodoistApi.getTask.mockResolvedValue(mockTask)
 
             const result = await fetch.execute({ id: `task:${TEST_IDS.TASK_1}` }, mockTodoistApi)
 
-            expect(() => JSON.parse(result.textContent ?? '{}')).not.toThrow()
+            expect(result.textContent).toContain('Fetched task:')
+            expect(result.textContent).toContain('Test Task')
+            expect(result.textContent).toContain(`id=task:${TEST_IDS.TASK_1}`)
+            expect(result.textContent).toContain('url=')
         })
 
-        it('should include all required fields (id, title, text, url)', async () => {
-            const mockTask = createMockTask({ id: TEST_IDS.TASK_1, content: 'Test' })
-            mockTodoistApi.getTask.mockResolvedValue(mockTask)
+        it('should return human-readable text for a project', async () => {
+            const mockProject = createMockProject({
+                id: TEST_IDS.PROJECT_WORK,
+                name: 'Test Project',
+            })
+            mockTodoistApi.getProject.mockResolvedValue(mockProject)
 
-            const result = await fetch.execute({ id: `task:${TEST_IDS.TASK_1}` }, mockTodoistApi)
+            const result = await fetch.execute(
+                { id: `project:${TEST_IDS.PROJECT_WORK}` },
+                mockTodoistApi,
+            )
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse).toHaveProperty('id')
-            expect(jsonResponse).toHaveProperty('title')
-            expect(jsonResponse).toHaveProperty('text')
-            expect(jsonResponse).toHaveProperty('url')
-            expect(typeof jsonResponse.id).toBe('string')
-            expect(typeof jsonResponse.title).toBe('string')
-            expect(typeof jsonResponse.text).toBe('string')
-            expect(typeof jsonResponse.url).toBe('string')
+            expect(result.textContent).toContain('Fetched project:')
+            expect(result.textContent).toContain('Test Project')
+            expect(result.textContent).toContain(`id=project:${TEST_IDS.PROJECT_WORK}`)
+            expect(result.textContent).toContain('url=')
         })
 
-        it('should include optional metadata field', async () => {
+        it('should include all required fields (id, title, text, url) in structuredContent', async () => {
             const mockTask = createMockTask({ id: TEST_IDS.TASK_1, content: 'Test' })
             mockTodoistApi.getTask.mockResolvedValue(mockTask)
 
             const result = await fetch.execute({ id: `task:${TEST_IDS.TASK_1}` }, mockTodoistApi)
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse).toHaveProperty('metadata')
-            expect(typeof jsonResponse.metadata).toBe('object')
+            expect(result.structuredContent).toHaveProperty('id')
+            expect(result.structuredContent).toHaveProperty('title')
+            expect(result.structuredContent).toHaveProperty('text')
+            expect(result.structuredContent).toHaveProperty('url')
+            expect(typeof result.structuredContent?.id).toBe('string')
+            expect(typeof result.structuredContent?.title).toBe('string')
+            expect(typeof result.structuredContent?.text).toBe('string')
+            expect(typeof result.structuredContent?.url).toBe('string')
+        })
+
+        it('should include optional metadata field in structuredContent', async () => {
+            const mockTask = createMockTask({ id: TEST_IDS.TASK_1, content: 'Test' })
+            mockTodoistApi.getTask.mockResolvedValue(mockTask)
+
+            const result = await fetch.execute({ id: `task:${TEST_IDS.TASK_1}` }, mockTodoistApi)
+
+            expect(result.structuredContent).toHaveProperty('metadata')
+            expect(typeof result.structuredContent?.metadata).toBe('object')
         })
     })
 })

--- a/src/tools/__tests__/search.test.ts
+++ b/src/tools/__tests__/search.test.ts
@@ -71,29 +71,30 @@ describe(`${SEARCH} tool`, () => {
                 cursor: null,
             })
 
-            // Parse the JSON response
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse).toHaveProperty('results')
-            expect(jsonResponse.results).toHaveLength(3) // 2 tasks + 1 project matching "important"
+            expect(result.structuredContent?.results).toHaveLength(3) // 2 tasks + 1 project matching "important"
 
             // Verify task results
-            expect(jsonResponse.results[0]).toEqual({
+            expect(result.structuredContent?.results[0]).toEqual({
                 id: `task:${TEST_IDS.TASK_1}`,
                 title: 'Important meeting task',
                 url: `https://app.todoist.com/app/task/${TEST_IDS.TASK_1}`,
             })
-            expect(jsonResponse.results[1]).toEqual({
+            expect(result.structuredContent?.results[1]).toEqual({
                 id: `task:${TEST_IDS.TASK_2}`,
                 title: 'Another important item',
                 url: `https://app.todoist.com/app/task/${TEST_IDS.TASK_2}`,
             })
 
             // Verify project result (only "Important Work Project" matches)
-            expect(jsonResponse.results[2]).toEqual({
+            expect(result.structuredContent?.results[2]).toEqual({
                 id: `project:${TEST_IDS.PROJECT_WORK}`,
                 title: 'Important Work Project',
                 url: `https://app.todoist.com/app/project/${TEST_IDS.PROJECT_WORK}`,
             })
+
+            // Verify human-readable text
+            expect(result.textContent).toContain('Found 3 results')
+            expect(result.textContent).toContain('important')
         })
 
         it('should return only matching tasks when no projects match', async () => {
@@ -108,9 +109,8 @@ describe(`${SEARCH} tool`, () => {
 
             const result = await search.execute({ query: 'unique' }, mockTodoistApi)
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse.results).toHaveLength(1)
-            expect(jsonResponse.results[0].id).toBe(`task:${TEST_IDS.TASK_1}`)
+            expect(result.structuredContent?.results).toHaveLength(1)
+            expect(result.structuredContent?.results[0]?.id).toBe(`task:${TEST_IDS.TASK_1}`)
         })
 
         it('should return only matching projects when no tasks match', async () => {
@@ -126,9 +126,8 @@ describe(`${SEARCH} tool`, () => {
 
             const result = await search.execute({ query: 'special' }, mockTodoistApi)
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse.results).toHaveLength(1)
-            expect(jsonResponse.results[0]).toEqual({
+            expect(result.structuredContent?.results).toHaveLength(1)
+            expect(result.structuredContent?.results[0]).toEqual({
                 id: `project:${TEST_IDS.PROJECT_WORK}`,
                 title: 'Special Project Name',
                 url: `https://app.todoist.com/app/project/${TEST_IDS.PROJECT_WORK}`,
@@ -141,8 +140,8 @@ describe(`${SEARCH} tool`, () => {
 
             const result = await search.execute({ query: 'nonexistent' }, mockTodoistApi)
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse.results).toHaveLength(0)
+            expect(result.structuredContent?.results).toHaveLength(0)
+            expect(result.textContent).toBe('No results found for "nonexistent".')
         })
 
         it('should perform case-insensitive project filtering', async () => {
@@ -158,9 +157,8 @@ describe(`${SEARCH} tool`, () => {
 
             const result = await search.execute({ query: 'IMPORTANT' }, mockTodoistApi)
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse.results).toHaveLength(1)
-            expect(jsonResponse.results[0].title).toBe('Important Work')
+            expect(result.structuredContent?.results).toHaveLength(1)
+            expect(result.structuredContent?.results[0]?.title).toBe('Important Work')
         })
 
         it('should handle partial matches in project names', async () => {
@@ -174,10 +172,9 @@ describe(`${SEARCH} tool`, () => {
 
             const result = await search.execute({ query: 'develop' }, mockTodoistApi)
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            expect(jsonResponse.results).toHaveLength(2)
-            expect(jsonResponse.results[0].title).toBe('Development Tasks')
-            expect(jsonResponse.results[1].title).toBe('Developer Resources')
+            expect(result.structuredContent?.results).toHaveLength(2)
+            expect(result.structuredContent?.results[0]?.title).toBe('Development Tasks')
+            expect(result.structuredContent?.results[1]?.title).toBe('Developer Resources')
         })
     })
 
@@ -201,16 +198,33 @@ describe(`${SEARCH} tool`, () => {
         })
     })
 
-    describe('OpenAI MCP spec compliance', () => {
-        it('should return valid JSON string in text field', async () => {
+    describe('human-readable text content', () => {
+        it('should return a human-readable message when no results found', async () => {
             mockGetTasksByFilter.mockResolvedValue({ tasks: [], nextCursor: null })
             mockTodoistApi.searchProjects.mockResolvedValue(createMockApiResponse([]))
 
             const result = await search.execute({ query: 'test' }, mockTodoistApi)
-            expect(() => JSON.parse(result.textContent ?? '{}')).not.toThrow()
+
+            expect(result.textContent).toBe('No results found for "test".')
         })
 
-        it('should include required fields (id, title, url) in each result', async () => {
+        it('should include result count and titles in text content', async () => {
+            const mockTasks = [createMappedTask({ id: TEST_IDS.TASK_1, content: 'Test Task' })]
+            const mockProjects = [
+                createMockProject({ id: TEST_IDS.PROJECT_WORK, name: 'Test Project' }),
+            ]
+
+            mockGetTasksByFilter.mockResolvedValue({ tasks: mockTasks, nextCursor: null })
+            mockTodoistApi.searchProjects.mockResolvedValue(createMockApiResponse(mockProjects))
+
+            const result = await search.execute({ query: 'test' }, mockTodoistApi)
+
+            expect(result.textContent).toContain('Found 2 results')
+            expect(result.textContent).toContain('Test Task')
+            expect(result.textContent).toContain('Test Project')
+        })
+
+        it('should include required fields (id, title, url) in structuredContent results', async () => {
             const mockTasks = [createMappedTask({ id: TEST_IDS.TASK_1, content: 'Test' })]
             const mockProjects = [createMockProject({ id: TEST_IDS.PROJECT_WORK, name: 'Test' })]
 
@@ -219,8 +233,7 @@ describe(`${SEARCH} tool`, () => {
 
             const result = await search.execute({ query: 'test' }, mockTodoistApi)
 
-            const jsonResponse = JSON.parse(result.textContent ?? '{}')
-            for (const item of jsonResponse.results) {
+            for (const item of result.structuredContent?.results ?? []) {
                 expect(item).toHaveProperty('id')
                 expect(item).toHaveProperty('title')
                 expect(item).toHaveProperty('url')

--- a/src/tools/fetch.ts
+++ b/src/tools/fetch.ts
@@ -124,8 +124,10 @@ const fetch = {
             }
         }
 
+        const textContent = `Fetched ${type}: ${result.title} • id=${result.id} • url=${result.url}`
+
         return {
-            textContent: JSON.stringify(result),
+            textContent,
             structuredContent: result,
         }
     },

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -78,8 +78,20 @@ const search = {
             })
         }
 
+        const taskCount = tasksResult.tasks.length
+        const projectCount = projects.length
+        const textContent =
+            results.length === 0
+                ? `No results found for "${query}".`
+                : `Found ${results.length} result${results.length === 1 ? '' : 's'} for "${query}": ${taskCount} task${taskCount === 1 ? '' : 's'}, ${projectCount} project${projectCount === 1 ? '' : 's'}.\nResults:\n${results
+                      .slice(0, 5)
+                      .map((r) => `    ${r.title} • ${r.id}`)
+                      .join(
+                          '\n',
+                      )}${results.length > 5 ? `\n    ... and ${results.length - 5} more` : ''}`
+
         return {
-            textContent: JSON.stringify({ results }),
+            textContent,
             structuredContent: { results, totalCount: results.length },
         }
     },


### PR DESCRIPTION
Closes #339

## Summary

- `search` and `fetch` tools were returning `JSON.stringify(...)` in `textContent`, inconsistent with all other 28+ tools which return human-readable summaries
- `structuredContent` already handles the machine-readable format, so `textContent` should be for humans
- `search` now returns e.g. `Found 3 results for "meeting": 2 tasks, 1 project.\nResults:\n    ...`
- `fetch` now returns e.g. `Fetched task: Buy milk • id=task:123 • url=https://...`
- Tests updated to assert on `structuredContent` for data and `textContent` for human-readable strings

## Test plan

- [x] All 530 tests pass
- [x] Type-check passes
- [x] `lint:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)