### PR TITLE
fix: promote noNonNullAssertion to error

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,8 @@
             "recommended": true,
             "style": {
                 "useImportType": "off",
-                "noEnum": "error"
+                "noEnum": "error",
+                "noNonNullAssertion": "error"
             },
             "correctness": {
                 "noUnusedVariables": "error",

--- a/src/tools/__tests__/add-labels.test.ts
+++ b/src/tools/__tests__/add-labels.test.ts
@@ -31,8 +31,8 @@ describe(`${ADD_LABELS} tool`, () => {
             expect(mockTodoistApi.addLabel).toHaveBeenCalledWith({ name: 'Work', color: 'blue' })
             expect(result.structuredContent.labels).toHaveLength(1)
             expect(result.structuredContent.totalCount).toBe(1)
-            expect(result.structuredContent.labels[0]!.name).toBe('Work')
-            expect(result.structuredContent.labels[0]!.id).toBe('label-1')
+            expect(result.structuredContent.labels[0]?.name).toBe('Work')
+            expect(result.structuredContent.labels[0]?.id).toBe('label-1')
             expect(result.textContent).toContain('Added 1 label')
             expect(result.textContent).toContain('Work')
             expect(result.textContent).toMatchSnapshot()
@@ -72,12 +72,12 @@ describe(`${ADD_LABELS} tool`, () => {
                 mockTodoistApi,
             )
 
-            const label = result.structuredContent.labels[0]!
-            expect(label.id).toBe('label-1')
-            expect(label.name).toBe('Work')
-            expect(label.color).toBe('blue')
-            expect(label.order).toBe(5)
-            expect(label.isFavorite).toBe(true)
+            const label = result.structuredContent.labels[0]
+            expect(label?.id).toBe('label-1')
+            expect(label?.name).toBe('Work')
+            expect(label?.color).toBe('blue')
+            expect(label?.order).toBe(5)
+            expect(label?.isFavorite).toBe(true)
         })
 
         it('should reject when one of multiple label creates fails', async () => {

--- a/src/tools/__tests__/get-productivity-stats.test.ts
+++ b/src/tools/__tests__/get-productivity-stats.test.ts
@@ -104,23 +104,23 @@ describe(`${GET_PRODUCTIVITY_STATS} tool`, () => {
         expect(mockTodoistApi.getProductivityStats).toHaveBeenCalledWith()
 
         // Verify structured content
-        const sc = result.structuredContent!
-        expect(sc.completedCount).toBe(5230)
-        expect(sc.karma).toBe(86394)
-        expect(sc.karmaTrend).toBe('up')
-        expect(sc.goals.dailyGoal).toBe(10)
-        expect(sc.goals.weeklyGoal).toBe(50)
-        expect(sc.goals.currentDailyStreak.count).toBe(14)
-        expect(sc.goals.currentWeeklyStreak.count).toBe(6)
-        expect(sc.goals.maxDailyStreak.count).toBe(30)
-        expect(sc.goals.maxWeeklyStreak.count).toBe(12)
-        expect(sc.goals.vacationMode).toBe(0)
-        expect(sc.goals.karmaDisabled).toBe(0)
-        expect(sc.daysItems).toHaveLength(3)
-        expect(sc.weekItems).toHaveLength(2)
-        expect(sc.karmaGraphData).toHaveLength(2)
-        expect(sc.karmaUpdateReasons).toHaveLength(1)
-        expect(sc.projectColors).toEqual({ proj1: 'berry_red', proj2: 'blue' })
+        const sc = result.structuredContent
+        expect(sc?.completedCount).toBe(5230)
+        expect(sc?.karma).toBe(86394)
+        expect(sc?.karmaTrend).toBe('up')
+        expect(sc?.goals.dailyGoal).toBe(10)
+        expect(sc?.goals.weeklyGoal).toBe(50)
+        expect(sc?.goals.currentDailyStreak.count).toBe(14)
+        expect(sc?.goals.currentWeeklyStreak.count).toBe(6)
+        expect(sc?.goals.maxDailyStreak.count).toBe(30)
+        expect(sc?.goals.maxWeeklyStreak.count).toBe(12)
+        expect(sc?.goals.vacationMode).toBe(0)
+        expect(sc?.goals.karmaDisabled).toBe(0)
+        expect(sc?.daysItems).toHaveLength(3)
+        expect(sc?.weekItems).toHaveLength(2)
+        expect(sc?.karmaGraphData).toHaveLength(2)
+        expect(sc?.karmaUpdateReasons).toHaveLength(1)
+        expect(sc?.projectColors).toEqual({ proj1: 'berry_red', proj2: 'blue' })
     })
 
     it('should include key stats in text content', async () => {
@@ -129,7 +129,7 @@ describe(`${GET_PRODUCTIVITY_STATS} tool`, () => {
 
         const result = await getProductivityStats.execute({}, mockTodoistApi)
 
-        const text = result.textContent!
+        const text = result.textContent
         expect(text).toContain('5,230')
         expect(text).toContain('86,394')
         expect(text).toContain('up')
@@ -147,7 +147,7 @@ describe(`${GET_PRODUCTIVITY_STATS} tool`, () => {
 
         const result = await getProductivityStats.execute({}, mockTodoistApi)
 
-        const text = result.textContent!
+        const text = result.textContent
         expect(text).toContain('2026-03-17: 12 tasks')
         expect(text).toContain('2026-03-16: 8 tasks')
         expect(text).toContain('2026-03-15: 5 tasks')
@@ -159,7 +159,7 @@ describe(`${GET_PRODUCTIVITY_STATS} tool`, () => {
 
         const result = await getProductivityStats.execute({}, mockTodoistApi)
 
-        const text = result.textContent!
+        const text = result.textContent
         expect(text).toContain('2026-03-11 to 2026-03-17: 45 tasks')
         expect(text).toContain('2026-03-04 to 2026-03-10: 38 tasks')
     })
@@ -170,7 +170,7 @@ describe(`${GET_PRODUCTIVITY_STATS} tool`, () => {
 
         const result = await getProductivityStats.execute({}, mockTodoistApi)
 
-        const text = result.textContent!
+        const text = result.textContent
         expect(text).not.toContain('Recent Daily Completions')
         expect(text).not.toContain('Recent Weekly Completions')
         expect(result.structuredContent?.daysItems).toHaveLength(0)


### PR DESCRIPTION
## Summary
- Promotes Biome's `noNonNullAssertion` lint rule from warning (default via `recommended: true`) to error in `biome.json`
- Replaces all non-null assertions (`!`) with optional chaining (`?.`) in test files

## Test plan
- [x] All 692 tests pass
- [x] `tsc --noEmit` passes
- [x] `biome lint` passes with zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)