### PR TITLE
fix: return HTTP 401 for invalid Todoist API tokens in HTTP transport

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 import { FEATURE_NAMES, type Feature, type FeatureName, type Features } from './mcp-helpers.js'
 import { getMcpServer } from './mcp-server.js'
+import {
+    requireValidTodoistToken,
+    type RequireValidTodoistTokenOptions,
+} from './middleware/require-valid-todoist-token.js'
 // Comment management tools
 import { addComments } from './tools/add-comments.js'
 // Filter management tools
@@ -47,6 +51,7 @@ import { updateSections } from './tools/update-sections.js'
 import { updateTasks } from './tools/update-tasks.js'
 import { userInfo } from './tools/user-info.js'
 import { viewAttachment } from './tools/view-attachment.js'
+import { validateTodoistToken } from './utils/validate-todoist-token.js'
 
 const tools = {
     // Task management tools
@@ -148,6 +153,9 @@ export {
     listWorkspaces,
     manageAssignments,
     reorderObjects,
+    // Token validation middleware
+    requireValidTodoistToken,
+    type RequireValidTodoistTokenOptions,
     rescheduleTasks,
     // OpenAI MCP tools
     search,
@@ -159,6 +167,8 @@ export {
     updateSections,
     updateTasks,
     userInfo,
+    // Token validation utility
+    validateTodoistToken,
     // Attachment tools
     viewAttachment,
 }

--- a/src/main-http.ts
+++ b/src/main-http.ts
@@ -17,6 +17,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import dotenv from 'dotenv'
 import express, { type Request, type Response } from 'express'
 import { getMcpServer } from './mcp-server.js'
+import { requireValidTodoistToken } from './middleware/require-valid-todoist-token.js'
 
 dotenv.config({ quiet: true })
 
@@ -40,27 +41,34 @@ function main() {
     })
 
     // MCP endpoint - POST for requests
-    app.post('/mcp', async (req: Request, res: Response) => {
-        try {
-            const transport = new StreamableHTTPServerTransport({
-                sessionIdGenerator: undefined,
-            })
+    // Validate the Todoist API token before MCP processing so that invalid
+    // tokens produce an HTTP 401 (per MCP spec) instead of being swallowed
+    // into a 200 JSON-RPC response with isError: true.
+    app.post(
+        '/mcp',
+        requireValidTodoistToken({ type: 'static', apiKey: todoistApiKey, baseUrl }),
+        async (req: Request, res: Response) => {
+            try {
+                const transport = new StreamableHTTPServerTransport({
+                    sessionIdGenerator: undefined,
+                })
 
-            const server = getMcpServer({ todoistApiKey, baseUrl })
-            await server.connect(transport)
-            await transport.handleRequest(req, res, req.body)
-        } catch (error) {
-            console.error('[Error] Request handling failed:', error)
-            res.status(500).json({
-                jsonrpc: '2.0',
-                error: {
-                    code: -32603,
-                    message: 'Internal server error',
-                },
-                id: null,
-            })
-        }
-    })
+                const server = getMcpServer({ todoistApiKey, baseUrl })
+                await server.connect(transport)
+                await transport.handleRequest(req, res, req.body)
+            } catch (error) {
+                console.error('[Error] Request handling failed:', error)
+                res.status(500).json({
+                    jsonrpc: '2.0',
+                    error: {
+                        code: -32603,
+                        message: 'Internal server error',
+                    },
+                    id: null,
+                })
+            }
+        },
+    )
 
     // MCP endpoint - GET returns 405 (needed for MCP client compatibility)
     app.get('/mcp', (_req: Request, res: Response) => {

--- a/src/middleware/require-valid-todoist-token.test.ts
+++ b/src/middleware/require-valid-todoist-token.test.ts
@@ -1,0 +1,209 @@
+import type { Request, Response } from 'express'
+import { type Mock, afterEach, beforeEach, vi } from 'vitest'
+
+import {
+    clearTokenValidationCache,
+    requireValidTodoistToken,
+} from './require-valid-todoist-token.js'
+
+vi.mock('../utils/validate-todoist-token.js', () => ({
+    validateTodoistToken: vi.fn(),
+}))
+
+import { validateTodoistToken } from '../utils/validate-todoist-token.js'
+
+const mockValidate = validateTodoistToken as Mock
+
+function createMockRes(): Response {
+    const res = {
+        status: vi.fn().mockReturnThis(),
+        set: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+    }
+    return res as unknown as Response
+}
+
+describe('requireValidTodoistToken', () => {
+    let next: Mock
+
+    beforeEach(() => {
+        next = vi.fn()
+        clearTokenValidationCache()
+        mockValidate.mockReset()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    describe('static mode', () => {
+        it('should call next() for a valid token', async () => {
+            mockValidate.mockResolvedValue(true)
+            const middleware = requireValidTodoistToken({
+                type: 'static',
+                apiKey: 'valid-key',
+            })
+
+            await middleware({} as Request, createMockRes(), next)
+
+            expect(next).toHaveBeenCalledOnce()
+            expect(mockValidate).toHaveBeenCalledWith('valid-key', undefined)
+        })
+
+        it('should return 401 for an invalid token', async () => {
+            mockValidate.mockResolvedValue(false)
+            const middleware = requireValidTodoistToken({
+                type: 'static',
+                apiKey: 'bad-key',
+            })
+            const res = createMockRes()
+
+            await middleware({} as Request, res, next)
+
+            expect(next).not.toHaveBeenCalled()
+            expect(res.status).toHaveBeenCalledWith(401)
+            expect(res.set).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer')
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'invalid_token',
+                error_description: 'Todoist API token is invalid or expired',
+            })
+        })
+
+        it('should include resource_metadata in WWW-Authenticate when configured', async () => {
+            mockValidate.mockResolvedValue(false)
+            const middleware = requireValidTodoistToken({
+                type: 'static',
+                apiKey: 'bad-key',
+                resourceMetadataUrl: 'https://example.com/.well-known/oauth-protected-resource',
+            })
+            const res = createMockRes()
+
+            await middleware({} as Request, res, next)
+
+            expect(res.set).toHaveBeenCalledWith(
+                'WWW-Authenticate',
+                'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"',
+            )
+        })
+
+        it('should pass baseUrl to validateTodoistToken', async () => {
+            mockValidate.mockResolvedValue(true)
+            const middleware = requireValidTodoistToken({
+                type: 'static',
+                apiKey: 'key',
+                baseUrl: 'https://custom.api.com',
+            })
+
+            await middleware({} as Request, createMockRes(), next)
+
+            expect(mockValidate).toHaveBeenCalledWith('key', 'https://custom.api.com')
+        })
+    })
+
+    describe('dynamic mode', () => {
+        it('should extract key from request and call next() for valid token', async () => {
+            mockValidate.mockResolvedValue(true)
+            const middleware = requireValidTodoistToken({
+                type: 'dynamic',
+                getApiKey: (req) => (req.headers as Record<string, string>)['x-todoist-token'],
+            })
+            const req = { headers: { 'x-todoist-token': 'dynamic-key' } } as unknown as Request
+
+            await middleware(req, createMockRes(), next)
+
+            expect(next).toHaveBeenCalledOnce()
+            expect(mockValidate).toHaveBeenCalledWith('dynamic-key', undefined)
+        })
+
+        it('should return 401 when getApiKey returns undefined', async () => {
+            const middleware = requireValidTodoistToken({
+                type: 'dynamic',
+                getApiKey: () => undefined,
+            })
+            const res = createMockRes()
+
+            await middleware({} as Request, res, next)
+
+            expect(next).not.toHaveBeenCalled()
+            expect(res.status).toHaveBeenCalledWith(401)
+            expect(mockValidate).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('caching', () => {
+        it('should cache valid results and skip subsequent API calls', async () => {
+            mockValidate.mockResolvedValue(true)
+            const middleware = requireValidTodoistToken({
+                type: 'static',
+                apiKey: 'cached-key',
+            })
+            const res1 = createMockRes()
+            const res2 = createMockRes()
+
+            await middleware({} as Request, res1, next)
+            await middleware({} as Request, res2, next)
+
+            expect(mockValidate).toHaveBeenCalledOnce()
+            expect(next).toHaveBeenCalledTimes(2)
+        })
+
+        it('should cache invalid results and skip subsequent API calls', async () => {
+            mockValidate.mockResolvedValue(false)
+            const middleware = requireValidTodoistToken({
+                type: 'static',
+                apiKey: 'bad-cached-key',
+            })
+            const res1 = createMockRes()
+            const res2 = createMockRes()
+            const next2 = vi.fn()
+
+            await middleware({} as Request, res1, next)
+            await middleware({} as Request, res2, next2)
+
+            expect(mockValidate).toHaveBeenCalledOnce()
+            expect(next).not.toHaveBeenCalled()
+            expect(next2).not.toHaveBeenCalled()
+            expect(res1.status).toHaveBeenCalledWith(401)
+            expect(res2.status).toHaveBeenCalledWith(401)
+        })
+
+        it('should re-validate after cache expires', async () => {
+            vi.useFakeTimers()
+            mockValidate.mockResolvedValue(true)
+            const middleware = requireValidTodoistToken({
+                type: 'static',
+                apiKey: 'expiring-key',
+                cacheTtlMs: 1000,
+            })
+
+            await middleware({} as Request, createMockRes(), next)
+            expect(mockValidate).toHaveBeenCalledOnce()
+
+            vi.advanceTimersByTime(1001)
+
+            await middleware({} as Request, createMockRes(), next)
+            expect(mockValidate).toHaveBeenCalledTimes(2)
+
+            vi.useRealTimers()
+        })
+    })
+
+    describe('transient errors', () => {
+        it('should fail open on transient errors and call next()', async () => {
+            const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+            mockValidate.mockRejectedValue(new Error('Network error'))
+            const middleware = requireValidTodoistToken({
+                type: 'static',
+                apiKey: 'key',
+            })
+
+            await middleware({} as Request, createMockRes(), next)
+
+            expect(next).toHaveBeenCalledOnce()
+            expect(consoleSpy).toHaveBeenCalledWith(
+                '[Token validation] Transient error, proceeding:',
+                expect.any(Error),
+            )
+        })
+    })
+})

--- a/src/middleware/require-valid-todoist-token.test.ts
+++ b/src/middleware/require-valid-todoist-token.test.ts
@@ -186,6 +186,27 @@ describe('requireValidTodoistToken', () => {
 
             vi.useRealTimers()
         })
+
+        it('should use separate cache entries for different baseUrls', async () => {
+            mockValidate.mockResolvedValue(true)
+            const middleware1 = requireValidTodoistToken({
+                type: 'static',
+                apiKey: 'same-key',
+                baseUrl: 'https://api.todoist.com',
+            })
+            const middleware2 = requireValidTodoistToken({
+                type: 'static',
+                apiKey: 'same-key',
+                baseUrl: 'https://staging.todoist.com',
+            })
+
+            await middleware1({} as Request, createMockRes(), next)
+            await middleware2({} as Request, createMockRes(), next)
+
+            expect(mockValidate).toHaveBeenCalledTimes(2)
+            expect(mockValidate).toHaveBeenCalledWith('same-key', 'https://api.todoist.com')
+            expect(mockValidate).toHaveBeenCalledWith('same-key', 'https://staging.todoist.com')
+        })
     })
 
     describe('transient errors', () => {

--- a/src/middleware/require-valid-todoist-token.ts
+++ b/src/middleware/require-valid-todoist-token.ts
@@ -38,22 +38,43 @@ type CacheEntry = {
 
 const DEFAULT_STATIC_TTL_MS = 300_000 // 5 minutes
 const DEFAULT_DYNAMIC_TTL_MS = 120_000 // 2 minutes
+const MAX_CACHE_SIZE = 10_000
 
 const cache = new Map<string, CacheEntry>()
 
-function getCachedResult(apiKey: string): boolean | undefined {
-    const entry = cache.get(apiKey)
+function makeCacheKey(apiKey: string, baseUrl?: string): string {
+    return baseUrl ? `${apiKey}::${baseUrl}` : apiKey
+}
+
+function pruneExpiredEntries(): void {
+    const now = Date.now()
+    for (const [key, entry] of cache) {
+        if (now >= entry.expiresAt) {
+            cache.delete(key)
+        }
+    }
+}
+
+function getCachedResult(cacheKey: string): boolean | undefined {
+    const entry = cache.get(cacheKey)
     if (entry && Date.now() < entry.expiresAt) {
         return entry.valid
     }
     if (entry) {
-        cache.delete(apiKey)
+        cache.delete(cacheKey)
     }
     return undefined
 }
 
-function setCachedResult(apiKey: string, valid: boolean, ttlMs: number): void {
-    cache.set(apiKey, { valid, expiresAt: Date.now() + ttlMs })
+function setCachedResult(cacheKey: string, valid: boolean, ttlMs: number): void {
+    if (cache.size >= MAX_CACHE_SIZE) {
+        pruneExpiredEntries()
+    }
+    // If still at capacity after pruning, clear everything
+    if (cache.size >= MAX_CACHE_SIZE) {
+        cache.clear()
+    }
+    cache.set(cacheKey, { valid, expiresAt: Date.now() + ttlMs })
 }
 
 function buildWwwAuthenticateHeader(resourceMetadataUrl?: string): string {
@@ -89,7 +110,8 @@ function requireValidTodoistToken(options: RequireValidTodoistTokenOptions): Req
             return
         }
 
-        const cached = getCachedResult(apiKey)
+        const cacheKey = makeCacheKey(apiKey, options.baseUrl)
+        const cached = getCachedResult(cacheKey)
         if (cached !== undefined) {
             if (cached) {
                 next()
@@ -101,7 +123,7 @@ function requireValidTodoistToken(options: RequireValidTodoistTokenOptions): Req
 
         try {
             const valid = await validateTodoistToken(apiKey, options.baseUrl)
-            setCachedResult(apiKey, valid, ttlMs)
+            setCachedResult(cacheKey, valid, ttlMs)
 
             if (valid) {
                 next()

--- a/src/middleware/require-valid-todoist-token.ts
+++ b/src/middleware/require-valid-todoist-token.ts
@@ -1,0 +1,127 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express'
+
+import { validateTodoistToken } from '../utils/validate-todoist-token.js'
+
+type StaticTokenSource = {
+    type: 'static'
+    apiKey: string
+    baseUrl?: string
+}
+
+type DynamicTokenSource = {
+    type: 'dynamic'
+    getApiKey: (req: Request) => string | undefined
+    baseUrl?: string
+}
+
+type TokenSource = StaticTokenSource | DynamicTokenSource
+
+type RequireValidTodoistTokenOptions = TokenSource & {
+    /**
+     * Cache TTL in milliseconds. Defaults to 300_000 (5 minutes) for static,
+     * 120_000 (2 minutes) for dynamic.
+     */
+    cacheTtlMs?: number
+
+    /**
+     * URL for the Protected Resource Metadata document (RFC 9728).
+     * Included in the WWW-Authenticate header when returning 401.
+     * If omitted, the header is sent without resource_metadata.
+     */
+    resourceMetadataUrl?: string
+}
+
+type CacheEntry = {
+    valid: boolean
+    expiresAt: number
+}
+
+const DEFAULT_STATIC_TTL_MS = 300_000 // 5 minutes
+const DEFAULT_DYNAMIC_TTL_MS = 120_000 // 2 minutes
+
+const cache = new Map<string, CacheEntry>()
+
+function getCachedResult(apiKey: string): boolean | undefined {
+    const entry = cache.get(apiKey)
+    if (entry && Date.now() < entry.expiresAt) {
+        return entry.valid
+    }
+    if (entry) {
+        cache.delete(apiKey)
+    }
+    return undefined
+}
+
+function setCachedResult(apiKey: string, valid: boolean, ttlMs: number): void {
+    cache.set(apiKey, { valid, expiresAt: Date.now() + ttlMs })
+}
+
+function buildWwwAuthenticateHeader(resourceMetadataUrl?: string): string {
+    if (resourceMetadataUrl) {
+        return `Bearer resource_metadata="${resourceMetadataUrl}"`
+    }
+    return 'Bearer'
+}
+
+function sendUnauthorized(res: Response, resourceMetadataUrl?: string): void {
+    res.status(401).set('WWW-Authenticate', buildWwwAuthenticateHeader(resourceMetadataUrl)).json({
+        error: 'invalid_token',
+        error_description: 'Todoist API token is invalid or expired',
+    })
+}
+
+/**
+ * Express middleware that validates the Todoist API token before MCP processing.
+ *
+ * Returns HTTP 401 with a spec-compliant WWW-Authenticate header if the token
+ * is invalid, allowing MCP clients to trigger OAuth token refresh.
+ */
+function requireValidTodoistToken(options: RequireValidTodoistTokenOptions): RequestHandler {
+    const defaultTtl = options.type === 'static' ? DEFAULT_STATIC_TTL_MS : DEFAULT_DYNAMIC_TTL_MS
+    const ttlMs = options.cacheTtlMs ?? defaultTtl
+    const { resourceMetadataUrl } = options
+
+    return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        const apiKey = options.type === 'static' ? options.apiKey : options.getApiKey(req)
+
+        if (!apiKey) {
+            sendUnauthorized(res, resourceMetadataUrl)
+            return
+        }
+
+        const cached = getCachedResult(apiKey)
+        if (cached !== undefined) {
+            if (cached) {
+                next()
+            } else {
+                sendUnauthorized(res, resourceMetadataUrl)
+            }
+            return
+        }
+
+        try {
+            const valid = await validateTodoistToken(apiKey, options.baseUrl)
+            setCachedResult(apiKey, valid, ttlMs)
+
+            if (valid) {
+                next()
+            } else {
+                sendUnauthorized(res, resourceMetadataUrl)
+            }
+        } catch (error) {
+            // Fail open on transient errors — don't block all requests during
+            // a Todoist API blip. Tool calls will fail with descriptive errors.
+            console.warn('[Token validation] Transient error, proceeding:', error)
+            next()
+        }
+    }
+}
+
+/**
+ * Clear the token validation cache. Useful for testing.
+ */
+function clearTokenValidationCache(): void {
+    cache.clear()
+}
+
+export { clearTokenValidationCache, requireValidTodoistToken, type RequireValidTodoistTokenOptions }

--- a/src/utils/validate-todoist-token.test.ts
+++ b/src/utils/validate-todoist-token.test.ts
@@ -57,6 +57,22 @@ describe('validateTodoistToken', () => {
         await expect(validateTodoistToken('valid-token')).rejects.toThrow('fetch failed')
     })
 
+    it('should return false for a nested 401 error (response.status shape)', async () => {
+        mockGetUser.mockRejectedValue({ response: { status: 401 }, message: 'Request failed' })
+
+        const result = await validateTodoistToken('invalid-token')
+
+        expect(result).toBe(false)
+    })
+
+    it('should return false for a nested 403 error (response.status shape)', async () => {
+        mockGetUser.mockRejectedValue({ response: { status: 403 }, message: 'Forbidden' })
+
+        const result = await validateTodoistToken('forbidden-token')
+
+        expect(result).toBe(false)
+    })
+
     it('should pass baseUrl to TodoistApi', async () => {
         mockGetUser.mockResolvedValue({ id: '123' })
 

--- a/src/utils/validate-todoist-token.test.ts
+++ b/src/utils/validate-todoist-token.test.ts
@@ -1,0 +1,67 @@
+import { TodoistApi } from '@doist/todoist-sdk'
+import { type Mock, vi } from 'vitest'
+
+import { validateTodoistToken } from './validate-todoist-token.js'
+
+const mockGetUser = vi.fn()
+
+vi.mock('@doist/todoist-sdk', () => ({
+    TodoistApi: vi.fn().mockImplementation(function () {
+        return { getUser: mockGetUser }
+    }),
+}))
+
+describe('validateTodoistToken', () => {
+    beforeEach(() => {
+        mockGetUser.mockReset()
+        ;(TodoistApi as unknown as Mock).mockClear()
+    })
+
+    it('should return true for a valid token', async () => {
+        mockGetUser.mockResolvedValue({ id: '123', full_name: 'Test' })
+
+        const result = await validateTodoistToken('valid-token')
+
+        expect(result).toBe(true)
+        expect(mockGetUser).toHaveBeenCalledOnce()
+    })
+
+    it('should return false for a 401 error', async () => {
+        mockGetUser.mockRejectedValue({ httpStatusCode: 401, message: 'Unauthorized' })
+
+        const result = await validateTodoistToken('invalid-token')
+
+        expect(result).toBe(false)
+    })
+
+    it('should return false for a 403 error', async () => {
+        mockGetUser.mockRejectedValue({ httpStatusCode: 403, message: 'Forbidden' })
+
+        const result = await validateTodoistToken('forbidden-token')
+
+        expect(result).toBe(false)
+    })
+
+    it('should throw on 5xx errors', async () => {
+        mockGetUser.mockRejectedValue({ httpStatusCode: 500, message: 'Internal Server Error' })
+
+        await expect(validateTodoistToken('valid-token')).rejects.toEqual({
+            httpStatusCode: 500,
+            message: 'Internal Server Error',
+        })
+    })
+
+    it('should throw on network errors', async () => {
+        mockGetUser.mockRejectedValue(new Error('fetch failed'))
+
+        await expect(validateTodoistToken('valid-token')).rejects.toThrow('fetch failed')
+    })
+
+    it('should pass baseUrl to TodoistApi', async () => {
+        mockGetUser.mockResolvedValue({ id: '123' })
+
+        await validateTodoistToken('token', 'https://custom.api.com')
+
+        expect(TodoistApi).toHaveBeenCalledWith('token', { baseUrl: 'https://custom.api.com' })
+    })
+})

--- a/src/utils/validate-todoist-token.ts
+++ b/src/utils/validate-todoist-token.ts
@@ -5,6 +5,24 @@ import { extractHttpStatusCode } from './retry.js'
 const AUTH_ERROR_CODES = new Set([401, 403])
 
 /**
+ * Extract HTTP status code from an error, checking both top-level fields
+ * and nested `error.response.status` (common in HTTP client libraries).
+ */
+function extractAuthStatusCode(error: unknown): number | undefined {
+    const direct = extractHttpStatusCode(error)
+    if (direct !== undefined) {
+        return direct
+    }
+
+    // Check nested response object (e.g. { response: { status: 401 } })
+    if (error !== null && typeof error === 'object' && 'response' in error) {
+        return extractHttpStatusCode((error as Record<string, unknown>).response)
+    }
+
+    return undefined
+}
+
+/**
  * Validates a Todoist API token by making a lightweight API call.
  *
  * @returns `true` if the token is valid, `false` if it's an auth error (401/403).
@@ -16,7 +34,7 @@ async function validateTodoistToken(apiKey: string, baseUrl?: string): Promise<b
         await client.getUser()
         return true
     } catch (error) {
-        const statusCode = extractHttpStatusCode(error)
+        const statusCode = extractAuthStatusCode(error)
         if (statusCode !== undefined && AUTH_ERROR_CODES.has(statusCode)) {
             return false
         }

--- a/src/utils/validate-todoist-token.ts
+++ b/src/utils/validate-todoist-token.ts
@@ -1,0 +1,27 @@
+import { TodoistApi } from '@doist/todoist-sdk'
+
+import { extractHttpStatusCode } from './retry.js'
+
+const AUTH_ERROR_CODES = new Set([401, 403])
+
+/**
+ * Validates a Todoist API token by making a lightweight API call.
+ *
+ * @returns `true` if the token is valid, `false` if it's an auth error (401/403).
+ * @throws On transient errors (network failures, 5xx) so the caller can decide.
+ */
+async function validateTodoistToken(apiKey: string, baseUrl?: string): Promise<boolean> {
+    const client = new TodoistApi(apiKey, { baseUrl })
+    try {
+        await client.getUser()
+        return true
+    } catch (error) {
+        const statusCode = extractHttpStatusCode(error)
+        if (statusCode !== undefined && AUTH_ERROR_CODES.has(statusCode)) {
+            return false
+        }
+        throw error
+    }
+}
+
+export { validateTodoistToken }


### PR DESCRIPTION
## Summary

- The [MCP authorization spec](https://modelcontextprotocol.io/specification/draft/basic/authorization) is explicit that **"Invalid or expired tokens MUST receive a HTTP 401 response"** (Token Handling section), and that 401 responses **MUST** include a `WWW-Authenticate` header with `resource_metadata` URL (RFC 9728) so clients can discover the authorization server and re-authenticate
- We were violating this: 401 errors from the Todoist API were caught in the tool callback and returned as **HTTP 200** JSON-RPC responses with `isError: true` and the 401 buried in text content — MCP clients expecting HTTP 401 to trigger OAuth token refresh never saw it
- The root cause is architectural: the Streamable HTTP transport commits `HTTP 200` with SSE headers before tool execution begins, so the status code cannot be changed after the fact
- Fix: validate the Todoist API token **before** entering the MCP layer via Express middleware, returning a spec-compliant HTTP 401 with `WWW-Authenticate: Bearer resource_metadata="..."` if validation fails

## What changed

- **`src/utils/validate-todoist-token.ts`** — Validates a token by calling `TodoistApi.getUser()`. Returns `true` if valid, `false` on 401/403, throws on transient errors
- **`src/middleware/require-valid-todoist-token.ts`** — Express middleware with TTL-based caching, static/dynamic token source modes, spec-compliant 401 responses. Fails open on transient errors (network/5xx) to avoid blocking all requests during a Todoist API blip
- **`src/main-http.ts`** — Middleware integrated before the MCP POST handler
- **`src/index.ts`** — Exports `validateTodoistToken` and `requireValidTodoistToken` for use by the hosted service (`todoist-ai-integrations`)

## MCP spec references

From the [Authorization spec](https://modelcontextprotocol.io/specification/draft/basic/authorization):

> **Token Handling**: "MCP servers MUST validate access tokens... If validation fails, servers MUST respond according to OAuth 2.1 Section 5.3 error handling requirements. Invalid or expired tokens MUST receive a HTTP 401 response."
>
> **Error Handling table**: `401 Unauthorized` — "Authorization required or token invalid"
>
> **Protected Resource Metadata Discovery**: "Include the resource metadata URL in the WWW-Authenticate HTTP header under resource_metadata when returning 401 Unauthorized responses"

## Test plan

- [ ] `npm run check` passes (types, formatting, schema validation)
- [ ] All 812 tests pass (including 16 new tests for validation and middleware)
- [ ] Manual test: start `main-http.ts` with invalid `TODOIST_API_KEY` → HTTP 401 with `WWW-Authenticate` header
- [ ] Manual test: start `main-http.ts` with valid key → MCP requests work normally
- [ ] Verify cached validation doesn't call Todoist API on every request

🤖 Generated with [Claude Code](https://claude.com/claude-code)