### PR TITLE
fix: prevent dist cleanup plugin from running during vitest

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ const PRESERVED_DIST_ENTRIES = new Set(['mcp-apps'])
 function cleanDistPreservingMcpApps(): Plugin {
     return {
         name: 'clean-dist-preserving-mcp-apps',
+        apply: 'build',
         buildStart() {
             if (!existsSync(DIST_DIR)) {
                 return


### PR DESCRIPTION
## Summary
- The `cleanDistPreservingMcpApps` Vite plugin's `buildStart` hook was firing during Vitest initialization, deleting all JS/declaration files from `dist/` after the build step in `prepublishOnly`
- This caused the published v8.7.0 package to only contain `dist/mcp-apps/index.html` (no JS, no type declarations)
- Adding `apply: 'build'` restricts the plugin to `vite build` commands only, not `vite serve` (used by Vitest)

## Test plan
- [x] `npm run build` produces all expected files in `dist/`
- [x] `npm test` (755/755 passing) no longer cleans `dist/`
- [x] `npm pack --dry-run` shows all 151 files (vs 7 in broken release)
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)