### PR TITLE
feat: add `get-project-health` tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "8.4.2",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-api-typescript": "7.3.0",
+                "@doist/todoist-api-typescript": "7.8.0",
                 "date-fns": "4.1.0",
                 "dompurify": "3.3.3",
                 "dotenv": "17.3.1",
@@ -341,9 +341,9 @@
             }
         },
         "node_modules/@doist/todoist-api-typescript": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-7.3.0.tgz",
-            "integrity": "sha512-kTNL1ed194ddzCRzI2uZ/1ZYBDYzafuCfYBXr7TPq23evoNA7SsmI/wAYm6ALcS+yWQ6utW+gGJg/sN486nodw==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-7.8.0.tgz",
+            "integrity": "sha512-Ckf6fEbuNOYvz0y3gD96TceXovjC9SwTVBPAKu+Cpg3Na5c5jIVVCWkpMo7+eDG+cHYxy9KefeFqOKABQS87hQ==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "6.3.0",
@@ -355,7 +355,7 @@
                 "zod": "4.3.6"
             },
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=20.18.1"
             },
             "peerDependencies": {
                 "type-fest": "^4.12.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-api-typescript": "7.3.0",
+        "@doist/todoist-api-typescript": "7.8.0",
         "date-fns": "4.1.0",
         "dompurify": "3.3.3",
         "dotenv": "17.3.1",

--- a/scripts/run-tool.ts
+++ b/scripts/run-tool.ts
@@ -38,6 +38,7 @@ import { findSections } from '../src/tools/find-sections.js'
 import { findTasks } from '../src/tools/find-tasks.js'
 import { findTasksByDate } from '../src/tools/find-tasks-by-date.js'
 import { getOverview } from '../src/tools/get-overview.js'
+import { getProjectHealth } from '../src/tools/get-project-health.js'
 import { listWorkspaces } from '../src/tools/list-workspaces.js'
 import { manageAssignments } from '../src/tools/manage-assignments.js'
 import { projectManagement } from '../src/tools/project-management.js'
@@ -90,6 +91,7 @@ const tools: Record<string, ExecutableTool> = {
     'find-tasks': findTasks,
     'find-tasks-by-date': findTasksByDate,
     'get-overview': getOverview,
+    'get-project-health': getProjectHealth,
     'list-workspaces': listWorkspaces,
     'manage-assignments': manageAssignments,
     'project-management': projectManagement,

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { findTasks } from './tools/find-tasks.js'
 import { findTasksByDate } from './tools/find-tasks-by-date.js'
 import { getOverview } from './tools/get-overview.js'
 import { getProductivityStats } from './tools/get-productivity-stats.js'
+import { getProjectHealth } from './tools/get-project-health.js'
 import { listWorkspaces } from './tools/list-workspaces.js'
 import { manageAssignments } from './tools/manage-assignments.js'
 import { reorderObjects } from './tools/reorder-objects.js'
@@ -79,6 +80,8 @@ const tools = {
     // Activity and audit tools
     findActivity,
     getProductivityStats,
+    // Health and insights tools
+    getProjectHealth,
     // General tools
     getOverview,
     deleteObject,
@@ -94,53 +97,59 @@ const tools = {
     fetch,
 }
 
-export { tools, getMcpServer, FEATURE_NAMES, type Feature, type FeatureName, type Features }
-
 export {
+    // Comment management tools
+    addComments,
+    addFilters,
+    // Label management tools
+    addLabels,
+    // Project management tools
+    addProjects,
+    // Section management tools
+    addSections,
     // Task management tools
     addTasks,
     completeTasks,
-    uncompleteTasks,
-    updateTasks,
-    findTasks,
-    findTasksByDate,
-    findCompletedTasks,
-    rescheduleTasks,
-    // Project management tools
-    addProjects,
-    updateProjects,
-    findProjects,
-    // Section management tools
-    addSections,
-    updateSections,
-    findSections,
-    // Comment management tools
-    addComments,
-    updateComments,
-    findComments,
-    // Attachment tools
-    viewAttachment,
-    // Label management tools
-    addLabels,
-    findLabels,
-    // Filter management tools
-    findFilters,
-    addFilters,
-    updateFilters,
+    deleteObject,
+    FEATURE_NAMES,
+    type Feature,
+    type FeatureName,
+    type Features,
+    fetch,
     // Activity and audit tools
     findActivity,
-    getProductivityStats,
-    // General tools
-    getOverview,
-    deleteObject,
-    reorderObjects,
-    userInfo,
+    findComments,
+    findCompletedTasks,
+    // Filter management tools
+    findFilters,
+    findLabels,
     // Assignment and collaboration tools
     findProjectCollaborators,
-    manageAssignments,
+    findProjects,
+    findSections,
+    findTasks,
+    findTasksByDate,
+    getMcpServer,
+    // General tools
+    getOverview,
+    getProductivityStats,
+    // Health and insights tools
+    getProjectHealth,
     // Workspace tools
     listWorkspaces,
+    manageAssignments,
+    reorderObjects,
+    rescheduleTasks,
     // OpenAI MCP tools
     search,
-    fetch,
+    tools,
+    uncompleteTasks,
+    updateComments,
+    updateFilters,
+    updateProjects,
+    updateSections,
+    updateTasks,
+    userInfo,
+    // Attachment tools
+    viewAttachment,
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -34,6 +34,7 @@ import { findTasksByDate } from './tools/find-tasks-by-date.js'
 import { createFindTasksByDateResource } from './tools/find-tasks-by-date.resource.js'
 import { getOverview } from './tools/get-overview.js'
 import { getProductivityStats } from './tools/get-productivity-stats.js'
+import { getProjectHealth } from './tools/get-project-health.js'
 import { listWorkspaces } from './tools/list-workspaces.js'
 import { manageAssignments } from './tools/manage-assignments.js'
 import { projectManagement } from './tools/project-management.js'
@@ -102,6 +103,9 @@ You have access to comprehensive Todoist management tools for personal productiv
 - **find-activity**: Retrieve recent activity logs to monitor and audit changes. Shows events from all users by default; use initiatorId to filter by specific user. Filter by object type (task/project/comment), event type (added/updated/deleted/completed/uncompleted/archived/unarchived/shared/left), and specific objects (objectId, projectId, taskId). Useful for tracking who did what and when. Note: Date-based filtering is not supported.
 - **get-productivity-stats**: Get comprehensive productivity statistics including daily/weekly completion breakdowns, goal streaks (current, last, max), karma score and trends, and historical karma data. No parameters required.
 
+**Project Health & Insights:**
+- **get-project-health**: Get comprehensive health assessment for a project including completion progress (completed/active counts, percentage), health status (EXCELLENT/ON_TRACK/AT_RISK/CRITICAL), description, and task-level recommendations. Use includeContext=true for detailed metrics (overdue tasks, weekly activity, avg completion time) and full task data. Health data may be stale — check isStale flag.
+
 **General Operations:**
 - **delete-object**: Remove projects, sections, tasks, comments, labels, or filters by type and ID
 - **fetch-object**: Fetch a single task, project, comment, or section by its ID
@@ -135,6 +139,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 - **Progress Reviews**: find-completed-tasks (defaults to last 7 days; optionally use explicit date ranges) → get-overview for project summaries
 - **Activity Auditing**: find-activity with event/object filters to track changes, monitor team activity, or investigate specific actions
 - **Productivity Analysis**: Use the productivity-analysis prompt for comprehensive analysis combining user-info, get-productivity-stats, and find-completed-tasks data into actionable insights
+- **Project Health Reviews**: get-project-health → get-project-health with includeContext=true for detailed metrics and task data
 
 Always provide clear, actionable task titles and descriptions. Use the overview tools to give users context about their workload and project status.
 `
@@ -233,6 +238,9 @@ function getMcpServer({
     registerTool({ tool: findActivity, ...toolArgs })
     registerTool({ tool: getProductivityStats, ...toolArgs })
 
+    // Health and insights tools
+    registerTool({ tool: getProjectHealth, ...toolArgs })
+
     // General tools
     registerTool({ tool: getOverview, ...toolArgs })
     registerTool({ tool: deleteObject, ...toolArgs })
@@ -267,4 +275,4 @@ function getMcpServer({
     return server
 }
 
-export { getMcpServer, FEATURE_NAMES, type Feature, type FeatureName, type Features }
+export { FEATURE_NAMES, type Feature, type FeatureName, type Features, getMcpServer }

--- a/src/tools/__tests__/get-project-health.test.ts
+++ b/src/tools/__tests__/get-project-health.test.ts
@@ -1,0 +1,324 @@
+import {
+    HEALTH_STATUSES,
+    type ProjectHealth,
+    type ProjectHealthContext,
+    type ProjectProgress,
+    type TodoistApi,
+} from '@doist/todoist-api-typescript'
+import { type Mocked, vi } from 'vitest'
+import { TEST_ERRORS } from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { getProjectHealth } from '../get-project-health.js'
+
+const mockTodoistApi = {
+    getProjectProgress: vi.fn(),
+    getProjectHealth: vi.fn(),
+    getProjectHealthContext: vi.fn(),
+} as unknown as Mocked<TodoistApi>
+
+const { GET_PROJECT_HEALTH } = ToolNames
+
+function createMockProgress(overrides: Partial<ProjectProgress> = {}): ProjectProgress {
+    return {
+        projectId: 'proj-123',
+        completedCount: 15,
+        activeCount: 10,
+        progressPercent: 60,
+        ...overrides,
+    }
+}
+
+function createMockHealth(overrides: Partial<ProjectHealth> = {}): ProjectHealth {
+    return {
+        status: 'ON_TRACK',
+        description: 'Project is progressing well.',
+        descriptionSummary: 'On track',
+        taskRecommendations: null,
+        projectId: 'proj-123',
+        updatedAt: '2026-03-28T10:00:00Z',
+        isStale: false,
+        updateInProgress: false,
+        ...overrides,
+    }
+}
+
+function createMockHealthContext(
+    overrides: Partial<ProjectHealthContext> = {},
+): ProjectHealthContext {
+    return {
+        projectId: 'proj-123',
+        projectName: 'Test Project',
+        projectDescription: 'A test project for health checks',
+        projectMetrics: {
+            totalTasks: 25,
+            completedTasks: 15,
+            overdueTasks: 3,
+            tasksCreatedThisWeek: 5,
+            tasksCompletedThisWeek: 4,
+            averageCompletionTime: 2.5,
+        },
+        tasks: [
+            {
+                id: 'task-1',
+                content: 'Fix the login bug',
+                priority: '1',
+                due: '2026-03-30',
+                deadline: null,
+                isCompleted: false,
+                createdAt: '2026-03-25T10:00:00Z',
+                updatedAt: '2026-03-27T10:00:00Z',
+                completedAt: null,
+                completedByUid: null,
+                labels: ['bug'],
+            },
+            {
+                id: 'task-2',
+                content: 'Write documentation',
+                priority: '3',
+                due: null,
+                deadline: null,
+                isCompleted: true,
+                createdAt: '2026-03-20T10:00:00Z',
+                updatedAt: '2026-03-26T10:00:00Z',
+                completedAt: '2026-03-26T10:00:00Z',
+                completedByUid: 'user-1',
+                labels: [],
+            },
+        ],
+        ...overrides,
+    }
+}
+
+describe('get-project-health tool', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('should have correct tool metadata', () => {
+        expect(getProjectHealth.name).toBe(GET_PROJECT_HEALTH)
+        expect(getProjectHealth.annotations).toEqual({
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+        })
+    })
+
+    it('should return combined progress and health data', async () => {
+        const mockProgress = createMockProgress()
+        const mockHealth = createMockHealth()
+
+        mockTodoistApi.getProjectProgress.mockResolvedValue(mockProgress)
+        mockTodoistApi.getProjectHealth.mockResolvedValue(mockHealth)
+
+        const result = await getProjectHealth.execute(
+            { projectId: 'proj-123', includeContext: false },
+            mockTodoistApi,
+        )
+
+        expect(mockTodoistApi.getProjectProgress).toHaveBeenCalledWith('proj-123')
+        expect(mockTodoistApi.getProjectHealth).toHaveBeenCalledWith('proj-123')
+        expect(mockTodoistApi.getProjectHealthContext).not.toHaveBeenCalled()
+
+        expect(result.structuredContent).toMatchObject({
+            projectId: 'proj-123',
+            progress: {
+                completedCount: 15,
+                activeCount: 10,
+                progressPercent: 60,
+            },
+            health: {
+                status: 'ON_TRACK',
+                description: 'Project is progressing well.',
+                isStale: false,
+                updateInProgress: false,
+            },
+        })
+
+        const structured = result.structuredContent as Record<string, unknown>
+        expect(structured.context).toBeUndefined()
+    })
+
+    it('should include context when includeContext is true', async () => {
+        const mockProgress = createMockProgress()
+        const mockHealth = createMockHealth()
+        const mockContext = createMockHealthContext()
+
+        mockTodoistApi.getProjectProgress.mockResolvedValue(mockProgress)
+        mockTodoistApi.getProjectHealth.mockResolvedValue(mockHealth)
+        mockTodoistApi.getProjectHealthContext.mockResolvedValue(mockContext)
+
+        const result = await getProjectHealth.execute(
+            { projectId: 'proj-123', includeContext: true },
+            mockTodoistApi,
+        )
+
+        expect(mockTodoistApi.getProjectHealthContext).toHaveBeenCalledWith('proj-123')
+
+        const structured = result.structuredContent as Record<string, unknown>
+        expect(structured).toHaveProperty('context')
+
+        const context = structured.context as Record<string, unknown>
+        expect(context).toMatchObject({
+            projectDescription: 'A test project for health checks',
+            projectMetrics: {
+                totalTasks: 25,
+                completedTasks: 15,
+                overdueTasks: 3,
+                tasksCreatedThisWeek: 5,
+                tasksCompletedThisWeek: 4,
+                averageCompletionTime: 2.5,
+            },
+        })
+
+        const tasks = context.tasks as Array<Record<string, unknown>>
+        expect(tasks).toHaveLength(2)
+        expect(tasks[0]).toMatchObject({
+            id: 'task-1',
+            content: 'Fix the login bug',
+            priority: '1',
+            due: '2026-03-30',
+            isCompleted: false,
+            labels: ['bug'],
+        })
+    })
+
+    it('should use project name from context when available', async () => {
+        const mockProgress = createMockProgress()
+        const mockHealth = createMockHealth()
+        const mockContext = createMockHealthContext({ projectName: 'My Named Project' })
+
+        mockTodoistApi.getProjectProgress.mockResolvedValue(mockProgress)
+        mockTodoistApi.getProjectHealth.mockResolvedValue(mockHealth)
+        mockTodoistApi.getProjectHealthContext.mockResolvedValue(mockContext)
+
+        const result = await getProjectHealth.execute(
+            { projectId: 'proj-123', includeContext: true },
+            mockTodoistApi,
+        )
+
+        expect(result.structuredContent).toMatchObject({ projectName: 'My Named Project' })
+        expect(result.textContent).toContain('My Named Project')
+    })
+
+    it('should fall back to project ID when context is not included', async () => {
+        const mockProgress = createMockProgress()
+        const mockHealth = createMockHealth()
+
+        mockTodoistApi.getProjectProgress.mockResolvedValue(mockProgress)
+        mockTodoistApi.getProjectHealth.mockResolvedValue(mockHealth)
+
+        const result = await getProjectHealth.execute(
+            { projectId: 'proj-123', includeContext: false },
+            mockTodoistApi,
+        )
+
+        expect(result.structuredContent).toMatchObject({ projectName: 'Project proj-123' })
+    })
+
+    it.each(HEALTH_STATUSES)('should handle %s health status in text output', async (status) => {
+        mockTodoistApi.getProjectProgress.mockResolvedValue(createMockProgress())
+        mockTodoistApi.getProjectHealth.mockResolvedValue(createMockHealth({ status }))
+
+        const result = await getProjectHealth.execute(
+            { projectId: 'proj-123', includeContext: false },
+            mockTodoistApi,
+        )
+
+        expect(result.textContent).toContain(`**Status:** ${status}`)
+        expect(result.structuredContent).toMatchObject({
+            health: { status },
+        })
+    })
+
+    it('should indicate stale health data in text output', async () => {
+        mockTodoistApi.getProjectProgress.mockResolvedValue(createMockProgress())
+        mockTodoistApi.getProjectHealth.mockResolvedValue(createMockHealth({ isStale: true }))
+
+        const result = await getProjectHealth.execute(
+            { projectId: 'proj-123', includeContext: false },
+            mockTodoistApi,
+        )
+
+        expect(result.textContent).toContain('Health data is stale')
+        expect(result.structuredContent).toMatchObject({
+            health: { isStale: true },
+        })
+    })
+
+    it('should indicate update in progress in text output', async () => {
+        mockTodoistApi.getProjectProgress.mockResolvedValue(createMockProgress())
+        mockTodoistApi.getProjectHealth.mockResolvedValue(
+            createMockHealth({ updateInProgress: true }),
+        )
+
+        const result = await getProjectHealth.execute(
+            { projectId: 'proj-123', includeContext: false },
+            mockTodoistApi,
+        )
+
+        expect(result.textContent).toContain('update is currently in progress')
+        expect(result.structuredContent).toMatchObject({
+            health: { updateInProgress: true },
+        })
+    })
+
+    it('should include task recommendations in output', async () => {
+        const recommendations = [
+            { taskId: 'task-1', recommendation: 'Break this task into subtasks' },
+            { taskId: 'task-2', recommendation: 'Set a due date' },
+        ]
+
+        mockTodoistApi.getProjectProgress.mockResolvedValue(createMockProgress())
+        mockTodoistApi.getProjectHealth.mockResolvedValue(
+            createMockHealth({ taskRecommendations: recommendations }),
+        )
+
+        const result = await getProjectHealth.execute(
+            { projectId: 'proj-123', includeContext: false },
+            mockTodoistApi,
+        )
+
+        expect(result.textContent).toContain('Task Recommendations')
+        expect(result.textContent).toContain('Break this task into subtasks')
+        expect(result.textContent).toContain('Set a due date')
+        expect(result.structuredContent).toMatchObject({
+            health: { taskRecommendations: recommendations },
+        })
+    })
+
+    it('should handle null average completion time in context', async () => {
+        const mockContext = createMockHealthContext({
+            projectMetrics: {
+                totalTasks: 5,
+                completedTasks: 0,
+                overdueTasks: 0,
+                tasksCreatedThisWeek: 5,
+                tasksCompletedThisWeek: 0,
+                averageCompletionTime: null,
+            },
+        })
+
+        mockTodoistApi.getProjectProgress.mockResolvedValue(createMockProgress())
+        mockTodoistApi.getProjectHealth.mockResolvedValue(createMockHealth())
+        mockTodoistApi.getProjectHealthContext.mockResolvedValue(mockContext)
+
+        const result = await getProjectHealth.execute(
+            { projectId: 'proj-123', includeContext: true },
+            mockTodoistApi,
+        )
+
+        expect(result.textContent).not.toContain('Avg Completion Time')
+    })
+
+    it('should propagate API errors', async () => {
+        mockTodoistApi.getProjectProgress.mockRejectedValue(new Error(TEST_ERRORS.API_RATE_LIMIT))
+        mockTodoistApi.getProjectHealth.mockResolvedValue(createMockHealth())
+
+        await expect(
+            getProjectHealth.execute(
+                { projectId: 'proj-123', includeContext: false },
+                mockTodoistApi,
+            ),
+        ).rejects.toThrow(TEST_ERRORS.API_RATE_LIMIT)
+    })
+})

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -216,6 +216,13 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         idempotentHint: true,
     },
     {
+        name: ToolNames.GET_PROJECT_HEALTH,
+        title: 'Todoist: Get Project Health',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    {
         name: ToolNames.GET_OVERVIEW,
         title: 'Todoist: Get Overview',
         readOnlyHint: true,

--- a/src/tools/__tests__/view-attachment.test.ts
+++ b/src/tools/__tests__/view-attachment.test.ts
@@ -1,4 +1,4 @@
-import type { TodoistApi, ViewAttachmentResponse } from '@doist/todoist-api-typescript'
+import type { FileResponse, TodoistApi } from '@doist/todoist-api-typescript'
 import type { Mocked } from 'vitest'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { viewAttachment } from '../view-attachment.js'
@@ -17,7 +17,7 @@ function createMockResponse({
     contentType?: string
     contentLength?: string
     body?: ArrayBuffer | string
-}): ViewAttachmentResponse {
+}): FileResponse {
     const headers: Record<string, string> = { 'content-type': contentType }
     if (contentLength) {
         headers['content-length'] = contentLength

--- a/src/tools/get-project-health.ts
+++ b/src/tools/get-project-health.ts
@@ -1,0 +1,264 @@
+import {
+    HEALTH_STATUSES,
+    type ProjectHealth,
+    type ProjectHealthContext,
+    type ProjectProgress,
+    type TodoistApi,
+} from '@doist/todoist-api-typescript'
+import { z } from 'zod'
+import type { TodoistTool } from '../todoist-tool.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    projectId: z.string().min(1).describe('The ID of the project to check health for.'),
+    includeContext: z
+        .boolean()
+        .default(false)
+        .describe(
+            'Include detailed health context with project metrics and task-level data. May produce large output for projects with many tasks.',
+        ),
+}
+
+const TaskRecommendationOutputSchema = z.object({
+    taskId: z.string().describe('The ID of the task this recommendation is for.'),
+    recommendation: z.string().describe('The recommendation for this task.'),
+})
+
+const TaskContextOutputSchema = z.object({
+    id: z.string().describe('The task ID.'),
+    content: z.string().describe('The task content/title.'),
+    priority: z.string().describe('The task priority (1-4).'),
+    due: z.string().nullable().optional().describe('The due date string, if set.'),
+    deadline: z.string().nullable().optional().describe('The deadline date string, if set.'),
+    isCompleted: z.boolean().describe('Whether the task is completed.'),
+    labels: z.array(z.string()).describe('Labels applied to this task.'),
+})
+
+const OutputSchema = {
+    projectId: z.string().describe('The project ID.'),
+    projectName: z.string().describe('The project name.'),
+    progress: z
+        .object({
+            completedCount: z.number().describe('Number of completed tasks.'),
+            activeCount: z.number().describe('Number of active (incomplete) tasks.'),
+            progressPercent: z.number().describe('Completion percentage (0-100).'),
+        })
+        .describe('Project completion progress.'),
+    health: z
+        .object({
+            status: z.enum(HEALTH_STATUSES).describe('The overall health status of the project.'),
+            description: z
+                .string()
+                .nullable()
+                .optional()
+                .describe('Detailed description of the health assessment.'),
+            descriptionSummary: z
+                .string()
+                .nullable()
+                .optional()
+                .describe('Brief summary of the health assessment.'),
+            taskRecommendations: z
+                .array(TaskRecommendationOutputSchema)
+                .nullable()
+                .optional()
+                .describe('Specific recommendations for individual tasks.'),
+            isStale: z
+                .boolean()
+                .describe('Whether the health data is stale and may need refreshing.'),
+            updateInProgress: z
+                .boolean()
+                .describe('Whether a health analysis update is currently in progress.'),
+            updatedAt: z
+                .string()
+                .nullable()
+                .optional()
+                .describe('When the health assessment was last updated.'),
+        })
+        .describe('Project health assessment.'),
+    context: z
+        .object({
+            projectDescription: z.string().nullable().describe('The project description, if any.'),
+            projectMetrics: z
+                .object({
+                    totalTasks: z.number().describe('Total number of tasks in the project.'),
+                    completedTasks: z.number().describe('Number of completed tasks.'),
+                    overdueTasks: z.number().describe('Number of overdue tasks.'),
+                    tasksCreatedThisWeek: z.number().describe('Tasks created in the current week.'),
+                    tasksCompletedThisWeek: z
+                        .number()
+                        .describe('Tasks completed in the current week.'),
+                    averageCompletionTime: z
+                        .number()
+                        .nullable()
+                        .describe('Average task completion time in days, if available.'),
+                })
+                .describe('Aggregated project metrics.'),
+            tasks: z.array(TaskContextOutputSchema).describe('Tasks in the project.'),
+        })
+        .optional()
+        .describe(
+            'Detailed project context with metrics and task data. Only included when includeContext is true.',
+        ),
+}
+
+type HealthData = {
+    progress: ProjectProgress
+    health: ProjectHealth
+    context?: ProjectHealthContext
+}
+
+async function fetchHealthData(
+    client: TodoistApi,
+    projectId: string,
+    includeContext: boolean,
+): Promise<HealthData> {
+    if (includeContext) {
+        const [progress, health, context] = await Promise.all([
+            client.getProjectProgress(projectId),
+            client.getProjectHealth(projectId),
+            client.getProjectHealthContext(projectId),
+        ])
+        return { progress, health, context }
+    }
+
+    const [progress, health] = await Promise.all([
+        client.getProjectProgress(projectId),
+        client.getProjectHealth(projectId),
+    ])
+    return { progress, health }
+}
+
+function generateTextContent(
+    projectName: string,
+    { progress, health, context }: HealthData,
+): string {
+    const lines: string[] = [`# Project Health: ${projectName}`, '']
+
+    // Health status
+    lines.push(`**Status:** ${health.status}`)
+    if (health.isStale) {
+        lines.push('**Note:** Health data is stale and may not reflect recent changes.')
+    }
+    if (health.updateInProgress) {
+        lines.push('**Note:** A health analysis update is currently in progress.')
+    }
+    if (health.updatedAt) {
+        lines.push(`**Last Updated:** ${health.updatedAt}`)
+    }
+
+    // Progress
+    lines.push('')
+    lines.push('## Progress')
+    lines.push(
+        `**Completed:** ${progress.completedCount} | **Active:** ${progress.activeCount} | **Progress:** ${progress.progressPercent}%`,
+    )
+
+    // Description
+    if (health.description) {
+        lines.push('')
+        lines.push('## Health Description')
+        lines.push(health.description)
+    }
+
+    // Task recommendations
+    if (health.taskRecommendations && health.taskRecommendations.length > 0) {
+        lines.push('')
+        lines.push('## Task Recommendations')
+        for (const rec of health.taskRecommendations) {
+            lines.push(`- **Task ${rec.taskId}**: ${rec.recommendation}`)
+        }
+    }
+
+    // Context (if included)
+    if (context) {
+        lines.push('')
+        lines.push('## Project Metrics')
+        const m = context.projectMetrics
+        lines.push(`- **Total Tasks:** ${m.totalTasks}`)
+        lines.push(`- **Completed:** ${m.completedTasks}`)
+        lines.push(`- **Overdue:** ${m.overdueTasks}`)
+        lines.push(`- **Created This Week:** ${m.tasksCreatedThisWeek}`)
+        lines.push(`- **Completed This Week:** ${m.tasksCompletedThisWeek}`)
+        if (m.averageCompletionTime !== null) {
+            lines.push(`- **Avg Completion Time:** ${m.averageCompletionTime} days`)
+        }
+
+        if (context.tasks.length > 0) {
+            lines.push('')
+            lines.push(`## Tasks (${context.tasks.length})`)
+            for (const task of context.tasks) {
+                const parts = [`id=${task.id}`, task.content]
+                if (task.due) parts.push(`due=${task.due}`)
+                if (task.deadline) parts.push(`deadline=${task.deadline}`)
+                if (task.isCompleted) parts.push('(completed)')
+                lines.push(`- ${parts.join('; ')}`)
+            }
+        }
+    }
+
+    return lines.join('\n')
+}
+
+const getProjectHealth = {
+    name: ToolNames.GET_PROJECT_HEALTH,
+    description:
+        'Get a comprehensive health assessment for a project including completion progress, health status (EXCELLENT, ON_TRACK, AT_RISK, CRITICAL), and optional detailed context with project metrics and task-level recommendations. Use includeContext=true for full detail including task data.',
+    parameters: ArgsSchema,
+    outputSchema: OutputSchema,
+    annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    async execute(args, client) {
+        const { projectId, includeContext } = args
+
+        const data = await fetchHealthData(client, projectId, includeContext)
+
+        // Get project name from context if available, otherwise from health context or progress
+        const projectName = data.context?.projectName ?? `Project ${projectId}`
+
+        const textContent = generateTextContent(projectName, data)
+
+        const context = data.context
+            ? {
+                  projectDescription: data.context.projectDescription,
+                  projectMetrics: data.context.projectMetrics,
+                  tasks: data.context.tasks.map((task) => ({
+                      id: task.id,
+                      content: task.content,
+                      priority: task.priority,
+                      due: task.due ?? null,
+                      deadline: task.deadline ?? null,
+                      isCompleted: task.isCompleted,
+                      labels: task.labels,
+                  })),
+              }
+            : undefined
+
+        return {
+            textContent,
+            structuredContent: {
+                projectId,
+                projectName,
+                progress: {
+                    completedCount: data.progress.completedCount,
+                    activeCount: data.progress.activeCount,
+                    progressPercent: data.progress.progressPercent,
+                },
+                health: {
+                    status: data.health.status,
+                    description: data.health.description ?? null,
+                    descriptionSummary: data.health.descriptionSummary ?? null,
+                    taskRecommendations: data.health.taskRecommendations ?? null,
+                    isStale: data.health.isStale,
+                    updateInProgress: data.health.updateInProgress,
+                    updatedAt: data.health.updatedAt ?? null,
+                },
+                context,
+            },
+        }
+    },
+} satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
+
+export { getProjectHealth }

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -44,6 +44,9 @@ export const ToolNames = {
     FIND_ACTIVITY: 'find-activity',
     GET_PRODUCTIVITY_STATS: 'get-productivity-stats',
 
+    // Health and insights tools
+    GET_PROJECT_HEALTH: 'get-project-health',
+
     // General tools
     GET_OVERVIEW: 'get-overview',
     DELETE_OBJECT: 'delete-object',


### PR DESCRIPTION
## Summary
- Adds a new `get-project-health` read-only MCP tool that provides a comprehensive health assessment for a project in a single call
- Combines progress data (completed/active counts, percentage), health status (EXCELLENT/ON_TRACK/AT_RISK/CRITICAL), and optional detailed context with task-level recommendations
- Upgrades `@doist/todoist-api-typescript` from 7.3.0 to 7.8.0 to access the new project health endpoints

## Test plan
- [x] 16 new tests covering all health statuses, context inclusion/exclusion, stale/in-progress flags, task recommendations, and error propagation
- [x] All 709 tests pass
- [x] TypeScript type check clean
- [x] Schema validation passes
- [x] Build succeeds
- [ ] Manual test with `npx tsx scripts/run-tool.ts get-project-health '{"projectId":"<id>"}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)