### PR TITLE
fix: update SDK to v7.9.1 and handle optional workspace fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "8.7.1",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-api-typescript": "7.8.0",
+                "@doist/todoist-api-typescript": "7.9.1",
                 "@modelcontextprotocol/ext-apps": "1.2.2",
                 "date-fns": "4.1.0",
                 "dompurify": "3.3.3",
@@ -622,9 +622,9 @@
             }
         },
         "node_modules/@doist/todoist-api-typescript": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-7.8.0.tgz",
-            "integrity": "sha512-Ckf6fEbuNOYvz0y3gD96TceXovjC9SwTVBPAKu+Cpg3Na5c5jIVVCWkpMo7+eDG+cHYxy9KefeFqOKABQS87hQ==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-7.9.1.tgz",
+            "integrity": "sha512-ytJrMYOHvdNyKBYdB9WU7EkDqqJ4/W7dE+GXiVTDpujMyk6miSPtsUEcTwlJYp4kHPKKzH+3/TZ66pp0w4Bo8A==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-api-typescript": "7.8.0",
+        "@doist/todoist-api-typescript": "7.9.1",
         "@modelcontextprotocol/ext-apps": "1.2.2",
         "date-fns": "4.1.0",
         "dompurify": "3.3.3",

--- a/src/tools/list-workspaces.ts
+++ b/src/tools/list-workspaces.ts
@@ -15,12 +15,18 @@ const WorkspaceOutputSchema = {
     id: z.string().describe('The unique identifier for the workspace.'),
     name: z.string().describe('The name of the workspace.'),
     plan: z.enum(WORKSPACE_PLANS).describe('The workspace plan type.'),
-    role: z.enum(WORKSPACE_ROLES).describe("The user's role in the workspace."),
+    role: z
+        .enum(WORKSPACE_ROLES)
+        .optional()
+        .describe("The user's role in the workspace, if available."),
     isLinkSharingEnabled: z
         .boolean()
         .describe('Whether link sharing is enabled for the workspace.'),
     isGuestAllowed: z.boolean().describe('Whether guests are allowed in the workspace.'),
-    createdAt: z.string().describe('The ISO 8601 timestamp when the workspace was created.'),
+    createdAt: z
+        .string()
+        .optional()
+        .describe('The ISO 8601 timestamp when the workspace was created.'),
     creatorId: z.string().describe('The ID of the user who created the workspace.'),
 }
 
@@ -34,10 +40,10 @@ type WorkspaceOutput = {
     id: string
     name: string
     plan: WorkspacePlan
-    role: WorkspaceRole
+    role?: WorkspaceRole
     isLinkSharingEnabled: boolean
     isGuestAllowed: boolean
-    createdAt: string
+    createdAt?: string
     creatorId: string
 }
 
@@ -78,12 +84,16 @@ async function generateWorkspacesList(
             lines.push(`## ${workspace.name}`)
             lines.push(`- **ID:** ${workspace.id}`)
             lines.push(`- **Plan:** ${workspace.plan}`)
-            lines.push(`- **Your Role:** ${workspace.role}`)
+            if (workspace.role) {
+                lines.push(`- **Your Role:** ${workspace.role}`)
+            }
             lines.push(
                 `- **Link Sharing:** ${workspace.isLinkSharingEnabled ? 'Enabled' : 'Disabled'}`,
             )
             lines.push(`- **Guests Allowed:** ${workspace.isGuestAllowed ? 'Yes' : 'No'}`)
-            lines.push(`- **Created:** ${workspace.createdAt}`)
+            if (workspace.createdAt) {
+                lines.push(`- **Created:** ${workspace.createdAt}`)
+            }
             lines.push(`- **Creator ID:** ${workspace.creatorId}`)
             lines.push('')
         }


### PR DESCRIPTION
## Summary

- Updates `@doist/todoist-api-typescript` to v7.9.1, which fixes Zod validation errors in `getWorkspaces()` — the REST API returns numeric IDs and omits `role`, `limits`, and `createdAt` fields
- Updates the `list-workspaces` tool to handle the now-optional `role` and `createdAt` fields

This also fixes `add-projects` with a `workspace` parameter (Bug 3 in the issue), since workspace resolution calls `getWorkspaces()` internally.

Related: #426

## Test plan

- [x] `list-workspaces` returns all workspaces via `run-tool.ts` against live API
- [x] `add-projects` with workspace parameter works against live API
- [x] Typecheck passes
- [x] All 755 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)