### PR TITLE
feat: add update-labels tool

### DIFF
--- a/scripts/run-tool.ts
+++ b/scripts/run-tool.ts
@@ -52,6 +52,7 @@ import { search } from '../src/tools/search.js'
 import { uncompleteTasks } from '../src/tools/uncomplete-tasks.js'
 import { updateComments } from '../src/tools/update-comments.js'
 import { updateFilters } from '../src/tools/update-filters.js'
+import { updateLabels } from '../src/tools/update-labels.js'
 import { updateProjects } from '../src/tools/update-projects.js'
 import { updateSections } from '../src/tools/update-sections.js'
 import { updateTasks } from '../src/tools/update-tasks.js'
@@ -107,6 +108,7 @@ const tools: Record<string, ExecutableTool> = {
     search: search,
     'update-comments': updateComments,
     'update-filters': updateFilters,
+    'update-labels': updateLabels,
     'update-projects': updateProjects,
     'update-sections': updateSections,
     'update-tasks': updateTasks,

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import { search } from './tools/search.js'
 import { uncompleteTasks } from './tools/uncomplete-tasks.js'
 import { updateComments } from './tools/update-comments.js'
 import { updateFilters } from './tools/update-filters.js'
+import { updateLabels } from './tools/update-labels.js'
 import { updateProjects } from './tools/update-projects.js'
 import { updateSections } from './tools/update-sections.js'
 import { updateTasks } from './tools/update-tasks.js'
@@ -79,6 +80,7 @@ const tools = {
     viewAttachment,
     // Label management tools
     addLabels,
+    updateLabels,
     findLabels,
     // Filter management tools
     findFilters,
@@ -163,6 +165,7 @@ export {
     uncompleteTasks,
     updateComments,
     updateFilters,
+    updateLabels,
     updateProjects,
     updateSections,
     updateTasks,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -48,6 +48,7 @@ import { search } from './tools/search.js'
 import { uncompleteTasks } from './tools/uncomplete-tasks.js'
 import { updateComments } from './tools/update-comments.js'
 import { updateFilters } from './tools/update-filters.js'
+import { updateLabels } from './tools/update-labels.js'
 import { updateProjects } from './tools/update-projects.js'
 import { updateReminders } from './tools/update-reminders.js'
 import { updateSections } from './tools/update-sections.js'
@@ -133,7 +134,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 
 5. **Date Handling**: All dates respect user timezone settings. Use 'today' keyword for dynamic date filtering (includes overdue tasks). **When rescheduling/moving tasks to a different date, always use reschedule-tasks** — never update-tasks with dueString, as that destroys recurrence on recurring tasks.
 
-6. **Labels**: Use label filtering with AND/OR operators for advanced task organization. Most search tools support labels parameter. Use **find-labels** to discover personal and shared labels — use label **names** (not IDs) when filtering tasks, and use label **IDs** only with **delete-object**. Use **add-labels** to create new personal labels.
+6. **Labels**: Use label filtering with AND/OR operators for advanced task organization. Most search tools support labels parameter. Use **find-labels** to discover personal and shared labels — use label **names** (not IDs) when filtering tasks, and use label **IDs** only with **delete-object** and **update-labels** (for personal label updates). Use **add-labels** to create new personal labels. Use **update-labels** to rename or recolor personal labels (by ID), or to rename shared labels (by name) — note that shared labels support renaming only, not color/order/favorite changes.
 
 7. **Pagination**: Large result sets use cursor-based pagination. Use limit parameter to control result size (default varies by tool).
 
@@ -239,6 +240,7 @@ function getMcpServer({
 
     // Label management tools
     registerTool({ tool: addLabels, ...toolArgs })
+    registerTool({ tool: updateLabels, ...toolArgs })
     registerTool({ tool: findLabels, ...toolArgs })
 
     // Filter management tools

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -186,6 +186,13 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         idempotentHint: false,
     },
     {
+        name: ToolNames.UPDATE_LABELS,
+        title: 'Todoist: Update Labels',
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+    },
+    {
         name: ToolNames.FIND_LABELS,
         title: 'Todoist: Find Labels',
         readOnlyHint: true,

--- a/src/tools/__tests__/update-labels.test.ts
+++ b/src/tools/__tests__/update-labels.test.ts
@@ -1,0 +1,250 @@
+import type { TodoistApi } from '@doist/todoist-sdk'
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest'
+import { z } from 'zod'
+import { createMockLabel, TEST_ERRORS } from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { updateLabels } from '../update-labels.js'
+
+const mockTodoistApi = {
+    updateLabel: vi.fn(),
+    renameSharedLabel: vi.fn(),
+} as unknown as Mocked<TodoistApi>
+
+const { UPDATE_LABELS } = ToolNames
+
+describe(`${UPDATE_LABELS} tool`, () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    describe('personal labels', () => {
+        it('should update name and return text + structured output', async () => {
+            mockTodoistApi.updateLabel.mockResolvedValue(
+                createMockLabel({ id: 'label-1', name: 'Renamed' }),
+            )
+
+            const result = await updateLabels.execute(
+                {
+                    labels: [{ labelType: 'personal', id: 'label-1', name: 'Renamed' }],
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.updateLabel).toHaveBeenCalledTimes(1)
+            expect(mockTodoistApi.updateLabel).toHaveBeenCalledWith('label-1', {
+                name: 'Renamed',
+            })
+            expect(result.structuredContent.updatedLabels).toHaveLength(1)
+            expect(result.structuredContent.totalCount).toBe(1)
+            expect(result.structuredContent.appliedOperations).toEqual({
+                updateCount: 1,
+                renameCount: 0,
+                skippedCount: 0,
+            })
+            expect(result.textContent).toContain('Updated 1 label')
+            expect(result.textContent).toContain('Renamed')
+        })
+
+        it('should update color, order, and isFavorite together', async () => {
+            mockTodoistApi.updateLabel.mockResolvedValue(
+                createMockLabel({
+                    id: 'label-1',
+                    name: 'Work',
+                    color: 'blue',
+                    order: 7,
+                    isFavorite: true,
+                }),
+            )
+
+            await updateLabels.execute(
+                {
+                    labels: [
+                        {
+                            labelType: 'personal',
+                            id: 'label-1',
+                            color: 'blue',
+                            order: 7,
+                            isFavorite: true,
+                        },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.updateLabel).toHaveBeenCalledWith('label-1', {
+                color: 'blue',
+                order: 7,
+                isFavorite: true,
+            })
+        })
+
+        it('should update multiple personal labels in one call', async () => {
+            mockTodoistApi.updateLabel
+                .mockResolvedValueOnce(createMockLabel({ id: 'label-1', name: 'A2' }))
+                .mockResolvedValueOnce(createMockLabel({ id: 'label-2', name: 'B2' }))
+
+            const result = await updateLabels.execute(
+                {
+                    labels: [
+                        { labelType: 'personal', id: 'label-1', name: 'A2' },
+                        { labelType: 'personal', id: 'label-2', name: 'B2' },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.updateLabel).toHaveBeenCalledTimes(2)
+            expect(result.structuredContent.totalCount).toBe(2)
+            expect(result.structuredContent.appliedOperations.updateCount).toBe(2)
+        })
+
+        it('should skip personal label when no fields are provided', async () => {
+            const result = await updateLabels.execute(
+                { labels: [{ labelType: 'personal', id: 'label-1' }] },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.updateLabel).not.toHaveBeenCalled()
+            expect(result.structuredContent.updatedLabels).toHaveLength(0)
+            expect(result.structuredContent.appliedOperations).toEqual({
+                updateCount: 0,
+                renameCount: 0,
+                skippedCount: 1,
+            })
+            expect(result.textContent).toContain('skipped - no changes')
+        })
+
+        it('should propagate API errors from updateLabel', async () => {
+            mockTodoistApi.updateLabel.mockRejectedValue(new Error(TEST_ERRORS.API_UNAUTHORIZED))
+
+            await expect(
+                updateLabels.execute(
+                    { labels: [{ labelType: 'personal', id: 'label-1', name: 'X' }] },
+                    mockTodoistApi,
+                ),
+            ).rejects.toThrow(TEST_ERRORS.API_UNAUTHORIZED)
+        })
+
+        it('should normalize a display color name to canonical key', async () => {
+            mockTodoistApi.updateLabel.mockResolvedValue(
+                createMockLabel({ id: 'label-1', color: 'berry_red' }),
+            )
+
+            const parsed = z.object(updateLabels.parameters).parse({
+                labels: [{ labelType: 'personal', id: 'label-1', color: 'Berry Red' }],
+            })
+            await updateLabels.execute(parsed, mockTodoistApi)
+
+            expect(mockTodoistApi.updateLabel).toHaveBeenCalledWith(
+                'label-1',
+                expect.objectContaining({ color: 'berry_red' }),
+            )
+        })
+    })
+
+    describe('shared labels', () => {
+        it('should rename a shared label', async () => {
+            mockTodoistApi.renameSharedLabel.mockResolvedValue(true)
+
+            const result = await updateLabels.execute(
+                {
+                    labels: [{ labelType: 'shared', name: 'old', newName: 'new' }],
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.renameSharedLabel).toHaveBeenCalledWith({
+                name: 'old',
+                newName: 'new',
+            })
+            expect(result.structuredContent.renamedSharedLabels).toEqual([
+                { name: 'old', newName: 'new' },
+            ])
+            expect(result.structuredContent.appliedOperations).toEqual({
+                updateCount: 0,
+                renameCount: 1,
+                skippedCount: 0,
+            })
+            expect(result.textContent).toContain('old → new')
+        })
+
+        it('should mark a shared rename as skipped when API returns false', async () => {
+            mockTodoistApi.renameSharedLabel.mockResolvedValue(false)
+
+            const result = await updateLabels.execute(
+                {
+                    labels: [{ labelType: 'shared', name: 'missing', newName: 'whatever' }],
+                },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.renamedSharedLabels).toHaveLength(0)
+            expect(result.structuredContent.appliedOperations).toEqual({
+                updateCount: 0,
+                renameCount: 0,
+                skippedCount: 1,
+            })
+            expect(result.textContent).toContain('shared label not found')
+        })
+    })
+
+    describe('mixed batch', () => {
+        it('should handle personal updates and shared renames in one call', async () => {
+            mockTodoistApi.updateLabel.mockResolvedValue(
+                createMockLabel({ id: 'label-1', name: 'P2' }),
+            )
+            mockTodoistApi.renameSharedLabel.mockResolvedValue(true)
+
+            const result = await updateLabels.execute(
+                {
+                    labels: [
+                        { labelType: 'personal', id: 'label-1', name: 'P2' },
+                        { labelType: 'shared', name: 's1', newName: 's2' },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.updateLabel).toHaveBeenCalledTimes(1)
+            expect(mockTodoistApi.renameSharedLabel).toHaveBeenCalledTimes(1)
+            expect(result.structuredContent.totalCount).toBe(2)
+            expect(result.structuredContent.appliedOperations).toEqual({
+                updateCount: 1,
+                renameCount: 1,
+                skippedCount: 0,
+            })
+            expect(result.textContent).toContain('Personal:')
+            expect(result.textContent).toContain('Shared:')
+        })
+    })
+
+    describe('schema validation', () => {
+        const ParamsSchema = z.object(updateLabels.parameters)
+
+        it('should reject personal update without id', () => {
+            const parsed = ParamsSchema.safeParse({
+                labels: [{ labelType: 'personal', name: 'X' }],
+            })
+            expect(parsed.success).toBe(false)
+        })
+
+        it('should reject shared update without newName', () => {
+            const parsed = ParamsSchema.safeParse({
+                labels: [{ labelType: 'shared', name: 'foo' }],
+            })
+            expect(parsed.success).toBe(false)
+        })
+
+        it('should reject items without labelType discriminator', () => {
+            const parsed = ParamsSchema.safeParse({
+                labels: [{ id: 'label-1', name: 'X' }],
+            })
+            expect(parsed.success).toBe(false)
+        })
+
+        it('should reject empty labels array', () => {
+            const parsed = ParamsSchema.safeParse({ labels: [] })
+            expect(parsed.success).toBe(false)
+        })
+    })
+})

--- a/src/tools/update-labels.ts
+++ b/src/tools/update-labels.ts
@@ -1,0 +1,192 @@
+import type { Label } from '@doist/todoist-sdk'
+import { z } from 'zod'
+import type { TodoistTool } from '../todoist-tool.js'
+import { ColorSchema } from '../utils/colors.js'
+import { LabelSchema as LabelOutputSchema } from '../utils/output-schemas.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const PersonalLabelUpdateSchema = z.object({
+    labelType: z.literal('personal').describe('Update a personal label, identified by its ID.'),
+    id: z.string().min(1).describe('The ID of the personal label to update.'),
+    name: z.string().min(1).max(128).optional().describe('The new name of the label.'),
+    color: ColorSchema,
+    order: z.number().int().optional().describe('The new position of the label in the label list.'),
+    isFavorite: z.boolean().optional().describe('Whether to mark the label as a favorite.'),
+})
+
+const SharedLabelUpdateSchema = z.object({
+    labelType: z
+        .literal('shared')
+        .describe(
+            'Rename a shared label across all tasks. Shared labels are identified by name; only renaming is supported (no color, order, or favorite).',
+        ),
+    name: z.string().min(1).describe('The current name of the shared label.'),
+    newName: z.string().min(1).describe('The new name for the shared label.'),
+})
+
+const LabelUpdateSchema = z.discriminatedUnion('labelType', [
+    PersonalLabelUpdateSchema,
+    SharedLabelUpdateSchema,
+])
+
+type PersonalLabelUpdate = z.infer<typeof PersonalLabelUpdateSchema>
+type SkipReason = 'no-fields' | 'not-found'
+
+const ArgsSchema = {
+    labels: z
+        .array(LabelUpdateSchema)
+        .min(1)
+        .describe(
+            'The labels to update. Use labelType="personal" with an ID to update a personal label, or labelType="shared" with name+newName to rename a shared label.',
+        ),
+}
+
+const SharedRenameResultSchema = z.object({
+    name: z.string().describe('The previous name of the shared label.'),
+    newName: z.string().describe('The new name of the shared label.'),
+})
+
+const OutputSchema = {
+    updatedLabels: z.array(LabelOutputSchema).describe('The updated personal labels.'),
+    renamedSharedLabels: z
+        .array(SharedRenameResultSchema)
+        .describe('The shared labels that were renamed.'),
+    totalCount: z
+        .number()
+        .describe('The total number of successful operations (personal + shared).'),
+    appliedOperations: z
+        .object({
+            updateCount: z.number().describe('Number of personal labels updated.'),
+            renameCount: z.number().describe('Number of shared labels renamed.'),
+            skippedCount: z
+                .number()
+                .describe('Number of operations skipped (no changes or shared label not found).'),
+        })
+        .describe('Summary of operations performed.'),
+}
+
+const updateLabels = {
+    name: ToolNames.UPDATE_LABELS,
+    description:
+        'Update one or more existing labels. Personal labels (identified by ID) can have their name, color, order, and favorite flag updated. Shared labels (identified by name) can only be renamed.',
+    parameters: ArgsSchema,
+    outputSchema: OutputSchema,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
+    async execute(args, client) {
+        const { labels } = args
+
+        type Result =
+            | { kind: 'updated'; label: Label }
+            | { kind: 'renamed'; name: string; newName: string }
+            | { kind: 'skipped'; reason: SkipReason }
+
+        const results: Result[] = await Promise.all(
+            labels.map(async (label): Promise<Result> => {
+                if (label.labelType === 'personal') {
+                    const skipReason = getPersonalSkipReason(label)
+                    if (skipReason !== null) return { kind: 'skipped', reason: skipReason }
+
+                    const { id, labelType: _labelType, ...updateArgs } = label
+                    const updated = await client.updateLabel(id, updateArgs)
+                    return { kind: 'updated', label: updated }
+                }
+
+                const ok = await client.renameSharedLabel({
+                    name: label.name,
+                    newName: label.newName,
+                })
+                if (!ok) return { kind: 'skipped', reason: 'not-found' }
+                return { kind: 'renamed', name: label.name, newName: label.newName }
+            }),
+        )
+
+        const updatedLabels = results
+            .filter((r): r is { kind: 'updated'; label: Label } => r.kind === 'updated')
+            .map((r) => LabelOutputSchema.parse(r.label))
+
+        const renamedSharedLabels = results
+            .filter(
+                (r): r is { kind: 'renamed'; name: string; newName: string } =>
+                    r.kind === 'renamed',
+            )
+            .map(({ name, newName }) => ({ name, newName }))
+
+        const skippedCount = results.filter((r) => r.kind === 'skipped').length
+        const skippedNoFields = results.filter(
+            (r) => r.kind === 'skipped' && r.reason === 'no-fields',
+        ).length
+        const skippedNotFound = results.filter(
+            (r) => r.kind === 'skipped' && r.reason === 'not-found',
+        ).length
+
+        const textContent = generateTextContent({
+            updatedLabels,
+            renamedSharedLabels,
+            skippedNoFields,
+            skippedNotFound,
+        })
+
+        return {
+            textContent,
+            structuredContent: {
+                updatedLabels,
+                renamedSharedLabels,
+                totalCount: updatedLabels.length + renamedSharedLabels.length,
+                appliedOperations: {
+                    updateCount: updatedLabels.length,
+                    renameCount: renamedSharedLabels.length,
+                    skippedCount,
+                },
+            },
+        }
+    },
+} satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
+
+function generateTextContent({
+    updatedLabels,
+    renamedSharedLabels,
+    skippedNoFields,
+    skippedNotFound,
+}: {
+    updatedLabels: Array<{ id: string; name: string }>
+    renamedSharedLabels: Array<{ name: string; newName: string }>
+    skippedNoFields: number
+    skippedNotFound: number
+}) {
+    const updateCount = updatedLabels.length
+    const renameCount = renamedSharedLabels.length
+    const total = updateCount + renameCount
+
+    const lines: string[] = []
+    lines.push(
+        `Updated ${total} label${total === 1 ? '' : 's'} (${updateCount} personal, ${renameCount} shared)`,
+    )
+
+    const skipParts: string[] = []
+    if (skippedNoFields > 0) skipParts.push(`${skippedNoFields} skipped - no changes`)
+    if (skippedNotFound > 0) skipParts.push(`${skippedNotFound} skipped - shared label not found`)
+    if (skipParts.length > 0) lines[0] += ` (${skipParts.join(', ')})`
+
+    if (updateCount > 0) {
+        lines.push('Personal:')
+        for (const l of updatedLabels) lines.push(`• ${l.name} (id=${l.id})`)
+    }
+    if (renameCount > 0) {
+        lines.push('Shared:')
+        for (const r of renamedSharedLabels) lines.push(`• ${r.name} → ${r.newName}`)
+    }
+
+    return lines.join('\n')
+}
+
+function getPersonalSkipReason({
+    id: _id,
+    labelType: _labelType,
+    ...otherUpdateArgs
+}: PersonalLabelUpdate): SkipReason | null {
+    const values = Object.values(otherUpdateArgs)
+    if (values.every((v) => v === undefined)) return 'no-fields'
+    return null
+}
+
+export { updateLabels }

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -64,6 +64,7 @@ export const ToolNames = {
 
     // Label management tools
     ADD_LABELS: 'add-labels',
+    UPDATE_LABELS: 'update-labels',
     FIND_LABELS: 'find-labels',
 
     // Filter management tools


### PR DESCRIPTION
## Summary
- Adds a new `update-labels` MCP tool that fills the previously missing label-update gap (the SDK already exposed `updateLabel` and `renameSharedLabel`, just nothing wired up)
- Uses a `zod` discriminated union on `labelType`: `"personal"` updates by id (name/color/order/isFavorite via `client.updateLabel`); `"shared"` renames by name (via `client.renameSharedLabel`)
- Mixed personal + shared updates in a single call are supported. Shared label deletion is intentionally out of scope.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run format:check` clean (oxlint + oxfmt)
- [x] `npx vitest run` — 841/841 passing (13 new cases in `update-labels.test.ts`, plus annotation expectation entry)
- [ ] Manual smoke via `scripts/run-tool.ts`:
  ```bash
  npx tsx scripts/run-tool.ts update-labels '{"labels":[{"labelType":"personal","id":"<id>","color":"red"}]}'
  npx tsx scripts/run-tool.ts update-labels '{"labels":[{"labelType":"shared","name":"old","newName":"new"}]}'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)