### PR TITLE
fix: remove biome format step from release pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
             "devDependencies": {
                 "@biomejs/biome": "2.4.7",
                 "@semantic-release/changelog": "6.0.3",
-                "@semantic-release/exec": "7.1.0",
                 "@semantic-release/git": "10.0.1",
                 "@types/dompurify": "3.2.0",
                 "@types/express": "5.0.6",
@@ -1668,37 +1667,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14.17"
-            }
-        },
-        "node_modules/@semantic-release/exec": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-7.1.0.tgz",
-            "integrity": "sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@semantic-release/error": "^4.0.0",
-                "aggregate-error": "^3.0.0",
-                "debug": "^4.0.0",
-                "execa": "^9.0.0",
-                "lodash-es": "^4.17.21",
-                "parse-json": "^8.0.0"
-            },
-            "engines": {
-                "node": ">=20.8.1"
-            },
-            "peerDependencies": {
-                "semantic-release": ">=24.1.0"
-            }
-        },
-        "node_modules/@semantic-release/exec/node_modules/@semantic-release/error": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-            "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/@semantic-release/git": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "devDependencies": {
         "@biomejs/biome": "2.4.7",
         "@semantic-release/changelog": "6.0.3",
-        "@semantic-release/exec": "7.1.0",
         "@semantic-release/git": "10.0.1",
         "@types/dompurify": "3.2.0",
         "@types/express": "5.0.6",

--- a/release.config.js
+++ b/release.config.js
@@ -7,10 +7,6 @@ export default {
         ['@semantic-release/commit-analyzer', { preset: 'conventionalcommits' }],
         ['@semantic-release/release-notes-generator', { preset: 'conventionalcommits' }],
         '@semantic-release/changelog',
-        [
-            '@semantic-release/exec',
-            { prepareCmd: 'npx @biomejs/biome format --write CHANGELOG.md' },
-        ],
         '@semantic-release/npm',
         [
             '@semantic-release/git',


### PR DESCRIPTION
## Summary
- Removes the `@semantic-release/exec` step that ran `npx @biomejs/biome format --write CHANGELOG.md` during releases
- Biome doesn't support formatting Markdown files, causing the release to fail with exit code 1
- Removes the now-unused `@semantic-release/exec` devDependency

## Test plan
- [ ] Verify the release workflow passes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)