### PR TITLE
fix: remove ui.domain from MCP Apps metadata for Claude Desktop compatibility

### DIFF
--- a/src/mcp-apps/resources.test.ts
+++ b/src/mcp-apps/resources.test.ts
@@ -26,7 +26,6 @@ describe('registerTaskListApp', () => {
                         connectDomains: [],
                         resourceDomains: [],
                     },
-                    domain: 'https://ai.todoist.net',
                 },
                 'openai/widgetDescription': 'Interactive task list widget',
                 'openai/widgetPrefersBorder': true,
@@ -37,6 +36,11 @@ describe('registerTaskListApp', () => {
                 'openai/widgetDomain': 'https://ai.todoist.net',
             },
         })
+
+        const registeredMeta = (
+            registerResourceSpy.mock.calls[0]?.[2] as { _meta: { ui: Record<string, unknown> } }
+        )._meta.ui
+        expect(registeredMeta).not.toHaveProperty('domain')
 
         const readCallback = registerResourceSpy.mock.calls[0]?.[3] as
             | (() => Promise<{ contents: Array<{ uri: string; text: string; _meta?: unknown }> }>)
@@ -62,7 +66,6 @@ describe('registerTaskListApp', () => {
                     connectDomains: [],
                     resourceDomains: [],
                 },
-                domain: 'https://ai.todoist.net',
             },
             'openai/widgetDescription': 'Interactive task list widget',
             'openai/widgetPrefersBorder': true,
@@ -72,5 +75,8 @@ describe('registerTaskListApp', () => {
             },
             'openai/widgetDomain': 'https://ai.todoist.net',
         })
+
+        const contentMeta = (result.contents[0]?._meta as { ui: Record<string, unknown> }).ui
+        expect(contentMeta).not.toHaveProperty('domain')
     })
 })

--- a/src/mcp-apps/resources.ts
+++ b/src/mcp-apps/resources.ts
@@ -37,7 +37,6 @@ const taskListHtml = loadTaskListHtml()
 const taskListHash = createHash('sha256').update(taskListHtml).digest('hex').slice(0, 12)
 const taskListResourceUri = `ui://todoist/task-list@${taskListHash}`
 const taskListResourceDescription = 'Interactive task list widget'
-// Apps SDK expects an origin here, so use the hosted MCP origin rather than the full /mcp URL.
 const taskListWidgetDomain = 'https://ai.todoist.net'
 const taskListResourceMeta = {
     ui: {
@@ -47,7 +46,6 @@ const taskListResourceMeta = {
             connectDomains: [] as string[],
             resourceDomains: [] as string[],
         },
-        domain: taskListWidgetDomain,
     },
     'openai/widgetDescription': taskListResourceDescription,
     'openai/widgetPrefersBorder': true,


### PR DESCRIPTION
## Summary

- Fixes Claude Desktop rejecting the Todoist MCP connection due to invalid `ui.domain` format — Claude expects `{hash}.claudemcpcontent.com` but we were sending `https://ai.todoist.net`
- Removes `ui.domain` from the MCP Apps resource metadata since the task list widget is fully self-contained (no network requests, empty CSP arrays) and does not need a dedicated sandbox origin
- Keeps `openai/widgetDomain` unchanged as it's a separate vendor-specific field with different format expectations

Fixes Doist/Issues#19953

## Test plan

- [x] All 760 tests pass
- [x] Build succeeds
- [x] Added explicit `not.toHaveProperty('domain')` assertions to verify `ui.domain` is absent from both registered resource metadata and read resource content


Made with [Cursor](https://cursor.com)