### PR TITLE
feat: make find-project-collaborators discoverable as user-lookup

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -97,7 +97,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 **Collaboration & Comments:**
 - **add-comments/update-comments/find-comments**: Manage task and project discussions
 - **view-attachment**: View file attachments from comments. Pass the fileUrl from a comment's fileAttachment. Returns images inline, text files as text, and binary files as embedded resources.
-- **find-project-collaborators**: Look up Todoist users (workspace members, collaborators, teammates) by name or email to get their user ID — use for "find/who is X" questions or any time you need to resolve a person's name to an ID. Searches the whole workspace by default; pass projectId to scope to a single project
+- **find-project-collaborators**: Look up Todoist users (collaborators, teammates) by name or email to get their user ID — use for "find/who is X" questions or any time you need to resolve a person's name to an ID. By default searches collaborators of every shared project the authenticated user can access (plus the authenticated user themselves). An empty result means the person is not a collaborator on any shared project, not that they do not exist. Pass projectId to scope to a single project
 - **manage-assignments**: Bulk assign/unassign/reassign up to 50 tasks with atomic operations and dry-run validation
 
 **Filters:**
@@ -127,7 +127,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 
 2. **Search Strategy**: Use specific search queries combining multiple filters for precise results. When searching for tasks, start with broader queries and narrow down as needed.
 
-3. **Assignments & user lookup**: Always validate project collaborators exist before assigning tasks. Use find-project-collaborators to verify user access. Also use find-project-collaborators (with just a searchTerm and no projectId) to resolve a user's ID whenever the user references a person by name or email — it searches across the whole workspace.
+3. **Assignments & user lookup**: Always validate project collaborators exist before assigning tasks. Use find-project-collaborators to verify user access. Also use find-project-collaborators (with just a searchTerm and no projectId) to resolve a user's ID whenever the user references a person by name or email — it searches collaborators of all shared projects you can access, plus yourself.
 
 4. **Bulk Operations**: When working with multiple items, prefer bulk tools (complete-tasks, manage-assignments) over individual operations for better performance.
 
@@ -143,7 +143,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 
 - **Daily Planning**: Use find-tasks-by-date with 'today' and get-overview for project status
 - **Team Assignment**: find-project-collaborators → add-tasks with responsibleUser → manage-assignments for bulk changes
-- **User Lookup**: find-project-collaborators with just a searchTerm (no projectId) to resolve a name or email to a Todoist user ID across the entire workspace
+- **User Lookup**: find-project-collaborators with just a searchTerm (no projectId) to resolve a name or email to a Todoist user ID across all shared-project collaborators you can access
 - **Task Search**: find-tasks with multiple filters → update-tasks or complete-tasks based on results
 - **Project Organization**: add-projects → add-sections → add-tasks with projectId and sectionId
 - **Progress Reviews**: find-completed-tasks (defaults to last 7 days; optionally use explicit date ranges) → get-overview for project summaries

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -97,7 +97,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 **Collaboration & Comments:**
 - **add-comments/update-comments/find-comments**: Manage task and project discussions
 - **view-attachment**: View file attachments from comments. Pass the fileUrl from a comment's fileAttachment. Returns images inline, text files as text, and binary files as embedded resources.
-- **find-project-collaborators**: Find team members by name or email for assignments
+- **find-project-collaborators**: Look up Todoist users (workspace members, collaborators, teammates) by name or email to get their user ID — use for "find/who is X" questions or any time you need to resolve a person's name to an ID. Searches the whole workspace by default; pass projectId to scope to a single project
 - **manage-assignments**: Bulk assign/unassign/reassign up to 50 tasks with atomic operations and dry-run validation
 
 **Filters:**
@@ -127,7 +127,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 
 2. **Search Strategy**: Use specific search queries combining multiple filters for precise results. When searching for tasks, start with broader queries and narrow down as needed.
 
-3. **Assignments**: Always validate project collaborators exist before assigning tasks. Use find-project-collaborators to verify user access.
+3. **Assignments & user lookup**: Always validate project collaborators exist before assigning tasks. Use find-project-collaborators to verify user access. Also use find-project-collaborators (with just a searchTerm and no projectId) to resolve a user's ID whenever the user references a person by name or email — it searches across the whole workspace.
 
 4. **Bulk Operations**: When working with multiple items, prefer bulk tools (complete-tasks, manage-assignments) over individual operations for better performance.
 
@@ -143,6 +143,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 
 - **Daily Planning**: Use find-tasks-by-date with 'today' and get-overview for project status
 - **Team Assignment**: find-project-collaborators → add-tasks with responsibleUser → manage-assignments for bulk changes
+- **User Lookup**: find-project-collaborators with just a searchTerm (no projectId) to resolve a name or email to a Todoist user ID across the entire workspace
 - **Task Search**: find-tasks with multiple filters → update-tasks or complete-tasks based on results
 - **Project Organization**: add-projects → add-sections → add-tasks with projectId and sectionId
 - **Progress Reviews**: find-completed-tasks (defaults to last 7 days; optionally use explicit date ranges) → get-overview for project summaries

--- a/src/tools/__tests__/find-project-collaborators.test.ts
+++ b/src/tools/__tests__/find-project-collaborators.test.ts
@@ -38,6 +38,7 @@ describe(`${FIND_PROJECT_COLLABORATORS} tool`, () => {
         vi.clearAllMocks()
         mockTodoistApi = {
             getProject: vi.fn(),
+            getUser: vi.fn().mockRejectedValue(new Error('getUser not stubbed in test')),
         } as unknown as Mocked<TodoistApi>
     })
 
@@ -157,7 +158,7 @@ describe(`${FIND_PROJECT_COLLABORATORS} tool`, () => {
             expect(result.structuredContent.collaborators).toEqual([ernesto])
         })
 
-        it('returns helpful empty result when workspace has no shared projects', async () => {
+        it('returns helpful empty result when workspace has no shared projects and getUser fails', async () => {
             vi.mocked(userResolver.getAllCollaborators).mockResolvedValue([])
 
             const result = await findProjectCollaborators.execute(
@@ -168,7 +169,43 @@ describe(`${FIND_PROJECT_COLLABORATORS} tool`, () => {
             expect(result.structuredContent.collaborators).toEqual([])
             expect(result.structuredContent.totalCount).toBe(0)
             expect(result.structuredContent.totalAvailable).toBe(0)
-            expect(result.textContent).toContain('No users found in workspace')
+            expect(result.textContent).toContain('No users found')
+        })
+
+        it('prepends the authenticated user so personal accounts can look up themselves', async () => {
+            vi.mocked(userResolver.getAllCollaborators).mockResolvedValue([])
+            vi.mocked(mockTodoistApi.getUser).mockResolvedValue({
+                id: 'me-id',
+                fullName: 'Scott Lovegrove',
+                email: 'scott@example.com',
+            } as Awaited<ReturnType<TodoistApi['getUser']>>)
+
+            const result = await findProjectCollaborators.execute(
+                { searchTerm: 'Scott' },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.collaborators).toEqual([
+                { id: 'me-id', name: 'Scott Lovegrove', email: 'scott@example.com' },
+            ])
+            expect(result.structuredContent.totalAvailable).toBe(1)
+        })
+
+        it('does not duplicate the authenticated user when already a collaborator', async () => {
+            vi.mocked(userResolver.getAllCollaborators).mockResolvedValue([
+                { id: 'me-id', name: 'Scott Lovegrove', email: 'scott@example.com' },
+                ernesto,
+            ])
+            vi.mocked(mockTodoistApi.getUser).mockResolvedValue({
+                id: 'me-id',
+                fullName: 'Scott Lovegrove',
+                email: 'scott@example.com',
+            } as Awaited<ReturnType<TodoistApi['getUser']>>)
+
+            const result = await findProjectCollaborators.execute({}, mockTodoistApi)
+
+            expect(result.structuredContent.collaborators).toHaveLength(2)
+            expect(result.structuredContent.totalAvailable).toBe(2)
         })
 
         it('returns helpful empty result when search term has no matches', async () => {

--- a/src/tools/__tests__/find-project-collaborators.test.ts
+++ b/src/tools/__tests__/find-project-collaborators.test.ts
@@ -1,0 +1,188 @@
+import type { TodoistApi } from '@doist/todoist-sdk'
+import { type Mocked, vi } from 'vitest'
+import { createMockProject } from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { userResolver } from '../../utils/user-resolver.js'
+import { findProjectCollaborators } from '../find-project-collaborators.js'
+
+vi.mock('../../utils/user-resolver.js', () => ({
+    userResolver: {
+        resolveUser: vi.fn(),
+        getProjectCollaborators: vi.fn(),
+        getAllCollaborators: vi.fn(),
+    },
+}))
+
+const { FIND_PROJECT_COLLABORATORS } = ToolNames
+
+const sharedProject = createMockProject({
+    id: 'project-shared',
+    name: 'Shared Project',
+    isShared: true,
+})
+
+const unsharedProject = createMockProject({
+    id: 'project-personal',
+    name: 'Personal Project',
+    isShared: false,
+})
+
+const carrie = { id: 'user-1', name: 'Carrie Anderson', email: 'carrie@example.com' }
+const ernesto = { id: 'user-2', name: 'Ernesto Garcia', email: 'ernesto@doist.com' }
+const dominique = { id: 'user-3', name: 'Dominique Rains', email: 'dominique@example.com' }
+
+describe(`${FIND_PROJECT_COLLABORATORS} tool`, () => {
+    let mockTodoistApi: Mocked<TodoistApi>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockTodoistApi = {
+            getProject: vi.fn(),
+        } as unknown as Mocked<TodoistApi>
+    })
+
+    describe('with projectId (per-project search)', () => {
+        it('returns all collaborators of the project when no searchTerm', async () => {
+            mockTodoistApi.getProject.mockResolvedValue(sharedProject)
+            vi.mocked(userResolver.getProjectCollaborators).mockResolvedValue([carrie, ernesto])
+
+            const result = await findProjectCollaborators.execute(
+                { projectId: sharedProject.id },
+                mockTodoistApi,
+            )
+
+            expect(userResolver.getAllCollaborators).not.toHaveBeenCalled()
+            expect(userResolver.getProjectCollaborators).toHaveBeenCalledWith(
+                mockTodoistApi,
+                sharedProject.id,
+            )
+            expect(result.structuredContent.collaborators).toEqual([carrie, ernesto])
+            expect(result.structuredContent.projectInfo).toEqual({
+                id: sharedProject.id,
+                name: sharedProject.name,
+                isShared: true,
+            })
+            expect(result.structuredContent.totalCount).toBe(2)
+            expect(result.structuredContent.totalAvailable).toBe(2)
+        })
+
+        it('filters collaborators by searchTerm (case-insensitive, partial)', async () => {
+            mockTodoistApi.getProject.mockResolvedValue(sharedProject)
+            vi.mocked(userResolver.getProjectCollaborators).mockResolvedValue([
+                carrie,
+                ernesto,
+                dominique,
+            ])
+
+            const result = await findProjectCollaborators.execute(
+                { projectId: sharedProject.id, searchTerm: 'ERNES' },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.collaborators).toEqual([ernesto])
+            expect(result.structuredContent.totalCount).toBe(1)
+            expect(result.structuredContent.totalAvailable).toBe(3)
+            expect(result.textContent).toContain('matching "ERNES"')
+        })
+
+        it('returns empty result with helpful message for non-shared projects', async () => {
+            mockTodoistApi.getProject.mockResolvedValue(unsharedProject)
+
+            const result = await findProjectCollaborators.execute(
+                { projectId: unsharedProject.id },
+                mockTodoistApi,
+            )
+
+            expect(userResolver.getProjectCollaborators).not.toHaveBeenCalled()
+            expect(result.structuredContent.collaborators).toEqual([])
+            expect(result.structuredContent.projectInfo).toEqual({
+                id: unsharedProject.id,
+                name: unsharedProject.name,
+                isShared: false,
+            })
+            expect(result.textContent).toContain('is not shared and has no collaborators')
+        })
+
+        it('throws when project lookup fails', async () => {
+            mockTodoistApi.getProject.mockRejectedValue(new Error('Project not found'))
+
+            await expect(
+                findProjectCollaborators.execute({ projectId: 'missing' }, mockTodoistApi),
+            ).rejects.toThrow('Failed to access project "missing"')
+        })
+    })
+
+    describe('without projectId (workspace-wide search)', () => {
+        it('searches all shared projects when only searchTerm is provided', async () => {
+            vi.mocked(userResolver.getAllCollaborators).mockResolvedValue([
+                carrie,
+                ernesto,
+                dominique,
+            ])
+
+            const result = await findProjectCollaborators.execute(
+                { searchTerm: 'ernesto' },
+                mockTodoistApi,
+            )
+
+            expect(userResolver.getAllCollaborators).toHaveBeenCalledWith(mockTodoistApi)
+            expect(mockTodoistApi.getProject).not.toHaveBeenCalled()
+            expect(userResolver.getProjectCollaborators).not.toHaveBeenCalled()
+            expect(result.structuredContent.collaborators).toEqual([ernesto])
+            expect(result.structuredContent.projectInfo).toBeUndefined()
+            expect(result.structuredContent.totalCount).toBe(1)
+            expect(result.structuredContent.totalAvailable).toBe(3)
+            expect(result.textContent).toContain('Workspace users matching "ernesto"')
+        })
+
+        it('returns all workspace users when no searchTerm', async () => {
+            vi.mocked(userResolver.getAllCollaborators).mockResolvedValue([carrie, ernesto])
+
+            const result = await findProjectCollaborators.execute({}, mockTodoistApi)
+
+            expect(result.structuredContent.collaborators).toEqual([carrie, ernesto])
+            expect(result.structuredContent.projectInfo).toBeUndefined()
+            expect(result.structuredContent.totalCount).toBe(2)
+            expect(result.textContent).toContain('Workspace users')
+        })
+
+        it('matches against email as well as name', async () => {
+            vi.mocked(userResolver.getAllCollaborators).mockResolvedValue([carrie, ernesto])
+
+            const result = await findProjectCollaborators.execute(
+                { searchTerm: '@doist.com' },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.collaborators).toEqual([ernesto])
+        })
+
+        it('returns helpful empty result when workspace has no shared projects', async () => {
+            vi.mocked(userResolver.getAllCollaborators).mockResolvedValue([])
+
+            const result = await findProjectCollaborators.execute(
+                { searchTerm: 'anyone' },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.collaborators).toEqual([])
+            expect(result.structuredContent.totalCount).toBe(0)
+            expect(result.structuredContent.totalAvailable).toBe(0)
+            expect(result.textContent).toContain('No users found in workspace')
+        })
+
+        it('returns helpful empty result when search term has no matches', async () => {
+            vi.mocked(userResolver.getAllCollaborators).mockResolvedValue([carrie, ernesto])
+
+            const result = await findProjectCollaborators.execute(
+                { searchTerm: 'nobody' },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.collaborators).toEqual([])
+            expect(result.structuredContent.totalCount).toBe(0)
+            expect(result.structuredContent.totalAvailable).toBe(2)
+            expect(result.textContent).toContain('No users match "nobody"')
+        })
+    })
+})

--- a/src/tools/find-project-collaborators.ts
+++ b/src/tools/find-project-collaborators.ts
@@ -1,3 +1,4 @@
+import type { TodoistApi } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
 import { type Project } from '../tool-helpers.js'
@@ -9,17 +10,23 @@ import { type ProjectCollaborator, userResolver } from '../utils/user-resolver.j
 const { FIND_PROJECTS, ADD_TASKS, UPDATE_TASKS } = ToolNames
 
 const ArgsSchema = {
-    projectId: z.string().min(1).describe('The ID of the project to search for collaborators in.'),
+    projectId: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+            'Optional. If provided, searches only collaborators of this project. If omitted, searches across all shared projects in the workspace — use this for general "find a user" / "who is X" lookups.',
+        ),
     searchTerm: z
         .string()
         .optional()
         .describe(
-            'Search for a collaborator by name or email (partial and case insensitive match). If omitted, all collaborators in the project are returned.',
+            'Search for a user by name or email (partial and case insensitive match). If omitted, all users are returned.',
         ),
 }
 
 const OutputSchema = {
-    collaborators: z.array(CollaboratorSchema).describe('The found collaborators.'),
+    collaborators: z.array(CollaboratorSchema).describe('The found users.'),
     projectInfo: z
         .object({
             id: z.string().describe('The project ID.'),
@@ -27,12 +34,12 @@ const OutputSchema = {
             isShared: z.boolean().describe('Whether the project is shared.'),
         })
         .optional()
-        .describe('Information about the project.'),
-    totalCount: z.number().describe('The total number of collaborators found.'),
+        .describe('Information about the project (only present when projectId was provided).'),
+    totalCount: z.number().describe('The total number of users found.'),
     totalAvailable: z
         .number()
         .optional()
-        .describe('The total number of available collaborators in the project.'),
+        .describe('The total number of available users before the search filter was applied.'),
     appliedFilters: z
         .record(z.string(), z.unknown())
         .describe('The filters that were applied to the search.'),
@@ -40,12 +47,17 @@ const OutputSchema = {
 
 const findProjectCollaborators = {
     name: ToolNames.FIND_PROJECT_COLLABORATORS,
-    description: 'Search for collaborators by name or other criteria in a project.',
+    description:
+        'Find Todoist users (workspace members, collaborators, teammates) by name or email to look up their user ID. Use this whenever the user asks to find, look up, or identify a person — e.g. "find Carrie\'s user ID", "who is Ernesto", "look up a user in my workspace". Searches across all shared projects by default; pass projectId to scope to a single project. Partial, case-insensitive match on name and email.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         const { projectId, searchTerm } = args
+
+        if (!projectId) {
+            return executeWorkspaceSearch({ searchTerm, client, appliedFilters: args })
+        }
 
         // First, validate that the project exists and get basic info
         let projectName = projectId
@@ -102,15 +114,7 @@ const findProjectCollaborators = {
         }
 
         // Filter collaborators if search term provided
-        let filteredCollaborators = allCollaborators
-        if (searchTerm) {
-            const searchLower = searchTerm.toLowerCase().trim()
-            filteredCollaborators = allCollaborators.filter(
-                (collaborator) =>
-                    collaborator.name.toLowerCase().includes(searchLower) ||
-                    collaborator.email.toLowerCase().includes(searchLower),
-            )
-        }
+        const filteredCollaborators = filterBySearchTerm(allCollaborators, searchTerm)
 
         const textContent = generateTextContent({
             collaborators: filteredCollaborators,
@@ -136,6 +140,68 @@ const findProjectCollaborators = {
     },
 } satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
 
+async function executeWorkspaceSearch({
+    searchTerm,
+    client,
+    appliedFilters,
+}: {
+    searchTerm: string | undefined
+    client: TodoistApi
+    appliedFilters: Record<string, unknown>
+}) {
+    const allCollaborators = await userResolver.getAllCollaborators(client)
+
+    if (allCollaborators.length === 0) {
+        const textContent = `No users found in workspace. You may have no shared projects, or collaborator data is not accessible.\n\n**Next steps:**\n• Use ${FIND_PROJECTS} to find shared projects\n• Share a project to add collaborators\n• Ensure you have permission to view collaborators`
+
+        return {
+            textContent,
+            structuredContent: {
+                collaborators: [],
+                projectInfo: undefined,
+                totalCount: 0,
+                totalAvailable: 0,
+                appliedFilters,
+            },
+        }
+    }
+
+    const filteredCollaborators = filterBySearchTerm(allCollaborators, searchTerm)
+
+    const textContent = generateTextContent({
+        collaborators: filteredCollaborators,
+        projectName: undefined,
+        searchTerm,
+        totalAvailable: allCollaborators.length,
+    })
+
+    return {
+        textContent,
+        structuredContent: {
+            collaborators: filteredCollaborators,
+            projectInfo: undefined,
+            totalCount: filteredCollaborators.length,
+            totalAvailable: allCollaborators.length,
+            appliedFilters,
+        },
+    }
+}
+
+function filterBySearchTerm(
+    collaborators: ProjectCollaborator[],
+    searchTerm: string | undefined,
+): ProjectCollaborator[] {
+    if (!searchTerm) {
+        return collaborators
+    }
+    const searchLower = searchTerm.toLowerCase().trim()
+    return collaborators.filter(
+        (collaborator) =>
+            collaborator.name.toLowerCase().includes(searchLower) ||
+            collaborator.email.toLowerCase().includes(searchLower),
+    )
+}
+
 function generateTextContent({
     collaborators,
     projectName,
@@ -143,19 +209,20 @@ function generateTextContent({
     totalAvailable,
 }: {
     collaborators: ProjectCollaborator[]
-    projectName: string
+    projectName: string | undefined
     searchTerm?: string
     totalAvailable: number
 }) {
-    const subject = searchTerm
-        ? `Project collaborators matching "${searchTerm}"`
-        : 'Project collaborators'
+    const scope = projectName ? `project "${projectName}"` : 'workspace'
+    const baseLabel = projectName ? 'Project collaborators' : 'Workspace users'
+
+    const subject = searchTerm ? `${baseLabel} matching "${searchTerm}"` : baseLabel
 
     const filterHints: string[] = []
     if (searchTerm) {
         filterHints.push(`matching "${searchTerm}"`)
     }
-    filterHints.push(`in project "${projectName}"`)
+    filterHints.push(`in ${scope}`)
 
     let previewLines: string[] = []
     if (collaborators.length > 0) {
@@ -173,14 +240,17 @@ function generateTextContent({
     const zeroReasonHints: string[] = []
     if (collaborators.length === 0) {
         if (searchTerm) {
-            zeroReasonHints.push(`No collaborators match "${searchTerm}"`)
+            zeroReasonHints.push(`No users match "${searchTerm}"`)
             zeroReasonHints.push('Try a broader search term or check spelling')
             if (totalAvailable > 0) {
-                zeroReasonHints.push(`${totalAvailable} collaborators available without filter`)
+                zeroReasonHints.push(`${totalAvailable} users available without filter`)
             }
-        } else {
+        } else if (projectName) {
             zeroReasonHints.push('Project has no collaborators')
             zeroReasonHints.push('Share the project to add collaborators')
+        } else {
+            zeroReasonHints.push('No users found in workspace')
+            zeroReasonHints.push('Share a project to add collaborators')
         }
     }
 
@@ -188,11 +258,11 @@ function generateTextContent({
     if (collaborators.length > 0) {
         nextSteps.push(`Use ${ADD_TASKS} with responsibleUser to assign new tasks`)
         nextSteps.push(`Use ${UPDATE_TASKS} with responsibleUser to reassign existing tasks`)
-        nextSteps.push('Use collaborator names, emails, or IDs for assignments')
+        nextSteps.push('Use user names, emails, or IDs for assignments')
     } else {
         nextSteps.push(`Use ${FIND_PROJECTS} to find other projects`)
         if (searchTerm && totalAvailable > 0) {
-            nextSteps.push('Try searching without filters to see all collaborators')
+            nextSteps.push('Try searching without filters to see all users')
         }
     }
 

--- a/src/tools/find-project-collaborators.ts
+++ b/src/tools/find-project-collaborators.ts
@@ -15,7 +15,7 @@ const ArgsSchema = {
         .min(1)
         .optional()
         .describe(
-            'Optional. If provided, searches only collaborators of this project. If omitted, searches across all shared projects in the workspace — use this for general "find a user" / "who is X" lookups.',
+            'Optional. If provided, searches only collaborators of this project. If omitted, searches across the collaborators of all shared projects the authenticated user can access (plus the authenticated user themselves) — use this for general "find a user" / "who is X" lookups.',
         ),
     searchTerm: z
         .string()
@@ -48,7 +48,7 @@ const OutputSchema = {
 const findProjectCollaborators = {
     name: ToolNames.FIND_PROJECT_COLLABORATORS,
     description:
-        'Find Todoist users (workspace members, collaborators, teammates) by name or email to look up their user ID. Use this whenever the user asks to find, look up, or identify a person — e.g. "find Carrie\'s user ID", "who is Ernesto", "look up a user in my workspace". Searches across all shared projects by default; pass projectId to scope to a single project. Partial, case-insensitive match on name and email.',
+        'Find Todoist users (collaborators, teammates) by name or email to look up their user ID. Use this whenever the user asks to find, look up, or identify a person — e.g. "find Carrie\'s user ID", "who is Ernesto", "look up a user". When projectId is omitted, searches across the collaborators of every shared project the authenticated user has access to, plus the authenticated user themselves — an empty result means the person is not a collaborator on any project you share with them, not necessarily that they do not exist in Todoist. When projectId is provided, searches only that project. Partial, case-insensitive match on name and email.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
@@ -149,10 +149,14 @@ async function executeWorkspaceSearch({
     client: TodoistApi
     appliedFilters: Record<string, unknown>
 }) {
-    const allCollaborators = await userResolver.getAllCollaborators(client)
+    const sharedCollaborators = await userResolver.getAllCollaborators(client)
+
+    // Always include the authenticated user so "find my user ID" / personal
+    // accounts (no shared projects) still work. Mirrors resolveUser().
+    const allCollaborators = await prependCurrentUser(client, sharedCollaborators)
 
     if (allCollaborators.length === 0) {
-        const textContent = `No users found in workspace. You may have no shared projects, or collaborator data is not accessible.\n\n**Next steps:**\n• Use ${FIND_PROJECTS} to find shared projects\n• Share a project to add collaborators\n• Ensure you have permission to view collaborators`
+        const textContent = `No users found. You may have no shared projects, or collaborator data is not accessible.\n\n**Next steps:**\n• Use ${FIND_PROJECTS} to find shared projects\n• Share a project to add collaborators\n• Ensure you have permission to view collaborators`
 
         return {
             textContent,
@@ -184,6 +188,23 @@ async function executeWorkspaceSearch({
             totalAvailable: allCollaborators.length,
             appliedFilters,
         },
+    }
+}
+
+async function prependCurrentUser(
+    client: TodoistApi,
+    collaborators: ProjectCollaborator[],
+): Promise<ProjectCollaborator[]> {
+    try {
+        const currentUser = await client.getUser()
+        if (!currentUser) return collaborators
+        if (collaborators.some((c) => c.id === currentUser.id)) return collaborators
+        return [
+            { id: currentUser.id, name: currentUser.fullName, email: currentUser.email },
+            ...collaborators,
+        ]
+    } catch {
+        return collaborators
     }
 }
 
@@ -237,20 +258,16 @@ function generateTextContent({
         }
     }
 
+    // Empty-result messages for the no-collaborators-at-all cases are emitted
+    // by the execute paths before they reach generateTextContent, so if we
+    // end up here with an empty list it's necessarily because searchTerm
+    // filtered everyone out.
     const zeroReasonHints: string[] = []
-    if (collaborators.length === 0) {
-        if (searchTerm) {
-            zeroReasonHints.push(`No users match "${searchTerm}"`)
-            zeroReasonHints.push('Try a broader search term or check spelling')
-            if (totalAvailable > 0) {
-                zeroReasonHints.push(`${totalAvailable} users available without filter`)
-            }
-        } else if (projectName) {
-            zeroReasonHints.push('Project has no collaborators')
-            zeroReasonHints.push('Share the project to add collaborators')
-        } else {
-            zeroReasonHints.push('No users found in workspace')
-            zeroReasonHints.push('Share a project to add collaborators')
+    if (collaborators.length === 0 && searchTerm) {
+        zeroReasonHints.push(`No users match "${searchTerm}"`)
+        zeroReasonHints.push('Try a broader search term or check spelling')
+        if (totalAvailable > 0) {
+            zeroReasonHints.push(`${totalAvailable} users available without filter`)
         }
     }
 

--- a/src/utils/__tests__/user-resolver.test.ts
+++ b/src/utils/__tests__/user-resolver.test.ts
@@ -66,4 +66,41 @@ describe('UserResolver', () => {
             expect(result).toBeNull()
         })
     })
+
+    describe('getAllCollaborators', () => {
+        it('paginates through every page of getProjects before collecting collaborators', async () => {
+            const page1Project = { id: 'p1', isShared: true } as unknown
+            const page2Project = { id: 'p2', isShared: true } as unknown
+            const page3Project = { id: 'p3', isShared: false } as unknown
+
+            mockClient.getProjects = vi
+                .fn()
+                .mockResolvedValueOnce({ results: [page1Project], nextCursor: 'cursor-2' })
+                .mockResolvedValueOnce({ results: [page2Project], nextCursor: 'cursor-3' })
+                .mockResolvedValueOnce({
+                    results: [page3Project],
+                    nextCursor: null,
+                }) as unknown as typeof mockClient.getProjects
+
+            mockClient.getProjectCollaborators = vi
+                .fn()
+                .mockImplementation(async (projectId: string) => ({
+                    results: [
+                        {
+                            id: `user-${projectId}`,
+                            name: `User ${projectId}`,
+                            email: `${projectId}@example.com`,
+                        },
+                    ],
+                    nextCursor: null,
+                })) as unknown as typeof mockClient.getProjectCollaborators
+
+            const collaborators = await resolver.getAllCollaborators(mockClient)
+
+            expect(mockClient.getProjects).toHaveBeenCalledTimes(3)
+            // Only the two shared projects should have been queried for collaborators.
+            expect(mockClient.getProjectCollaborators).toHaveBeenCalledTimes(2)
+            expect(collaborators.map((c) => c.id).sort()).toEqual(['user-p1', 'user-p2'])
+        })
+    })
 })

--- a/src/utils/user-resolver.ts
+++ b/src/utils/user-resolver.ts
@@ -1,4 +1,5 @@
-import type { TodoistApi } from '@doist/todoist-sdk'
+import type { PersonalProject, TodoistApi, WorkspaceProject } from '@doist/todoist-sdk'
+import { fetchAllPages } from '../tool-helpers.js'
 
 export type ResolvedUser = {
     userId: string
@@ -228,8 +229,13 @@ export class UserResolver {
         }
 
         try {
-            // Get all projects to find shared ones
-            const { results: projects } = await client.getProjects({})
+            // Get all projects to find shared ones (paginated — accounts with
+            // more than one page of projects would otherwise miss collaborators
+            // from later pages).
+            const projects: (PersonalProject | WorkspaceProject)[] = await fetchAllPages({
+                apiMethod: client.getProjects.bind(client),
+                args: {},
+            })
             const sharedProjects = projects.filter((p) => p.isShared)
 
             if (sharedProjects.length === 0) {

--- a/src/utils/user-resolver.ts
+++ b/src/utils/user-resolver.ts
@@ -217,9 +217,9 @@ export class UserResolver {
     }
 
     /**
-     * Get all collaborators from all shared projects
+     * Get all collaborators from all shared projects, deduplicated by user ID.
      */
-    private async getAllCollaborators(client: TodoistApi): Promise<ProjectCollaborator[]> {
+    async getAllCollaborators(client: TodoistApi): Promise<ProjectCollaborator[]> {
         // Check cache first
         const cacheKey = 'all_collaborators'
         const cached = collaboratorsCache.get(cacheKey)


### PR DESCRIPTION
## Summary

- Rewrite the `find-project-collaborators` tool description with user/person/teammate language and explicit example phrasings so LLM agents match it on "find a user" / "who is X" style prompts.
- Make `projectId` optional; when omitted, search across all shared projects via `userResolver.getAllCollaborators` (promoted from `private` to `public`) — no more forcing the agent to pick a project first.
- Update `mcp-server.ts` instructions to frame this as the user-lookup tool and add a **User Lookup** common workflow.
- Keep the tool name unchanged for backward compatibility (10+ call sites incl. tests, scripts, helpers would otherwise churn, and existing MCP clients would break).

Fixes the agent-discoverability problem raised in Doist/automations#2332 — Ernesto (gnapse) flagged that the name "collaborator" and the project-scoped description were misleading to LLMs looking up a "user".

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full test suite passes (824/824)
- [x] `npm run format:check` clean
- [x] New `src/tools/__tests__/find-project-collaborators.test.ts` covers both branches (per-project and workspace-wide), searchTerm filtering, empty/non-shared cases
- [ ] Manual MCP probe: `npx tsx scripts/run-tool.ts find-project-collaborators '{"searchTerm":"Ernesto"}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)