### PR TITLE
fix: remove invalid mimeType property from TextContent blocks

### DIFF
--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -112,9 +112,8 @@ function getToolOutput<StructuredContent extends Record<string, unknown>>({
         if (!result.content) {
             result.content = []
         }
-        ;(result.content as Array<{ type: 'text'; text: string; mimeType?: string }>).push({
+        ;(result.content as Array<{ type: 'text'; text: string }>).push({
             type: 'text',
-            mimeType: 'application/json',
             text: json,
         })
     }


### PR DESCRIPTION
## Summary
- Removes the `mimeType` property from `TextContent` blocks in the legacy structured content output path (`src/mcp-helpers.ts`)
- Per the MCP spec, `TextContent` only supports `type`, `text`, and `annotations` — `mimeType` belongs on `ResourceContents`
- Claude web's MCP client rejects the extra property as a malformed response, causing tools to appear broken despite the underlying API call succeeding

## Context
Identified by Anthropic's MCP Review team during directory submission review. Other MCP clients (Claude Code, ChatGPT) are more lenient about extra properties, which is why this only manifested in Claude web.

## Test plan
- [x] Build passes
- [x] All 795 tests pass
- [ ] Verify `add-sections` and `update-sections` work correctly in Claude web after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)