### PR TITLE
fix: add retry with exponential backoff for transient 5xx errors

### DIFF
--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -5,6 +5,7 @@ import type { ContentBlock, ToolAnnotations } from '@modelcontextprotocol/sdk/ty
 import type { z } from 'zod'
 import type { TodoistTool } from './todoist-tool.js'
 import { formatToolExecutionError } from './tool-execution-error.js'
+import { executeWithRetry } from './utils/retry.js'
 import { removeNullFields } from './utils/sanitize-data.js'
 import { ToolNames } from './utils/tool-names.js'
 
@@ -236,9 +237,8 @@ function registerTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape
     // @ts-expect-error I give up
     const cb: ToolCallback<Params> = async (args: z.infer<z.ZodObject<Params>>, _context) => {
         try {
-            let { textContent, structuredContent, contentItems } = await tool.execute(
-                args as z.infer<z.ZodObject<Params>>,
-                client,
+            let { textContent, structuredContent, contentItems } = await executeWithRetry(() =>
+                tool.execute(args as z.infer<z.ZodObject<Params>>, client),
             )
 
             // Strip emails from outputs for ChatGPT clients on collaborator-related tools

--- a/src/utils/retry.test.ts
+++ b/src/utils/retry.test.ts
@@ -1,0 +1,288 @@
+import { executeWithRetry, extractHttpStatusCode, isTransientError } from './retry.js'
+
+const NO_DELAY: { baseDelayMs: number; maxDelayMs: number } = {
+    baseDelayMs: 0,
+    maxDelayMs: 0,
+}
+
+describe('extractHttpStatusCode', () => {
+    it('should extract httpStatusCode from TodoistRequestError shape', () => {
+        const error = { httpStatusCode: 503, message: 'Service Unavailable' }
+        expect(extractHttpStatusCode(error)).toBe(503)
+    })
+
+    it('should extract statusCode property', () => {
+        const error = { statusCode: 502 }
+        expect(extractHttpStatusCode(error)).toBe(502)
+    })
+
+    it('should extract status property', () => {
+        const error = { status: 504 }
+        expect(extractHttpStatusCode(error)).toBe(504)
+    })
+
+    it('should extract status code from Error message', () => {
+        const error = new Error('HTTP 503: Service Unavailable')
+        expect(extractHttpStatusCode(error)).toBe(503)
+    })
+
+    it('should return undefined for null', () => {
+        expect(extractHttpStatusCode(null)).toBeUndefined()
+    })
+
+    it('should return undefined for undefined', () => {
+        expect(extractHttpStatusCode(undefined)).toBeUndefined()
+    })
+
+    it('should return undefined for non-object', () => {
+        expect(extractHttpStatusCode('string error')).toBeUndefined()
+    })
+
+    it('should return undefined for object without status code', () => {
+        expect(extractHttpStatusCode({ message: 'Something went wrong' })).toBeUndefined()
+    })
+
+    it('should return undefined for Error without status in message', () => {
+        const error = new Error('Something went wrong')
+        expect(extractHttpStatusCode(error)).toBeUndefined()
+    })
+
+    it('should prefer httpStatusCode over statusCode', () => {
+        const error = { httpStatusCode: 503, statusCode: 400 }
+        expect(extractHttpStatusCode(error)).toBe(503)
+    })
+})
+
+describe('isTransientError', () => {
+    it('should return true for 502 Bad Gateway', () => {
+        expect(isTransientError({ httpStatusCode: 502 })).toBe(true)
+    })
+
+    it('should return true for 503 Service Unavailable', () => {
+        expect(isTransientError({ httpStatusCode: 503 })).toBe(true)
+    })
+
+    it('should return true for 504 Gateway Timeout', () => {
+        expect(isTransientError({ httpStatusCode: 504 })).toBe(true)
+    })
+
+    it('should return false for 500 Internal Server Error', () => {
+        expect(isTransientError({ httpStatusCode: 500 })).toBe(false)
+    })
+
+    it('should return false for 400 Bad Request', () => {
+        expect(isTransientError({ httpStatusCode: 400 })).toBe(false)
+    })
+
+    it('should return false for 401 Unauthorized', () => {
+        expect(isTransientError({ httpStatusCode: 401 })).toBe(false)
+    })
+
+    it('should return false for 404 Not Found', () => {
+        expect(isTransientError({ httpStatusCode: 404 })).toBe(false)
+    })
+
+    it('should return false for 429 Too Many Requests', () => {
+        expect(isTransientError({ httpStatusCode: 429 })).toBe(false)
+    })
+
+    it('should return false for errors without status code', () => {
+        expect(isTransientError(new Error('Unknown error'))).toBe(false)
+    })
+
+    it('should return false for null', () => {
+        expect(isTransientError(null)).toBe(false)
+    })
+
+    it('should detect transient error from message', () => {
+        expect(isTransientError(new Error('HTTP 503: Service Unavailable'))).toBe(true)
+    })
+})
+
+describe('executeWithRetry', () => {
+    it('should return result on first successful attempt', async () => {
+        const fn = vi.fn().mockResolvedValue('success')
+
+        const result = await executeWithRetry(fn, NO_DELAY)
+
+        expect(result).toBe('success')
+        expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should retry on 503 and succeed on second attempt', async () => {
+        const error503 = Object.assign(new Error('HTTP 503: Service Unavailable'), {
+            httpStatusCode: 503,
+        })
+        const fn = vi.fn().mockRejectedValueOnce(error503).mockResolvedValue('success')
+
+        const result = await executeWithRetry(fn, NO_DELAY)
+
+        expect(result).toBe('success')
+        expect(fn).toHaveBeenCalledTimes(2)
+    })
+
+    it('should retry on 502 and succeed on third attempt', async () => {
+        const error502 = Object.assign(new Error('HTTP 502: Bad Gateway'), {
+            httpStatusCode: 502,
+        })
+        const fn = vi
+            .fn()
+            .mockRejectedValueOnce(error502)
+            .mockRejectedValueOnce(error502)
+            .mockResolvedValue('success')
+
+        const result = await executeWithRetry(fn, NO_DELAY)
+
+        expect(result).toBe('success')
+        expect(fn).toHaveBeenCalledTimes(3)
+    })
+
+    it('should throw after exhausting all retries on persistent 503', async () => {
+        const error503 = Object.assign(new Error('HTTP 503: Service Unavailable'), {
+            httpStatusCode: 503,
+        })
+        const fn = vi.fn().mockRejectedValue(error503)
+
+        await expect(executeWithRetry(fn, NO_DELAY)).rejects.toThrow(
+            'HTTP 503: Service Unavailable',
+        )
+        expect(fn).toHaveBeenCalledTimes(3)
+    })
+
+    it('should not retry on 400 Bad Request', async () => {
+        const error400 = Object.assign(new Error('HTTP 400: Bad Request'), {
+            httpStatusCode: 400,
+        })
+        const fn = vi.fn().mockRejectedValue(error400)
+
+        await expect(executeWithRetry(fn, NO_DELAY)).rejects.toThrow('HTTP 400: Bad Request')
+        expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not retry on 401 Unauthorized', async () => {
+        const error401 = Object.assign(new Error('HTTP 401: Unauthorized'), {
+            httpStatusCode: 401,
+        })
+        const fn = vi.fn().mockRejectedValue(error401)
+
+        await expect(executeWithRetry(fn, NO_DELAY)).rejects.toThrow('HTTP 401: Unauthorized')
+        expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not retry on 404 Not Found', async () => {
+        const error404 = Object.assign(new Error('HTTP 404: Not Found'), {
+            httpStatusCode: 404,
+        })
+        const fn = vi.fn().mockRejectedValue(error404)
+
+        await expect(executeWithRetry(fn, NO_DELAY)).rejects.toThrow('HTTP 404: Not Found')
+        expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not retry on 500 Internal Server Error', async () => {
+        const error500 = Object.assign(new Error('HTTP 500: Internal Server Error'), {
+            httpStatusCode: 500,
+        })
+        const fn = vi.fn().mockRejectedValue(error500)
+
+        await expect(executeWithRetry(fn, NO_DELAY)).rejects.toThrow(
+            'HTTP 500: Internal Server Error',
+        )
+        expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not retry on non-HTTP errors', async () => {
+        const fn = vi.fn().mockRejectedValue(new Error('Network failure'))
+
+        await expect(executeWithRetry(fn, NO_DELAY)).rejects.toThrow('Network failure')
+        expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should retry on 504 Gateway Timeout', async () => {
+        const error504 = Object.assign(new Error('HTTP 504: Gateway Timeout'), {
+            httpStatusCode: 504,
+        })
+        const fn = vi.fn().mockRejectedValueOnce(error504).mockResolvedValue('recovered')
+
+        const result = await executeWithRetry(fn, NO_DELAY)
+
+        expect(result).toBe('recovered')
+        expect(fn).toHaveBeenCalledTimes(2)
+    })
+
+    it('should respect custom maxRetries config', async () => {
+        const error503 = Object.assign(new Error('HTTP 503: Service Unavailable'), {
+            httpStatusCode: 503,
+        })
+        const fn = vi.fn().mockRejectedValue(error503)
+
+        await expect(executeWithRetry(fn, { maxRetries: 1, ...NO_DELAY })).rejects.toThrow(
+            'HTTP 503: Service Unavailable',
+        )
+        expect(fn).toHaveBeenCalledTimes(2)
+    })
+
+    it('should use exponential backoff delays', async () => {
+        vi.useFakeTimers()
+
+        const error503 = Object.assign(new Error('HTTP 503: Service Unavailable'), {
+            httpStatusCode: 503,
+        })
+        const fn = vi.fn().mockRejectedValueOnce(error503).mockResolvedValue('recovered')
+        const sleepSpy = vi.spyOn(globalThis, 'setTimeout')
+
+        const promise = executeWithRetry(fn, { baseDelayMs: 500, maxDelayMs: 2000 })
+        await vi.advanceTimersByTimeAsync(500)
+        const result = await promise
+
+        expect(result).toBe('recovered')
+
+        const retryDelays = sleepSpy.mock.calls
+            .filter(([, delay]) => typeof delay === 'number' && delay >= 500)
+            .map(([, delay]) => delay)
+
+        expect(retryDelays).toContain(500)
+
+        vi.useRealTimers()
+    })
+
+    it('should cap delay at maxDelayMs', async () => {
+        vi.useFakeTimers()
+
+        const error503 = Object.assign(new Error('HTTP 503: Service Unavailable'), {
+            httpStatusCode: 503,
+        })
+        const fn = vi
+            .fn()
+            .mockRejectedValueOnce(error503)
+            .mockRejectedValueOnce(error503)
+            .mockResolvedValue('recovered')
+        const sleepSpy = vi.spyOn(globalThis, 'setTimeout')
+
+        const promise = executeWithRetry(fn, { baseDelayMs: 1000, maxDelayMs: 1500 })
+        await vi.advanceTimersByTimeAsync(1000)
+        await vi.advanceTimersByTimeAsync(1500)
+        const result = await promise
+
+        expect(result).toBe('recovered')
+
+        const retryDelays = sleepSpy.mock.calls
+            .filter(([, delay]) => typeof delay === 'number' && delay >= 1000)
+            .map(([, delay]) => delay)
+
+        expect(retryDelays).toContain(1000)
+        expect(retryDelays).toContain(1500)
+        expect(retryDelays).not.toContain(2000)
+
+        vi.useRealTimers()
+    })
+
+    it('should use default config when none provided', async () => {
+        const fn = vi.fn().mockResolvedValue('success')
+
+        const result = await executeWithRetry(fn)
+
+        expect(result).toBe('success')
+        expect(fn).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,90 @@
+const DEFAULT_MAX_RETRIES = 2
+const DEFAULT_BASE_DELAY_MS = 500
+const DEFAULT_MAX_DELAY_MS = 2000
+
+const RETRYABLE_STATUS_CODES = new Set([502, 503, 504])
+
+type RetryConfig = {
+    maxRetries?: number
+    baseDelayMs?: number
+    maxDelayMs?: number
+}
+
+function extractHttpStatusCode(error: unknown): number | undefined {
+    if (error === null || error === undefined || typeof error !== 'object') {
+        return undefined
+    }
+
+    const record = error as Record<string, unknown>
+
+    if (typeof record.httpStatusCode === 'number') {
+        return record.httpStatusCode
+    }
+
+    if (typeof record.statusCode === 'number') {
+        return record.statusCode
+    }
+
+    if (typeof record.status === 'number') {
+        return record.status
+    }
+
+    if (error instanceof Error) {
+        const match = error.message.match(/\bHTTP\s+(\d{3})\b/i)
+        if (match?.[1]) {
+            return Number(match[1])
+        }
+    }
+
+    return undefined
+}
+
+function isTransientError(error: unknown): boolean {
+    const statusCode = extractHttpStatusCode(error)
+    return statusCode !== undefined && RETRYABLE_STATUS_CODES.has(statusCode)
+}
+
+function getRetryDelay({
+    attempt,
+    baseDelayMs,
+    maxDelayMs,
+}: {
+    attempt: number
+    baseDelayMs: number
+    maxDelayMs: number
+}): number {
+    const delay = baseDelayMs * 2 ** attempt
+    return Math.min(delay, maxDelayMs)
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function executeWithRetry<T>(fn: () => Promise<T>, config: RetryConfig = {}): Promise<T> {
+    const maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES
+    const baseDelayMs = config.baseDelayMs ?? DEFAULT_BASE_DELAY_MS
+    const maxDelayMs = config.maxDelayMs ?? DEFAULT_MAX_DELAY_MS
+
+    let lastError: unknown
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
+            return await fn()
+        } catch (error) {
+            lastError = error
+
+            if (attempt < maxRetries && isTransientError(error)) {
+                const delay = getRetryDelay({ attempt, baseDelayMs, maxDelayMs })
+                await sleep(delay)
+                continue
+            }
+
+            throw error
+        }
+    }
+
+    throw lastError
+}
+
+export { executeWithRetry, extractHttpStatusCode, isTransientError, type RetryConfig }


### PR DESCRIPTION
## Summary

- Adds automatic retry logic (up to 2 retries with exponential backoff) for transient HTTP 502/503/504 errors from the Todoist REST API
- Wraps all tool executions in `executeWithRetry()` so failures are transparently retried before surfacing to MCP clients
- Non-retryable errors (400, 401, 404, 500, etc.) continue to fail immediately with no behavior change

## Context

Datadog investigation of [Doist/Issues#19954](https://github.com/Doist/Issues/issues/19954) revealed:

- The Todoist REST API returns intermittent **503 Service Unavailable** errors during periodic load spikes, clustering heavily at the top of each hour (~262 logged 503s from MCP in 7 days)
- The `agentist` service also encounters **502 Bad Gateway** when connecting to `ai.todoist.net/mcp` (1–4 times daily since mid-March)
- Neither `todoist-ai` nor `@doist/todoist-sdk` had retry logic for HTTP 5xx responses — the SDK only retries on network-level errors (DNS failures, timeouts)

## Changes

| File | Change |
|------|--------|
| `src/utils/retry.ts` | New retry utility: `executeWithRetry()` with configurable exponential backoff (defaults: 2 retries, 500ms base delay, 2s max) |
| `src/mcp-helpers.ts` | Wraps `tool.execute()` with `executeWithRetry()` in `registerTool` |
| `src/utils/retry.test.ts` | 35 tests covering status code extraction, transient error detection, retry behavior, backoff timing, and configuration |

## Test plan

- [x] All 795 tests pass (including 35 new retry tests)
- [x] TypeScript type check passes
- [x] Biome lint/format passes
- [ ] Deploy to staging and verify 503 errors are retried transparently
- [ ] Monitor Datadog `todoist-ai-integrations` error logs for reduction in 503-related tool failures

Made with [Cursor](https://cursor.com)