### PR TITLE
fix: move .optional() outside z.preprocess() for dueString/deadlineDate

### DIFF
--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -37,26 +37,28 @@ const TasksUpdateSchema = z.object({
     parentId: z.string().optional().describe('The new parent task ID (for subtasks).'),
     order: z.number().optional().describe('The new order of the task within its parent/section.'),
     priority: PrioritySchema.optional().describe(PRIORITY_INPUT_DESCRIPTION),
-    dueString: z.preprocess(
-        // Keep accepting legacy null while exposing a Gemini-compatible string schema.
-        (value) => (value === null ? 'remove' : value),
-        z
-            .string()
-            .optional()
-            .describe(
-                'The new due date for the task in natural language (e.g., "tomorrow at 5pm"). Use "remove" to clear the due date.',
-            ),
-    ),
-    deadlineDate: z.preprocess(
-        // Keep accepting legacy null while exposing a Gemini-compatible string schema.
-        (value) => (value === null ? 'remove' : value),
-        z
-            .string()
-            .optional()
-            .describe(
-                'The new deadline date for the task in ISO 8601 format (YYYY-MM-DD, e.g., "2025-12-31"). Deadlines are immovable constraints shown with a different indicator than due dates. Use "remove" to clear the deadline.',
-            ),
-    ),
+    dueString: z
+        .preprocess(
+            // Keep accepting legacy null while exposing a Gemini-compatible string schema.
+            (value) => (value === null ? 'remove' : value),
+            z
+                .string()
+                .describe(
+                    'The new due date for the task in natural language (e.g., "tomorrow at 5pm"). Use "remove" to clear the due date.',
+                ),
+        )
+        .optional(),
+    deadlineDate: z
+        .preprocess(
+            // Keep accepting legacy null while exposing a Gemini-compatible string schema.
+            (value) => (value === null ? 'remove' : value),
+            z
+                .string()
+                .describe(
+                    'The new deadline date for the task in ISO 8601 format (YYYY-MM-DD, e.g., "2025-12-31"). Deadlines are immovable constraints shown with a different indicator than due dates. Use "remove" to clear the deadline.',
+                ),
+        )
+        .optional(),
     duration: z
         .string()
         .optional()


### PR DESCRIPTION
## Summary

- Fixes #409: `z.preprocess()` wrapping `.optional()` inside it causes Zod v4's `toJSONSchema()` to emit `dueString` and `deadlineDate` as `required` fields in the JSON Schema
- LLM agents are forced to always supply these values, which destroys recurring task schedules when they only intend to update other fields (e.g. labels, priority)
- Moves `.optional()` from inside `z.preprocess()` to outside it, so the emitted schema correctly marks the fields as optional while preserving the legacy null-to-"remove" coercion

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 692 tests pass
- [x] Verified emitted JSON Schema no longer includes `dueString`/`deadlineDate` in `required` array
- [x] Verified runtime parsing still works: omitting fields, providing values, legacy `null`, and `"remove"` all behave identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)