### PR TITLE
feat: add productivity analysis prompt and get-productivity-stats tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { findSections } from './tools/find-sections.js'
 import { findTasks } from './tools/find-tasks.js'
 import { findTasksByDate } from './tools/find-tasks-by-date.js'
 import { getOverview } from './tools/get-overview.js'
+import { getProductivityStats } from './tools/get-productivity-stats.js'
 import { listWorkspaces } from './tools/list-workspaces.js'
 import { manageAssignments } from './tools/manage-assignments.js'
 import { rescheduleTasks } from './tools/reschedule-tasks.js'
@@ -73,6 +74,7 @@ const tools = {
 
     // Activity and audit tools
     findActivity,
+    getProductivityStats,
     // General tools
     getOverview,
     deleteObject,
@@ -120,6 +122,7 @@ export {
     updateFilters,
     // Activity and audit tools
     findActivity,
+    getProductivityStats,
     // General tools
     getOverview,
     deleteObject,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -10,6 +10,7 @@ import {
     registerResource,
     registerTool,
 } from './mcp-helpers.js'
+import { productivityAnalysis } from './prompts/productivity-analysis.js'
 import { addComments } from './tools/add-comments.js'
 import { addFilters } from './tools/add-filters.js'
 import { addLabels } from './tools/add-labels.js'
@@ -32,6 +33,7 @@ import { findTasks } from './tools/find-tasks.js'
 import { findTasksByDate } from './tools/find-tasks-by-date.js'
 import { createFindTasksByDateResource } from './tools/find-tasks-by-date.resource.js'
 import { getOverview } from './tools/get-overview.js'
+import { getProductivityStats } from './tools/get-productivity-stats.js'
 import { listWorkspaces } from './tools/list-workspaces.js'
 import { manageAssignments } from './tools/manage-assignments.js'
 import { projectManagement } from './tools/project-management.js'
@@ -95,6 +97,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 
 **Activity & Audit:**
 - **find-activity**: Retrieve recent activity logs to monitor and audit changes. Shows events from all users by default; use initiatorId to filter by specific user. Filter by object type (task/project/comment), event type (added/updated/deleted/completed/uncompleted/archived/unarchived/shared/left), and specific objects (objectId, projectId, taskId). Useful for tracking who did what and when. Note: Date-based filtering is not supported.
+- **get-productivity-stats**: Get comprehensive productivity statistics including daily/weekly completion breakdowns, goal streaks (current, last, max), karma score and trends, and historical karma data. No parameters required.
 
 **General Operations:**
 - **delete-object**: Remove projects, sections, tasks, comments, labels, or filters by type and ID
@@ -127,6 +130,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 - **Project Organization**: add-projects → add-sections → add-tasks with projectId and sectionId
 - **Progress Reviews**: find-completed-tasks (defaults to last 7 days; optionally use explicit date ranges) → get-overview for project summaries
 - **Activity Auditing**: find-activity with event/object filters to track changes, monitor team activity, or investigate specific actions
+- **Productivity Analysis**: Use the productivity-analysis prompt for comprehensive analysis combining user-info, get-productivity-stats, and find-completed-tasks data into actionable insights
 
 Always provide clear, actionable task titles and descriptions. Use the overview tools to give users context about their workload and project status.
 `
@@ -152,6 +156,7 @@ function getMcpServer({
         {
             capabilities: {
                 tools: { listChanged: true },
+                prompts: { listChanged: true },
             },
             instructions,
         },
@@ -219,6 +224,7 @@ function getMcpServer({
 
     // Activity and audit tools
     registerTool({ tool: findActivity, ...toolArgs })
+    registerTool({ tool: getProductivityStats, ...toolArgs })
 
     // General tools
     registerTool({ tool: getOverview, ...toolArgs })
@@ -236,6 +242,19 @@ function getMcpServer({
     // OpenAI MCP tools
     registerTool({ tool: search, ...toolArgs })
     registerTool({ tool: fetch, ...toolArgs })
+
+    /**
+     * Prompts
+     */
+    server.registerPrompt(
+        productivityAnalysis.name,
+        {
+            title: productivityAnalysis.title,
+            description: productivityAnalysis.description,
+            argsSchema: productivityAnalysis.argsSchema,
+        },
+        productivityAnalysis.callback,
+    )
 
     return server
 }

--- a/src/prompts/__tests__/productivity-analysis.test.ts
+++ b/src/prompts/__tests__/productivity-analysis.test.ts
@@ -1,0 +1,213 @@
+import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js'
+import {
+    buildPromptText,
+    computeDateRange,
+    productivityAnalysis,
+} from '../productivity-analysis.js'
+
+function getPromptText(result: GetPromptResult): string {
+    return (result.messages[0]?.content as { type: 'text'; text: string }).text
+}
+
+describe('productivity-analysis prompt', () => {
+    describe('prompt metadata', () => {
+        it('should have correct name and description', () => {
+            expect(productivityAnalysis.name).toBe('productivity-analysis')
+            expect(productivityAnalysis.title).toBe('Productivity Analysis')
+            expect(productivityAnalysis.description).toContain('productivity')
+        })
+    })
+
+    describe('callback', () => {
+        it('should return a valid GetPromptResult with a user message', () => {
+            const result = productivityAnalysis.callback({
+                period: '7d',
+                focus: 'overall',
+            })
+
+            expect(result.messages).toHaveLength(1)
+            expect(result.messages[0]?.role).toBe('user')
+            expect(result.messages[0]?.content.type).toBe('text')
+        })
+
+        it('should include tool instructions in the prompt text', () => {
+            const result = productivityAnalysis.callback({
+                period: '7d',
+                focus: 'overall',
+            })
+
+            const text = getPromptText(result)
+            expect(text).toContain('user-info')
+            expect(text).toContain('get-productivity-stats')
+            expect(text).toContain('find-completed-tasks')
+            expect(text).toContain('get-overview')
+        })
+
+        it('should include projectId scope when provided', () => {
+            const result = productivityAnalysis.callback({
+                period: '7d',
+                focus: 'overall',
+                projectId: 'proj123',
+            })
+
+            const text = getPromptText(result)
+            expect(text).toContain('proj123')
+            expect(text).toContain('Scope this analysis to project ID: proj123')
+        })
+
+        it('should not include projectId text when not provided', () => {
+            const result = productivityAnalysis.callback({
+                period: '7d',
+                focus: 'overall',
+            })
+
+            const text = getPromptText(result)
+            expect(text).not.toContain('Scope this analysis to project ID')
+        })
+    })
+
+    describe('focus areas', () => {
+        it.each([
+            {
+                focus: 'overall' as const,
+                includes: [
+                    'Goal Tracking',
+                    'Completion Trends',
+                    'Project Distribution',
+                    'Recommendations',
+                ],
+                excludes: [],
+                includesOverview: true,
+            },
+            {
+                focus: 'goals' as const,
+                includes: ['Goal Tracking'],
+                excludes: [
+                    '### Completion Trends',
+                    '### Project Distribution',
+                    '### Recommendations',
+                ],
+                includesOverview: false,
+            },
+            {
+                focus: 'projects' as const,
+                includes: ['Project Distribution'],
+                excludes: ['### Goal Tracking', '### Completion Trends', '### Recommendations'],
+                includesOverview: true,
+            },
+            {
+                focus: 'trends' as const,
+                includes: ['Completion Trends'],
+                excludes: ['### Goal Tracking', '### Project Distribution', '### Recommendations'],
+                includesOverview: false,
+            },
+            {
+                focus: 'recommendations' as const,
+                includes: ['Karma & Momentum', 'Recommendations'],
+                excludes: ['### Goal Tracking', '### Completion Trends'],
+                includesOverview: false,
+            },
+        ])('should include correct sections for "$focus" focus', ({
+            focus,
+            includes,
+            excludes,
+            includesOverview,
+        }) => {
+            const text = buildPromptText({ period: '7d', focus })
+
+            for (const section of includes) {
+                expect(text).toContain(section)
+            }
+            for (const section of excludes) {
+                expect(text).not.toContain(section)
+            }
+            if (includesOverview) {
+                expect(text).toContain('get-overview')
+            } else {
+                expect(text).not.toContain('get-overview')
+            }
+        })
+    })
+
+    describe('computeDateRange', () => {
+        const fixedDate = new Date('2026-03-17T12:00:00Z')
+
+        it.each([
+            {
+                period: 'today' as const,
+                date: fixedDate,
+                since: '2026-03-17',
+                until: '2026-03-17',
+                descriptionContains: 'today',
+            },
+            {
+                period: '7d' as const,
+                date: fixedDate,
+                since: '2026-03-11',
+                until: '2026-03-17',
+                descriptionContains: '7 days',
+            },
+            {
+                period: '14d' as const,
+                date: fixedDate,
+                since: '2026-03-04',
+                until: '2026-03-17',
+                descriptionContains: '14 days',
+            },
+            {
+                period: '30d' as const,
+                date: fixedDate,
+                since: '2026-02-16',
+                until: '2026-03-17',
+                descriptionContains: '30 days',
+            },
+            {
+                period: 'this-week' as const,
+                date: fixedDate, // Tuesday
+                since: '2026-03-16',
+                until: '2026-03-17',
+                descriptionContains: 'this week',
+            },
+            {
+                period: 'this-week' as const,
+                date: new Date('2026-03-16T12:00:00Z'), // Monday
+                since: '2026-03-16',
+                until: '2026-03-16',
+                descriptionContains: 'this week',
+            },
+            {
+                period: 'this-week' as const,
+                date: new Date('2026-03-22T12:00:00Z'), // Sunday
+                since: '2026-03-16',
+                until: '2026-03-22',
+                descriptionContains: 'this week',
+            },
+            {
+                period: 'this-month' as const,
+                date: fixedDate,
+                since: '2026-03-01',
+                until: '2026-03-17',
+                descriptionContains: 'this month',
+            },
+        ])('should compute "$period" period ($since to $until)', ({
+            period,
+            date,
+            since,
+            until,
+            descriptionContains,
+        }) => {
+            const range = computeDateRange(period, date)
+
+            expect(range.since).toBe(since)
+            expect(range.until).toBe(until)
+            expect(range.periodDescription).toContain(descriptionContains)
+        })
+
+        it('should embed date range in the prompt text', () => {
+            const text = buildPromptText({ period: '7d', focus: 'overall' })
+
+            expect(text).toMatch(/since: "\d{4}-\d{2}-\d{2}"/)
+            expect(text).toMatch(/until: "\d{4}-\d{2}-\d{2}"/)
+        })
+    })
+})

--- a/src/prompts/productivity-analysis.ts
+++ b/src/prompts/productivity-analysis.ts
@@ -1,0 +1,189 @@
+import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+
+const argsSchema = {
+    period: z
+        .enum(['today', '7d', '14d', '30d', 'this-week', 'this-month'])
+        .default('7d')
+        .describe(
+            'Time period for the analysis. "today" analyzes the current day, "7d"/"14d"/"30d" analyze the last N days, "this-week" and "this-month" analyze the current week or month.',
+        ),
+    focus: z
+        .enum(['overall', 'goals', 'projects', 'trends', 'recommendations'])
+        .default('overall')
+        .describe(
+            'Focus area for the analysis. "overall" provides a comprehensive report covering all areas. Other values focus on a specific aspect.',
+        ),
+    projectId: z
+        .string()
+        .optional()
+        .describe('Optional project ID to scope the analysis to a specific project.'),
+}
+
+type PromptArgs = z.infer<z.ZodObject<typeof argsSchema>>
+
+/**
+ * Compute the date range (since/until as YYYY-MM-DD) for a given period.
+ * Uses UTC since the prompt instructs the LLM to call user-info for timezone.
+ */
+function computeDateRange(
+    period: PromptArgs['period'],
+    now: Date = new Date(),
+): { since: string; until: string; periodDescription: string } {
+    const formatDate = (d: Date): string => d.toISOString().slice(0, 10)
+    const until = formatDate(now)
+
+    switch (period) {
+        case 'today':
+            return { since: until, until, periodDescription: 'today' }
+
+        case '7d': {
+            const since = new Date(now)
+            since.setDate(since.getDate() - 6)
+            return {
+                since: formatDate(since),
+                until,
+                periodDescription: 'the last 7 days',
+            }
+        }
+
+        case '14d': {
+            const since = new Date(now)
+            since.setDate(since.getDate() - 13)
+            return {
+                since: formatDate(since),
+                until,
+                periodDescription: 'the last 14 days',
+            }
+        }
+
+        case '30d': {
+            const since = new Date(now)
+            since.setDate(since.getDate() - 29)
+            return {
+                since: formatDate(since),
+                until,
+                periodDescription: 'the last 30 days',
+            }
+        }
+
+        case 'this-week': {
+            const dayOfWeek = now.getUTCDay()
+            const monday = new Date(now)
+            monday.setDate(now.getDate() - ((dayOfWeek + 6) % 7))
+            return {
+                since: formatDate(monday),
+                until,
+                periodDescription: 'this week (Monday to today)',
+            }
+        }
+
+        case 'this-month': {
+            const firstOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+            return {
+                since: formatDate(firstOfMonth),
+                until,
+                periodDescription: 'this month',
+            }
+        }
+    }
+}
+
+function buildFocusSections(focus: PromptArgs['focus']): string {
+    const sections: Record<string, string> = {
+        goals: `### Goal Tracking
+- Compare tasks completed today vs the daily goal
+- Calculate progress toward the weekly goal (using daysItems to sum completions for the current week)
+- Report on the current daily and weekly streaks — how long they've been going, and how they compare to the user's best streaks
+- Flag if the user is at risk of breaking a streak`,
+
+        trends: `### Completion Trends
+- Show a day-by-day breakdown of tasks completed over the period
+- Identify peak productivity days and low-activity days
+- Note any patterns (e.g., weekday vs weekend, specific days that are consistently high or low)
+- Compare weekly totals if multiple weeks are in the period`,
+
+        projects: `### Project Distribution
+- Break down completions by project (using per-project data from daysItems/weekItems)
+- Identify which projects received the most and least attention
+- Highlight any projects with zero completions in the period
+- If a specific project was requested, focus the analysis on that project's performance`,
+
+        recommendations: `### Karma & Momentum
+- Report the current karma score and trend
+- Summarize recent karma changes and their reasons
+
+### Recommendations
+- Based on all the data gathered, provide 3-5 specific, actionable suggestions
+- Address any concerning patterns (declining completions, broken streaks, neglected projects)
+- Suggest concrete next steps (e.g., "Focus on Project X which has had no completions this week")
+- If goals seem too easy or too hard based on actual completion rates, suggest adjustments`,
+    }
+
+    if (focus === 'overall') {
+        return Object.values(sections).join('\n\n')
+    }
+
+    return sections[focus] ?? ''
+}
+
+function buildPromptText(args: PromptArgs): string {
+    const { since, until, periodDescription } = computeDateRange(args.period)
+    const projectScope = args.projectId
+        ? `\nScope this analysis to project ID: ${args.projectId}. Pass this projectId when calling find-completed-tasks and get-overview.`
+        : ''
+
+    return `Analyze my Todoist productivity for ${periodDescription} (${since} to ${until}).${projectScope}
+
+## Instructions
+
+Follow these steps to gather data and produce the analysis:
+
+### Step 1: Gather Data
+
+Call the following tools to collect the necessary data:
+
+1. **user-info** — Get my timezone, daily/weekly goals, tasks completed today, and user ID (you'll need the user ID for the responsibleUser filter)
+2. **get-productivity-stats** — Get streak data, karma score/trend, daily and weekly completion breakdowns, and karma history
+3. **find-completed-tasks** — Get completed tasks for the period (since: "${since}", until: "${until}"). Set responsibleUser to my user ID (from user-info) to see only my completions${args.projectId ? `. Set projectId to "${args.projectId}"` : ''}
+${args.focus === 'overall' || args.focus === 'projects' ? `4. **get-overview** — Get the project structure${args.projectId ? ` for project "${args.projectId}"` : ''} to provide context for the analysis` : ''}
+
+### Step 2: Analyze
+
+Using the collected data, produce an analysis covering the following sections:
+
+${buildFocusSections(args.focus)}
+
+### Step 3: Format
+
+Present the analysis as a clear, well-structured markdown report with:
+- A summary header with the period and key headline metrics
+- Each analytical section with its own header
+- Specific numbers and comparisons (not vague statements)
+- Actionable takeaways highlighted clearly`
+}
+
+function callback(args: PromptArgs): GetPromptResult {
+    return {
+        messages: [
+            {
+                role: 'user',
+                content: {
+                    type: 'text',
+                    text: buildPromptText(args),
+                },
+            },
+        ],
+    }
+}
+
+const productivityAnalysis = {
+    name: 'productivity-analysis',
+    title: 'Productivity Analysis',
+    description:
+        'Analyze your Todoist productivity with insights on completion trends, goal streaks, project distribution, and actionable recommendations. Gathers data from multiple tools and synthesizes a comprehensive report.',
+    argsSchema,
+    callback,
+}
+
+export { productivityAnalysis, computeDateRange, buildPromptText }

--- a/src/tools/__tests__/get-productivity-stats.test.ts
+++ b/src/tools/__tests__/get-productivity-stats.test.ts
@@ -1,0 +1,195 @@
+import type { ProductivityStats, TodoistApi } from '@doist/todoist-api-typescript'
+import { type Mocked, vi } from 'vitest'
+import { TEST_ERRORS } from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { getProductivityStats } from '../get-productivity-stats.js'
+
+const mockTodoistApi = {
+    getProductivityStats: vi.fn(),
+} as unknown as Mocked<TodoistApi>
+
+const { GET_PRODUCTIVITY_STATS } = ToolNames
+
+function createMockStats(overrides: Partial<ProductivityStats> = {}): ProductivityStats {
+    return {
+        completedCount: 5230,
+        daysItems: [
+            {
+                date: '2026-03-17',
+                totalCompleted: 12,
+                items: [
+                    { id: 'proj1', completed: 8 },
+                    { id: 'proj2', completed: 4 },
+                ],
+            },
+            {
+                date: '2026-03-16',
+                totalCompleted: 8,
+                items: [{ id: 'proj1', completed: 8 }],
+            },
+            {
+                date: '2026-03-15',
+                totalCompleted: 5,
+                items: [{ id: 'proj2', completed: 5 }],
+            },
+        ],
+        weekItems: [
+            {
+                from: '2026-03-11',
+                to: '2026-03-17',
+                totalCompleted: 45,
+                items: [
+                    { id: 'proj1', completed: 30 },
+                    { id: 'proj2', completed: 15 },
+                ],
+            },
+            {
+                from: '2026-03-04',
+                to: '2026-03-10',
+                totalCompleted: 38,
+                items: [{ id: 'proj1', completed: 38 }],
+            },
+        ],
+        goals: {
+            dailyGoal: 10,
+            weeklyGoal: 50,
+            currentDailyStreak: { count: 14, start: '2026-03-04', end: '2026-03-17' },
+            currentWeeklyStreak: { count: 6, start: '2026-02-02', end: '2026-03-17' },
+            lastDailyStreak: { count: 7, start: '2026-02-20', end: '2026-02-26' },
+            lastWeeklyStreak: { count: 3, start: '2026-01-05', end: '2026-01-25' },
+            maxDailyStreak: { count: 30, start: '2025-11-01', end: '2025-11-30' },
+            maxWeeklyStreak: { count: 12, start: '2025-09-01', end: '2025-11-24' },
+            user: 'user123',
+            userId: 'user123',
+            vacationMode: 0,
+            karmaDisabled: 0,
+            ignoreDays: [6, 7],
+        },
+        karma: 86394,
+        karmaTrend: 'up',
+        karmaLastUpdate: 1742230800,
+        karmaGraphData: [
+            { date: '2026-03-10', karmaAvg: 86200 },
+            { date: '2026-03-17', karmaAvg: 86394 },
+        ],
+        karmaUpdateReasons: [
+            {
+                time: '2026-03-17T10:00:00Z',
+                newKarma: 86394,
+                positiveKarma: 20,
+                negativeKarma: 0,
+                positiveKarmaReasons: [{ reason: 'completed_task', count: 4 }],
+                negativeKarmaReasons: [],
+            },
+        ],
+        projectColors: {
+            proj1: 'berry_red',
+            proj2: 'blue',
+        },
+        ...overrides,
+    }
+}
+
+describe(`${GET_PRODUCTIVITY_STATS} tool`, () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('should return comprehensive productivity statistics', async () => {
+        const mockStats = createMockStats()
+        mockTodoistApi.getProductivityStats.mockResolvedValue(mockStats)
+
+        const result = await getProductivityStats.execute({}, mockTodoistApi)
+
+        expect(mockTodoistApi.getProductivityStats).toHaveBeenCalledWith()
+
+        // Verify structured content
+        const sc = result.structuredContent!
+        expect(sc.completedCount).toBe(5230)
+        expect(sc.karma).toBe(86394)
+        expect(sc.karmaTrend).toBe('up')
+        expect(sc.goals.dailyGoal).toBe(10)
+        expect(sc.goals.weeklyGoal).toBe(50)
+        expect(sc.goals.currentDailyStreak.count).toBe(14)
+        expect(sc.goals.currentWeeklyStreak.count).toBe(6)
+        expect(sc.goals.maxDailyStreak.count).toBe(30)
+        expect(sc.goals.maxWeeklyStreak.count).toBe(12)
+        expect(sc.goals.vacationMode).toBe(0)
+        expect(sc.goals.karmaDisabled).toBe(0)
+        expect(sc.daysItems).toHaveLength(3)
+        expect(sc.weekItems).toHaveLength(2)
+        expect(sc.karmaGraphData).toHaveLength(2)
+        expect(sc.karmaUpdateReasons).toHaveLength(1)
+        expect(sc.projectColors).toEqual({ proj1: 'berry_red', proj2: 'blue' })
+    })
+
+    it('should include key stats in text content', async () => {
+        const mockStats = createMockStats()
+        mockTodoistApi.getProductivityStats.mockResolvedValue(mockStats)
+
+        const result = await getProductivityStats.execute({}, mockTodoistApi)
+
+        const text = result.textContent!
+        expect(text).toContain('5,230')
+        expect(text).toContain('86,394')
+        expect(text).toContain('up')
+        expect(text).toContain('10 tasks/day')
+        expect(text).toContain('50 tasks/week')
+        expect(text).toContain('14 days')
+        expect(text).toContain('6 weeks')
+        expect(text).toContain('30 days')
+        expect(text).toContain('12 weeks')
+    })
+
+    it('should include daily completion breakdown in text content', async () => {
+        const mockStats = createMockStats()
+        mockTodoistApi.getProductivityStats.mockResolvedValue(mockStats)
+
+        const result = await getProductivityStats.execute({}, mockTodoistApi)
+
+        const text = result.textContent!
+        expect(text).toContain('2026-03-17: 12 tasks')
+        expect(text).toContain('2026-03-16: 8 tasks')
+        expect(text).toContain('2026-03-15: 5 tasks')
+    })
+
+    it('should include weekly completion breakdown in text content', async () => {
+        const mockStats = createMockStats()
+        mockTodoistApi.getProductivityStats.mockResolvedValue(mockStats)
+
+        const result = await getProductivityStats.execute({}, mockTodoistApi)
+
+        const text = result.textContent!
+        expect(text).toContain('2026-03-11 to 2026-03-17: 45 tasks')
+        expect(text).toContain('2026-03-04 to 2026-03-10: 38 tasks')
+    })
+
+    it('should handle empty days and weeks gracefully', async () => {
+        const mockStats = createMockStats({ daysItems: [], weekItems: [] })
+        mockTodoistApi.getProductivityStats.mockResolvedValue(mockStats)
+
+        const result = await getProductivityStats.execute({}, mockTodoistApi)
+
+        const text = result.textContent!
+        expect(text).not.toContain('Recent Daily Completions')
+        expect(text).not.toContain('Recent Weekly Completions')
+        expect(result.structuredContent?.daysItems).toHaveLength(0)
+        expect(result.structuredContent?.weekItems).toHaveLength(0)
+    })
+
+    it('should propagate API errors', async () => {
+        const apiError = new Error(TEST_ERRORS.API_UNAUTHORIZED)
+        mockTodoistApi.getProductivityStats.mockRejectedValue(apiError)
+
+        await expect(getProductivityStats.execute({}, mockTodoistApi)).rejects.toThrow(
+            TEST_ERRORS.API_UNAUTHORIZED,
+        )
+    })
+
+    it('should have correct tool metadata', () => {
+        expect(getProductivityStats.name).toBe('get-productivity-stats')
+        expect(getProductivityStats.annotations.readOnlyHint).toBe(true)
+        expect(getProductivityStats.annotations.destructiveHint).toBe(false)
+        expect(getProductivityStats.annotations.idempotentHint).toBe(true)
+    })
+})

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -202,6 +202,13 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         idempotentHint: true,
     },
     {
+        name: ToolNames.GET_PRODUCTIVITY_STATS,
+        title: 'Todoist: Get Productivity Stats',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    {
         name: ToolNames.GET_OVERVIEW,
         title: 'Todoist: Get Overview',
         readOnlyHint: true,

--- a/src/tools/get-productivity-stats.ts
+++ b/src/tools/get-productivity-stats.ts
@@ -1,0 +1,169 @@
+import { z } from 'zod'
+import type { TodoistTool } from '../todoist-tool.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {}
+
+const StreakSchema = z.object({
+    count: z.number().describe('Number of consecutive periods in this streak.'),
+    start: z.string().describe('Start date of the streak.'),
+    end: z.string().describe('End date of the streak.'),
+})
+
+const ProjectCompletionSchema = z.object({
+    id: z.string().describe('Project ID.'),
+    completed: z.number().describe('Number of tasks completed in this project.'),
+})
+
+const OutputSchema = {
+    completedCount: z.number().describe('Total number of completed tasks (all-time).'),
+    daysItems: z
+        .array(
+            z.object({
+                date: z.string().describe('Date string (YYYY-MM-DD).'),
+                totalCompleted: z.number().describe('Total tasks completed on this day.'),
+                items: z
+                    .array(ProjectCompletionSchema)
+                    .describe('Per-project completion breakdown for this day.'),
+            }),
+        )
+        .describe('Daily completion breakdown (most recent days).'),
+    weekItems: z
+        .array(
+            z.object({
+                from: z.string().describe('Start date of the week.'),
+                to: z.string().describe('End date of the week.'),
+                totalCompleted: z.number().describe('Total tasks completed in this week.'),
+                items: z
+                    .array(ProjectCompletionSchema)
+                    .describe('Per-project completion breakdown for this week.'),
+            }),
+        )
+        .describe('Weekly completion breakdown (most recent weeks).'),
+    goals: z
+        .object({
+            dailyGoal: z.number().describe('Daily task completion goal.'),
+            weeklyGoal: z.number().describe('Weekly task completion goal.'),
+            currentDailyStreak: StreakSchema.describe('Current daily goal streak.'),
+            currentWeeklyStreak: StreakSchema.describe('Current weekly goal streak.'),
+            lastDailyStreak: StreakSchema.describe('Previous daily goal streak.'),
+            lastWeeklyStreak: StreakSchema.describe('Previous weekly goal streak.'),
+            maxDailyStreak: StreakSchema.describe('Best daily goal streak ever.'),
+            maxWeeklyStreak: StreakSchema.describe('Best weekly goal streak ever.'),
+            vacationMode: z.number().describe('Whether vacation mode is enabled (0 or 1).'),
+            karmaDisabled: z.number().describe('Whether karma tracking is disabled (0 or 1).'),
+        })
+        .describe('Goal and streak information.'),
+    karma: z.number().describe('Current karma score.'),
+    karmaTrend: z.string().describe('Karma trend direction (e.g., "up" or "down").'),
+    karmaLastUpdate: z.number().describe('Timestamp of the last karma update.'),
+    karmaGraphData: z
+        .array(
+            z.object({
+                date: z.string().describe('Date of the karma data point.'),
+                karmaAvg: z.number().describe('Average karma for this date.'),
+            }),
+        )
+        .describe('Historical karma data points for graphing.'),
+    karmaUpdateReasons: z
+        .array(
+            z.object({
+                time: z.string().describe('Timestamp of the karma change.'),
+                newKarma: z.number().describe('New karma value after the change.'),
+                positiveKarma: z.number().describe('Positive karma earned.'),
+                negativeKarma: z.number().describe('Negative karma incurred.'),
+                positiveKarmaReasons: z.array(z.any()).describe('Reasons for positive karma.'),
+                negativeKarmaReasons: z.array(z.any()).describe('Reasons for negative karma.'),
+            }),
+        )
+        .describe('Recent karma change events with reasons.'),
+    projectColors: z.record(z.string(), z.string()).describe('Map of project ID to color key.'),
+}
+
+const getProductivityStats = {
+    name: ToolNames.GET_PRODUCTIVITY_STATS,
+    description:
+        'Get comprehensive productivity statistics including daily/weekly completion breakdowns, goal streaks (current, last, max), karma score and trends, and historical karma data. Useful for productivity analysis and tracking goal progress.',
+    parameters: ArgsSchema,
+    outputSchema: OutputSchema,
+    annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    async execute(_args, client) {
+        const stats = await client.getProductivityStats()
+
+        const textContent = generateTextContent(stats)
+
+        return {
+            textContent,
+            structuredContent: {
+                completedCount: stats.completedCount,
+                daysItems: stats.daysItems,
+                weekItems: stats.weekItems,
+                goals: {
+                    dailyGoal: stats.goals.dailyGoal,
+                    weeklyGoal: stats.goals.weeklyGoal,
+                    currentDailyStreak: stats.goals.currentDailyStreak,
+                    currentWeeklyStreak: stats.goals.currentWeeklyStreak,
+                    lastDailyStreak: stats.goals.lastDailyStreak,
+                    lastWeeklyStreak: stats.goals.lastWeeklyStreak,
+                    maxDailyStreak: stats.goals.maxDailyStreak,
+                    maxWeeklyStreak: stats.goals.maxWeeklyStreak,
+                    vacationMode: stats.goals.vacationMode,
+                    karmaDisabled: stats.goals.karmaDisabled,
+                },
+                karma: stats.karma,
+                karmaTrend: stats.karmaTrend,
+                karmaLastUpdate: stats.karmaLastUpdate,
+                karmaGraphData: stats.karmaGraphData,
+                karmaUpdateReasons: stats.karmaUpdateReasons,
+                projectColors: stats.projectColors,
+            },
+        }
+    },
+} satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
+
+function generateTextContent(
+    stats: Awaited<
+        ReturnType<
+            typeof import('@doist/todoist-api-typescript').TodoistApi.prototype.getProductivityStats
+        >
+    >,
+): string {
+    const lines: string[] = [
+        '# Productivity Statistics',
+        '',
+        `**Total Completed Tasks:** ${stats.completedCount.toLocaleString()}`,
+        `**Karma:** ${stats.karma.toLocaleString()} (${stats.karmaTrend})`,
+        '',
+        '## Goals & Streaks',
+        `**Daily Goal:** ${stats.goals.dailyGoal} tasks/day`,
+        `**Weekly Goal:** ${stats.goals.weeklyGoal} tasks/week`,
+        `**Current Daily Streak:** ${stats.goals.currentDailyStreak.count} days (${stats.goals.currentDailyStreak.start} to ${stats.goals.currentDailyStreak.end})`,
+        `**Current Weekly Streak:** ${stats.goals.currentWeeklyStreak.count} weeks (${stats.goals.currentWeeklyStreak.start} to ${stats.goals.currentWeeklyStreak.end})`,
+        `**Best Daily Streak:** ${stats.goals.maxDailyStreak.count} days`,
+        `**Best Weekly Streak:** ${stats.goals.maxWeeklyStreak.count} weeks`,
+    ]
+
+    if (stats.daysItems.length > 0) {
+        lines.push('', '## Recent Daily Completions')
+        const recentDays = stats.daysItems.slice(0, 7)
+        for (const day of recentDays) {
+            lines.push(`  ${day.date}: ${day.totalCompleted} tasks`)
+        }
+    }
+
+    if (stats.weekItems.length > 0) {
+        lines.push('', '## Recent Weekly Completions')
+        const recentWeeks = stats.weekItems.slice(0, 4)
+        for (const week of recentWeeks) {
+            lines.push(`  ${week.from} to ${week.to}: ${week.totalCompleted} tasks`)
+        }
+    }
+
+    return lines.join('\n')
+}
+
+export { getProductivityStats }

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -39,6 +39,7 @@ export const ToolNames = {
 
     // Activity and audit tools
     FIND_ACTIVITY: 'find-activity',
+    GET_PRODUCTIVITY_STATS: 'get-productivity-stats',
 
     // General tools
     GET_OVERVIEW: 'get-overview',


### PR DESCRIPTION
## Summary

- Adds the project's first **MCP Prompt** (`productivity-analysis`) that guides LLMs through a multi-step productivity analysis workflow
- Adds a new **`get-productivity-stats` tool** exposing the Todoist `getProductivityStats()` API endpoint (streaks, karma, daily/weekly completion breakdowns)
- Adds `prompts` capability to the MCP server

Closes #56

## Details

### `get-productivity-stats` tool
New read-only tool with no parameters that returns comprehensive productivity data not available through existing tools: daily/weekly completion breakdowns, goal streaks (current/last/max), karma score/trend/history, and karma update reasons.

### `productivity-analysis` prompt
Accepts `period` (today/7d/14d/30d/this-week/this-month), `focus` (overall/goals/projects/trends/recommendations), and optional `projectId` arguments. Returns a structured prompt message that instructs the LLM to:
1. Call `user-info`, `get-productivity-stats`, `find-completed-tasks`, and optionally `get-overview`
2. Analyze the data across configurable focus areas
3. Format as a markdown report with actionable insights

## Test plan
- [ ] All 651 existing + new tests pass
- [ ] TypeScript type check passes
- [ ] Pre-commit hooks (biome, type-check, schema validation) pass
- [ ] Verify `get-productivity-stats` tool via `npx tsx scripts/run-tool.ts get-productivity-stats '{}'`
- [ ] Verify prompt registration via MCP inspector

🤖 Generated with [Claude Code](https://claude.com/claude-code)