### PR TITLE
fix: Remove host-agnostic ui.domain metadata

### DIFF
--- a/src/mcp-apps/resources.test.ts
+++ b/src/mcp-apps/resources.test.ts
@@ -26,7 +26,6 @@ describe('registerTaskListApp', () => {
                         connectDomains: [],
                         resourceDomains: [],
                     },
-                    domain: 'https://ai.todoist.net',
                 },
                 'openai/widgetDescription': 'Interactive task list widget',
                 'openai/widgetPrefersBorder': true,
@@ -48,6 +47,9 @@ describe('registerTaskListApp', () => {
         }
 
         const result = await readCallback()
+        const registerConfigMeta = registerResourceSpy.mock.calls[0]?.[2]?._meta as
+            | { ui?: Record<string, unknown> }
+            | undefined
 
         expect(result.contents).toHaveLength(1)
         expect(result.contents[0]?.uri).toBe(taskListResourceUri)
@@ -55,6 +57,7 @@ describe('registerTaskListApp', () => {
         expect(result.contents[0]?.text).toContain(
             '<script type="module" src="/main.tsx"></script>',
         )
+        expect(registerConfigMeta?.ui).not.toHaveProperty('domain')
         expect(result.contents[0]?._meta).toMatchObject({
             ui: {
                 prefersBorder: true,
@@ -62,7 +65,6 @@ describe('registerTaskListApp', () => {
                     connectDomains: [],
                     resourceDomains: [],
                 },
-                domain: 'https://ai.todoist.net',
             },
             'openai/widgetDescription': 'Interactive task list widget',
             'openai/widgetPrefersBorder': true,
@@ -72,5 +74,8 @@ describe('registerTaskListApp', () => {
             },
             'openai/widgetDomain': 'https://ai.todoist.net',
         })
+        expect(
+            (result.contents[0]?._meta as { ui?: Record<string, unknown> } | undefined)?.ui,
+        ).not.toHaveProperty('domain')
     })
 })

--- a/src/mcp-apps/resources.ts
+++ b/src/mcp-apps/resources.ts
@@ -37,7 +37,6 @@ const taskListHtml = loadTaskListHtml()
 const taskListHash = createHash('sha256').update(taskListHtml).digest('hex').slice(0, 12)
 const taskListResourceUri = `ui://todoist/task-list@${taskListHash}`
 const taskListResourceDescription = 'Interactive task list widget'
-// Apps SDK expects an origin here, so use the hosted MCP origin rather than the full /mcp URL.
 const taskListWidgetDomain = 'https://ai.todoist.net'
 const taskListResourceMeta = {
     ui: {
@@ -47,7 +46,6 @@ const taskListResourceMeta = {
             connectDomains: [] as string[],
             resourceDomains: [] as string[],
         },
-        domain: taskListWidgetDomain,
     },
     'openai/widgetDescription': taskListResourceDescription,
     'openai/widgetPrefersBorder': true,


### PR DESCRIPTION
## Summary
- remove `_meta.ui.domain` from the task list MCP App resource so we do not advertise a host-specific sandbox origin to every host
- keep `_meta["openai/widgetDomain"] = "https://ai.todoist.net"` for ChatGPT/OpenAI compatibility
- update the resource test to assert `ui.domain` is absent in both the registered metadata and returned resource contents

## Reference

Closes https://github.com/Doist/todoist-ai/issues/432
Fixes Doist/Issues#19953

## Testing

- [ ] Run the app with `npm run dev:http`, expose the http server (e.g. with ngrok) and set it up in Claude -> you should be able to use the app


## Docs
- MCP Apps `domain` is host-dependent and falls back to the host default when omitted: https://apps.extensions.modelcontextprotocol.io/api/interfaces/app.McpUiResourceMeta.html#domain
- `registerAppResource()` docs show Claude-style hashed `*.claudemcpcontent.com` domains as a host-specific example: https://apps.extensions.modelcontextprotocol.io/api/functions/server-helpers.registerAppResource.html
- OpenAI documents `_meta["openai/widgetDomain"]` as the ChatGPT compatibility alias for a dedicated origin: https://developers.openai.com/apps-sdk/reference
