### PR TITLE
docs: Add one-click "Add to Kiro" install badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,42 @@ This will take you through a wizard to authenticate using your browser with Todo
 }
 ```
 
+#### Kiro
+
+[![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=todoist&config=%7B%22url%22%3A%22https%3A%2F%2Fai.todoist.net%2Fmcp%22%7D)
+
+Create or edit a configuration file:
+
+- **Global:** `~/.kiro/settings/mcp.json`
+- **Project-specific:** `.kiro/settings/mcp.json`
+
+Using the remote URL (recommended):
+
+```json
+{
+    "mcpServers": {
+        "todoist": {
+            "url": "https://ai.todoist.net/mcp"
+        }
+    }
+}
+```
+
+Or using npx:
+
+```json
+{
+    "mcpServers": {
+        "todoist": {
+            "command": "npx",
+            "args": ["-y", "mcp-remote", "https://ai.todoist.net/mcp"]
+        }
+    }
+}
+```
+
+For more information, see the [Kiro MCP documentation](https://kiro.dev/docs/mcp/).
+
 #### Other MCP Clients
 
 ```bash


### PR DESCRIPTION
# Pull Request

Closes #

## Short description

Adds an "Add to Kiro" one-click install badge to the README for [Kiro](https://kiro.dev), an AI-powered IDE.

The badge auto-configures the Todoist MCP server in Kiro with no manual JSON editing. A dedicated Kiro section is added under the Setup Guide. Both remote HTTP and npx transport configs are included as manual fallbacks.

Only the README is modified — no code or tool changes.

## PR Checklist

- [ ] Added tests for bugs / new features
- [x] Updated docs (README, etc.)
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.
