### PR TITLE
feat: track mcp usage in request headers

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -38,6 +38,7 @@ src/
 ├─ index.ts                   # Public package exports — a curated subset of tools + helpers + types. NOT the full registry.
 ├─ mcp-server.ts              # getMcpServer() factory. **Authoritative tool registry** — imports every tool, calls registerTool() for each, registers productivity-analysis prompt, contains the giant `instructions` string shown to the LLM
 ├─ mcp-helpers.ts             # registerTool(), FEATURE_NAMES, output formatting, retry wrapping
+├─ usage-tracking.ts          # Shared Todoist request headers + SDK customFetch wrapper for MCP usage attribution
 ├─ todoist-tool.ts            # TodoistTool<Params, Output> contract (the tool interface)
 ├─ tool-helpers.ts            # Shared transforms: mapTask, fetchAllPages, resolveInboxProjectId, isInboxProjectId, isPersonalProject, isWorkspaceProject. Re-exports filter-helpers.
 ├─ filter-helpers.ts          # appendToQuery, buildResponsibleUserQueryFilter, resolveResponsibleUser
@@ -54,7 +55,7 @@ src/
 
 1. `main.ts` reads `TODOIST_API_KEY` (and optional `TODOIST_BASE_URL`) from env.
 2. Calls `getMcpServer()` in `mcp-server.ts`, which:
-    - instantiates `new TodoistApi(apiKey, baseUrl)`,
+    - instantiates a shared tracked `TodoistApi` client via `usage-tracking.ts`,
     - iterates every imported tool object and calls
       `registerTool(server, tool, client, features)` from `mcp-helpers.ts`,
     - registers the `productivity-analysis` prompt,

--- a/scripts/run-tool.ts
+++ b/scripts/run-tool.ts
@@ -185,7 +185,11 @@ async function main() {
     }
 
     const baseUrl = process.env.TODOIST_BASE_URL
-    const client = createTodoistClient(apiKey, { baseUrl })
+    const client = createTodoistClient(apiKey, {
+        baseUrl,
+        // Local direct runs are a dev helper, not real MCP traffic.
+        tracking: { enabled: false },
+    })
 
     console.log(`Running ${toolName} with args:`)
     console.log(JSON.stringify(parsedArgs, null, 2))

--- a/scripts/run-tool.ts
+++ b/scripts/run-tool.ts
@@ -58,6 +58,7 @@ import { updateSections } from '../src/tools/update-sections.js'
 import { updateTasks } from '../src/tools/update-tasks.js'
 import { userInfo } from '../src/tools/user-info.js'
 import { viewAttachment } from '../src/tools/view-attachment.js'
+import { createTodoistClient, runWithUsageTrackingContext } from '../src/usage-tracking.js'
 
 config()
 
@@ -184,14 +185,16 @@ async function main() {
     }
 
     const baseUrl = process.env.TODOIST_BASE_URL
-    const client = new TodoistApi(apiKey, baseUrl ? { baseUrl } : undefined)
+    const client = createTodoistClient(apiKey, { baseUrl })
 
     console.log(`Running ${toolName} with args:`)
     console.log(JSON.stringify(parsedArgs, null, 2))
     console.log('---')
 
     try {
-        const result = await tool.execute(parsedArgs, client)
+        const result = await runWithUsageTrackingContext(tool.name, () =>
+            tool.execute(parsedArgs, client),
+        )
 
         if (result.textContent) {
             console.log('\nText output:')

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -5,6 +5,7 @@ import type { ContentBlock, ToolAnnotations } from '@modelcontextprotocol/sdk/ty
 import type { z } from 'zod'
 import type { TodoistTool } from './todoist-tool.js'
 import { formatToolExecutionError } from './tool-execution-error.js'
+import { runWithUsageTrackingContext } from './usage-tracking.js'
 import { executeWithRetry } from './utils/retry.js'
 import { removeNullFields } from './utils/sanitize-data.js'
 import { ToolNames } from './utils/tool-names.js'
@@ -236,9 +237,12 @@ function registerTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape
     // @ts-expect-error I give up
     const cb: ToolCallback<Params> = async (args: z.infer<z.ZodObject<Params>>, _context) => {
         try {
-            let { textContent, structuredContent, contentItems } = await executeWithRetry(() =>
-                tool.execute(args as z.infer<z.ZodObject<Params>>, client),
-            )
+            let { textContent, structuredContent, contentItems } =
+                await runWithUsageTrackingContext(tool.name, () =>
+                    executeWithRetry(() =>
+                        tool.execute(args as z.infer<z.ZodObject<Params>>, client),
+                    ),
+                )
 
             // Strip emails from outputs for ChatGPT clients on collaborator-related tools
             if (shouldStripEmails) {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,4 +1,3 @@
-import { TodoistApi } from '@doist/todoist-sdk'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
 import { registerTaskListApp, taskListResourceUri } from './mcp-apps/resources.js'
@@ -55,6 +54,7 @@ import { updateSections } from './tools/update-sections.js'
 import { updateTasks } from './tools/update-tasks.js'
 import { userInfo } from './tools/user-info.js'
 import { viewAttachment } from './tools/view-attachment.js'
+import { TODOIST_AI_VERSION, createTodoistClient } from './usage-tracking.js'
 
 const instructions = `
 ## Todoist Task and Project Management Tools
@@ -172,7 +172,7 @@ function getMcpServer({
     features?: Features
 }) {
     const server = new McpServer(
-        { name: 'todoist-mcp-server', version: '0.1.0' },
+        { name: 'todoist-mcp-server', version: TODOIST_AI_VERSION },
         {
             capabilities: {
                 tools: { listChanged: true },
@@ -182,7 +182,7 @@ function getMcpServer({
         },
     )
 
-    const todoist = new TodoistApi(todoistApiKey, { baseUrl })
+    const todoist = createTodoistClient(todoistApiKey, { baseUrl })
 
     /**
      * MCP Apps

--- a/src/usage-tracking.test.ts
+++ b/src/usage-tracking.test.ts
@@ -1,20 +1,16 @@
-import { getDefaultDispatcher } from '@doist/todoist-sdk'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
     buildUsageTrackingHeaders,
     createTrackedFetch,
+    resetDispatcherModuleLoaderForTests,
+    resetDefaultDispatcherForTests,
+    setDispatcherModuleLoaderForTests,
     runWithUsageTrackingContext,
 } from './usage-tracking.js'
 
-vi.mock('@doist/todoist-sdk', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('@doist/todoist-sdk')>()
-    return {
-        ...actual,
-        getDefaultDispatcher: vi.fn(() => Promise.resolve(undefined)),
-    }
-})
-
-const getDefaultDispatcherMock = vi.mocked(getDefaultDispatcher)
+const getDefaultDispatcherMock = vi.fn<() => Promise<unknown | undefined>>(() =>
+    Promise.resolve(undefined),
+)
 
 function createJsonResponse(body: unknown = { ok: true }): Response {
     return new Response(JSON.stringify(body), {
@@ -25,26 +21,33 @@ function createJsonResponse(body: unknown = { ok: true }): Response {
 
 describe('usage tracking', () => {
     it('builds mcp tracking headers with tool metadata', () => {
-        const headers = runWithUsageTrackingContext('Find-Tasks', () => buildUsageTrackingHeaders())
+        const headers = runWithUsageTrackingContext('Find-Tasks', () =>
+            buildUsageTrackingHeaders({ sessionId: 'session-123' }),
+        )
 
         expect(headers['User-Agent']).toMatch(/^todoist-ai\/\d+\.\d+\.\d+$/)
         expect(headers['doist-platform']).toBe('mcp')
         expect(headers['doist-version']).toMatch(/^\d+\.\d+\.\d+$/)
         expect(headers['X-TD-Request-Id']).toBeTruthy()
-        expect(headers['X-TD-Session-Id']).toBeTruthy()
+        expect(headers['X-TD-Session-Id']).toBe('session-123')
         expect(headers['X-TD-MCP-Tool']).toBe('find-tasks')
     })
 
     it('falls back to unknown when no tool context is set', () => {
-        expect(buildUsageTrackingHeaders()['X-TD-MCP-Tool']).toBe('unknown')
+        expect(buildUsageTrackingHeaders({ sessionId: 'session-123' })['X-TD-MCP-Tool']).toBe(
+            'unknown',
+        )
     })
 
     it('injects tracking headers into sdk custom fetch requests', async () => {
         const captured: RequestInit[] = []
-        const trackedFetch = createTrackedFetch(async (_url, options) => {
-            captured.push(options ?? {})
-            return createJsonResponse()
-        })
+        const trackedFetch = createTrackedFetch(
+            async (_url, options) => {
+                captured.push(options ?? {})
+                return createJsonResponse()
+            },
+            { sessionId: 'session-123' },
+        )
 
         const response = await runWithUsageTrackingContext('find-tasks', async () => {
             await trackedFetch('https://api.todoist.com/api/v1/tasks', {
@@ -73,22 +76,48 @@ describe('usage tracking', () => {
         expect(firstHeaders['doist-platform']).toBe('mcp')
         expect(firstHeaders['doist-version']).toMatch(/^\d+\.\d+\.\d+$/)
         expect(firstHeaders['x-td-mcp-tool']).toBe('find-tasks')
+        expect(firstHeaders['x-td-session-id']).toBe('session-123')
         expect(firstHeaders['x-td-session-id']).toBe(secondHeaders['x-td-session-id'])
         expect(firstHeaders['x-td-request-id']).not.toBe(secondHeaders['x-td-request-id'])
         expect(response.ok).toBe(true)
     })
 
+    it('uses a different session id for separate tracked fetch instances', async () => {
+        const capturedSessionIds: string[] = []
+        const captureFetch: typeof fetch = async (_url, options) => {
+            const headers = new Headers(options?.headers)
+            const sessionId = headers.get('x-td-session-id')
+            if (!sessionId) {
+                throw new Error('tracked fetch did not include the session header')
+            }
+            capturedSessionIds.push(sessionId)
+            return createJsonResponse()
+        }
+
+        const firstFetch = createTrackedFetch(captureFetch)
+        const secondFetch = createTrackedFetch(captureFetch)
+
+        await firstFetch('https://api.todoist.com/api/v1/tasks')
+        await secondFetch('https://api.todoist.com/api/v1/tasks')
+
+        expect(capturedSessionIds).toHaveLength(2)
+        expect(capturedSessionIds[0]).not.toBe(capturedSessionIds[1])
+    })
+
     it('isolates concurrent tool contexts', async () => {
         const capturedTools: string[] = []
-        const trackedFetch = createTrackedFetch(async (_url, options) => {
-            const headers = options?.headers as Record<string, string>
-            const toolName = headers['x-td-mcp-tool']
-            if (!toolName) {
-                throw new Error('tracked fetch did not include the MCP tool header')
-            }
-            capturedTools.push(toolName)
-            return createJsonResponse()
-        })
+        const trackedFetch = createTrackedFetch(
+            async (_url, options) => {
+                const headers = options?.headers as Record<string, string>
+                const toolName = headers['x-td-mcp-tool']
+                if (!toolName) {
+                    throw new Error('tracked fetch did not include the MCP tool header')
+                }
+                capturedTools.push(toolName)
+                return createJsonResponse()
+            },
+            { sessionId: 'session-123' },
+        )
 
         await Promise.all([
             runWithUsageTrackingContext('find-tasks', async () => {
@@ -105,35 +134,54 @@ describe('usage tracking', () => {
 
     it('maps sdk timeouts to abort signals', async () => {
         let captured: RequestInit | undefined
-        const trackedFetch = createTrackedFetch(async (_url, options) => {
-            captured = options
-            return createJsonResponse()
-        })
+        const trackedFetch = createTrackedFetch(
+            async (_url, options) => {
+                captured = options
+                const abortSignal = options?.signal
+                return await new Promise<Response>((_resolve, reject) => {
+                    if (!(abortSignal instanceof AbortSignal)) {
+                        reject(new Error('tracked fetch did not provide an AbortSignal'))
+                        return
+                    }
 
-        await trackedFetch('https://api.todoist.com/api/v1/tasks', {
-            method: 'GET',
-            timeout: 250,
-        })
+                    if (abortSignal.aborted) {
+                        reject(abortSignal.reason)
+                        return
+                    }
+
+                    abortSignal.addEventListener('abort', () => reject(abortSignal.reason), {
+                        once: true,
+                    })
+                })
+            },
+            { sessionId: 'session-123' },
+        )
+
+        await expect(
+            trackedFetch('https://api.todoist.com/api/v1/tasks', {
+                method: 'GET',
+                timeout: 50,
+            }),
+        ).rejects.toBeInstanceOf(DOMException)
 
         expect(captured?.signal).toBeInstanceOf(AbortSignal)
-        expect(captured?.signal?.aborted).toBe(false)
-
-        await new Promise((resolve) => setTimeout(resolve, 300))
-
         expect(captured?.signal?.aborted).toBe(true)
     })
 
     describe('proxy dispatcher injection', () => {
-        afterEach(() => {
+        afterEach(async () => {
             getDefaultDispatcherMock.mockReset()
             getDefaultDispatcherMock.mockResolvedValue(undefined)
+            await resetDefaultDispatcherForTests()
+            resetDispatcherModuleLoaderForTests()
         })
 
         it('attaches the env proxy dispatcher when createTrackedFetch uses native fetch', async () => {
-            const fakeDispatcher = { kind: 'env-http-proxy-agent' } as unknown as NonNullable<
-                Awaited<ReturnType<typeof getDefaultDispatcher>>
-            >
+            const fakeDispatcher = { kind: 'env-http-proxy-agent', close: vi.fn() }
             getDefaultDispatcherMock.mockResolvedValue(fakeDispatcher)
+            setDispatcherModuleLoaderForTests(async () => ({
+                getDefaultDispatcher: getDefaultDispatcherMock,
+            }))
 
             let captured: RequestInit | undefined
             const originalFetch = globalThis.fetch
@@ -158,10 +206,13 @@ describe('usage tracking', () => {
 
         it('does not attach a dispatcher when createTrackedFetch is given a stub', async () => {
             let captured: RequestInit | undefined
-            const trackedFetch = createTrackedFetch(async (_url, options) => {
-                captured = options
-                return createJsonResponse()
-            })
+            const trackedFetch = createTrackedFetch(
+                async (_url, options) => {
+                    captured = options
+                    return createJsonResponse()
+                },
+                { sessionId: 'session-123' },
+            )
 
             await trackedFetch('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
 
@@ -175,12 +226,30 @@ describe('usage tracking', () => {
         const abortController = new AbortController()
 
         let captured: RequestInit | undefined
-        const trackedFetch = createTrackedFetch(async (_url, options) => {
-            captured = options
-            return createJsonResponse()
-        })
+        const trackedFetch = createTrackedFetch(
+            async (_url, options) => {
+                captured = options
+                const abortSignal = options?.signal
+                return await new Promise<Response>((_resolve, reject) => {
+                    if (!(abortSignal instanceof AbortSignal)) {
+                        reject(new Error('tracked fetch did not provide an AbortSignal'))
+                        return
+                    }
 
-        await trackedFetch('https://api.todoist.com/api/v1/tasks', {
+                    if (abortSignal.aborted) {
+                        reject(abortSignal.reason)
+                        return
+                    }
+
+                    abortSignal.addEventListener('abort', () => reject(abortSignal.reason), {
+                        once: true,
+                    })
+                })
+            },
+            { sessionId: 'session-123' },
+        )
+
+        const fetchPromise = trackedFetch('https://api.todoist.com/api/v1/tasks', {
             method: 'GET',
             signal: abortController.signal,
             timeout: 250,
@@ -192,6 +261,29 @@ describe('usage tracking', () => {
 
         abortController.abort()
 
+        await expect(fetchPromise).rejects.toBeDefined()
         expect(captured?.signal?.aborted).toBe(true)
+    })
+
+    it('can disable usage tracking for direct helper flows', async () => {
+        let captured: RequestInit | undefined
+        const trackedFetch = createTrackedFetch(
+            async (_url, options) => {
+                captured = options
+                return createJsonResponse()
+            },
+            { enabled: false, sessionId: 'session-123' },
+        )
+
+        await trackedFetch('https://api.todoist.com/api/v1/tasks', {
+            method: 'GET',
+            headers: { Authorization: 'Bearer token' },
+        })
+
+        const headers = new Headers(captured?.headers)
+        expect(headers.get('authorization')).toBe('Bearer token')
+        expect(headers.get('doist-platform')).toBeNull()
+        expect(headers.get('x-td-mcp-tool')).toBeNull()
+        expect(headers.get('x-td-session-id')).toBeNull()
     })
 })

--- a/src/usage-tracking.test.ts
+++ b/src/usage-tracking.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import {
+    buildUsageTrackingHeaders,
+    createTrackedFetch,
+    runWithUsageTrackingContext,
+} from './usage-tracking.js'
+
+function createJsonResponse(body: unknown = { ok: true }): Response {
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+    })
+}
+
+describe('usage tracking', () => {
+    it('builds mcp tracking headers with tool metadata', () => {
+        const headers = runWithUsageTrackingContext('Find-Tasks', () => buildUsageTrackingHeaders())
+
+        expect(headers['User-Agent']).toMatch(/^todoist-ai\/\d+\.\d+\.\d+$/)
+        expect(headers['doist-platform']).toBe('mcp')
+        expect(headers['doist-version']).toMatch(/^\d+\.\d+\.\d+$/)
+        expect(headers['X-TD-Request-Id']).toBeTruthy()
+        expect(headers['X-TD-Session-Id']).toBeTruthy()
+        expect(headers['X-TD-MCP-Tool']).toBe('find-tasks')
+    })
+
+    it('falls back to unknown when no tool context is set', () => {
+        expect(buildUsageTrackingHeaders()['X-TD-MCP-Tool']).toBe('unknown')
+    })
+
+    it('injects tracking headers into sdk custom fetch requests', async () => {
+        const captured: RequestInit[] = []
+        const trackedFetch = createTrackedFetch(async (_url, options) => {
+            captured.push(options ?? {})
+            return createJsonResponse()
+        })
+
+        const response = await runWithUsageTrackingContext('find-tasks', async () => {
+            await trackedFetch('https://api.todoist.com/api/v1/tasks', {
+                method: 'GET',
+                headers: { Authorization: 'Bearer token' },
+            })
+
+            return trackedFetch('https://api.todoist.com/api/v1/tasks', {
+                method: 'GET',
+                headers: { Authorization: 'Bearer token' },
+            })
+        })
+
+        expect(captured).toHaveLength(2)
+        const [firstRequest, secondRequest] = captured
+        expect(firstRequest).toBeDefined()
+        expect(secondRequest).toBeDefined()
+        if (!firstRequest || !secondRequest) {
+            throw new Error('tracked fetch did not capture both requests')
+        }
+
+        const firstHeaders = firstRequest.headers as Record<string, string>
+        const secondHeaders = secondRequest.headers as Record<string, string>
+
+        expect(firstHeaders.authorization).toBe('Bearer token')
+        expect(firstHeaders['doist-platform']).toBe('mcp')
+        expect(firstHeaders['doist-version']).toMatch(/^\d+\.\d+\.\d+$/)
+        expect(firstHeaders['x-td-mcp-tool']).toBe('find-tasks')
+        expect(firstHeaders['x-td-session-id']).toBe(secondHeaders['x-td-session-id'])
+        expect(firstHeaders['x-td-request-id']).not.toBe(secondHeaders['x-td-request-id'])
+        expect(response.ok).toBe(true)
+    })
+
+    it('isolates concurrent tool contexts', async () => {
+        const capturedTools: string[] = []
+        const trackedFetch = createTrackedFetch(async (_url, options) => {
+            const headers = options?.headers as Record<string, string>
+            const toolName = headers['x-td-mcp-tool']
+            if (!toolName) {
+                throw new Error('tracked fetch did not include the MCP tool header')
+            }
+            capturedTools.push(toolName)
+            return createJsonResponse()
+        })
+
+        await Promise.all([
+            runWithUsageTrackingContext('find-tasks', async () => {
+                await new Promise((resolve) => setTimeout(resolve, 10))
+                await trackedFetch('https://api.todoist.com/api/v1/tasks')
+            }),
+            runWithUsageTrackingContext('update-tasks', async () => {
+                await trackedFetch('https://api.todoist.com/api/v1/tasks')
+            }),
+        ])
+
+        expect(capturedTools.sort()).toEqual(['find-tasks', 'update-tasks'])
+    })
+
+    it('maps sdk timeouts to abort signals', async () => {
+        let captured: RequestInit | undefined
+        const trackedFetch = createTrackedFetch(async (_url, options) => {
+            captured = options
+            return createJsonResponse()
+        })
+
+        await trackedFetch('https://api.todoist.com/api/v1/tasks', {
+            method: 'GET',
+            timeout: 250,
+        })
+
+        expect(captured?.signal).toBeInstanceOf(AbortSignal)
+        expect(captured?.signal?.aborted).toBe(false)
+
+        await new Promise((resolve) => setTimeout(resolve, 300))
+
+        expect(captured?.signal?.aborted).toBe(true)
+    })
+
+    it('combines sdk timeouts with existing abort signals', async () => {
+        const abortController = new AbortController()
+
+        let captured: RequestInit | undefined
+        const trackedFetch = createTrackedFetch(async (_url, options) => {
+            captured = options
+            return createJsonResponse()
+        })
+
+        await trackedFetch('https://api.todoist.com/api/v1/tasks', {
+            method: 'GET',
+            signal: abortController.signal,
+            timeout: 250,
+        })
+
+        expect(captured?.signal).toBeInstanceOf(AbortSignal)
+        expect(captured?.signal).not.toBe(abortController.signal)
+        expect(captured?.signal?.aborted).toBe(false)
+
+        abortController.abort()
+
+        expect(captured?.signal?.aborted).toBe(true)
+    })
+})

--- a/src/usage-tracking.test.ts
+++ b/src/usage-tracking.test.ts
@@ -1,9 +1,20 @@
-import { describe, expect, it } from 'vitest'
+import { getDefaultDispatcher } from '@doist/todoist-sdk'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
     buildUsageTrackingHeaders,
     createTrackedFetch,
     runWithUsageTrackingContext,
 } from './usage-tracking.js'
+
+vi.mock('@doist/todoist-sdk', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@doist/todoist-sdk')>()
+    return {
+        ...actual,
+        getDefaultDispatcher: vi.fn(() => Promise.resolve(undefined)),
+    }
+})
+
+const getDefaultDispatcherMock = vi.mocked(getDefaultDispatcher)
 
 function createJsonResponse(body: unknown = { ok: true }): Response {
     return new Response(JSON.stringify(body), {
@@ -110,6 +121,54 @@ describe('usage tracking', () => {
         await new Promise((resolve) => setTimeout(resolve, 300))
 
         expect(captured?.signal?.aborted).toBe(true)
+    })
+
+    describe('proxy dispatcher injection', () => {
+        afterEach(() => {
+            getDefaultDispatcherMock.mockReset()
+            getDefaultDispatcherMock.mockResolvedValue(undefined)
+        })
+
+        it('attaches the env proxy dispatcher when createTrackedFetch uses native fetch', async () => {
+            const fakeDispatcher = { kind: 'env-http-proxy-agent' } as unknown as NonNullable<
+                Awaited<ReturnType<typeof getDefaultDispatcher>>
+            >
+            getDefaultDispatcherMock.mockResolvedValue(fakeDispatcher)
+
+            let captured: RequestInit | undefined
+            const originalFetch = globalThis.fetch
+            globalThis.fetch = (async (_url: RequestInfo | URL, options?: RequestInit) => {
+                captured = options
+                return createJsonResponse()
+            }) as typeof fetch
+
+            try {
+                const trackedFetch = createTrackedFetch()
+                await trackedFetch('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
+            } finally {
+                globalThis.fetch = originalFetch
+            }
+
+            expect(getDefaultDispatcherMock).toHaveBeenCalled()
+            expect(captured).toBeTruthy()
+            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBe(
+                fakeDispatcher,
+            )
+        })
+
+        it('does not attach a dispatcher when createTrackedFetch is given a stub', async () => {
+            let captured: RequestInit | undefined
+            const trackedFetch = createTrackedFetch(async (_url, options) => {
+                captured = options
+                return createJsonResponse()
+            })
+
+            await trackedFetch('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
+
+            expect(getDefaultDispatcherMock).not.toHaveBeenCalled()
+            expect(captured).toBeTruthy()
+            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBeUndefined()
+        })
     })
 
     it('combines sdk timeouts with existing abort signals', async () => {

--- a/src/usage-tracking.ts
+++ b/src/usage-tracking.ts
@@ -1,6 +1,11 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { randomUUID } from 'node:crypto'
-import { TodoistApi, type CustomFetch, type CustomFetchResponse } from '@doist/todoist-sdk'
+import {
+    type CustomFetch,
+    type CustomFetchResponse,
+    getDefaultDispatcher,
+    TodoistApi,
+} from '@doist/todoist-sdk'
 import packageJson from '../package.json' with { type: 'json' }
 
 const TODOIST_AI_NAME = 'todoist-ai'
@@ -41,6 +46,14 @@ function mergeTodoistHeaders(headersInit?: HeadersInit): Record<string, string> 
     return Object.fromEntries(mergedHeaders.entries())
 }
 
+async function attachDispatcher(options: RequestInit): Promise<void> {
+    const dispatcher = await getDefaultDispatcher()
+    if (dispatcher !== undefined) {
+        // @ts-expect-error - dispatcher is a valid option for Node's fetch but not in the TS types
+        options.dispatcher = dispatcher
+    }
+}
+
 function toCustomFetchResponse(response: Response): CustomFetchResponse {
     return {
         ok: response.ok,
@@ -53,6 +66,10 @@ function toCustomFetchResponse(response: Response): CustomFetchResponse {
 }
 
 export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): CustomFetch {
+    // Only attach the EnvHttpProxyAgent dispatcher when running through the
+    // real native fetch. Test stubs pass an explicit `baseFetch` and don't
+    // need (or understand) the dispatcher option.
+    const useDispatcher = baseFetch === globalThis.fetch
     return async (url, options = {}) => {
         const { timeout: timeoutMs, headers, signal, ...rest } = options
 
@@ -62,12 +79,16 @@ export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): 
             abortSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
         }
 
-        const response = await baseFetch(url, {
+        const fetchOptions: RequestInit = {
             ...rest,
             signal: abortSignal,
             headers: mergeTodoistHeaders(headers),
-        })
+        }
+        if (useDispatcher) {
+            await attachDispatcher(fetchOptions)
+        }
 
+        const response = await baseFetch(url, fetchOptions)
         return toCustomFetchResponse(response)
     }
 }

--- a/src/usage-tracking.ts
+++ b/src/usage-tracking.ts
@@ -1,0 +1,85 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { randomUUID } from 'node:crypto'
+import { TodoistApi, type CustomFetch, type CustomFetchResponse } from '@doist/todoist-sdk'
+import packageJson from '../package.json' with { type: 'json' }
+
+const TODOIST_AI_NAME = 'todoist-ai'
+const TODOIST_AI_VERSION = packageJson.version
+const SESSION_ID = randomUUID()
+const toolContext = new AsyncLocalStorage<string>()
+
+function getUserAgent(): string {
+    return `${TODOIST_AI_NAME}/${TODOIST_AI_VERSION}`
+}
+
+export function normalizeUsageLabel(label: string): string {
+    return label.trim().toLowerCase()
+}
+
+export function runWithUsageTrackingContext<T>(label: string, fn: () => T): T {
+    return toolContext.run(normalizeUsageLabel(label), fn)
+}
+
+export function buildUsageTrackingHeaders(label?: string): Record<string, string> {
+    const normalizedLabel = label ? normalizeUsageLabel(label) : toolContext.getStore()
+
+    return {
+        'User-Agent': getUserAgent(),
+        'doist-platform': 'mcp',
+        'doist-version': TODOIST_AI_VERSION,
+        'X-TD-Request-Id': randomUUID(),
+        'X-TD-Session-Id': SESSION_ID,
+        'X-TD-MCP-Tool': normalizedLabel ?? 'unknown',
+    }
+}
+
+function mergeTodoistHeaders(headersInit?: HeadersInit): Record<string, string> {
+    const mergedHeaders = new Headers(headersInit)
+    for (const [key, value] of Object.entries(buildUsageTrackingHeaders())) {
+        mergedHeaders.set(key, value)
+    }
+    return Object.fromEntries(mergedHeaders.entries())
+}
+
+function toCustomFetchResponse(response: Response): CustomFetchResponse {
+    return {
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        headers: Object.fromEntries(response.headers.entries()),
+        text: () => response.text(),
+        json: () => response.json(),
+    }
+}
+
+export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): CustomFetch {
+    return async (url, options = {}) => {
+        const { timeout: timeoutMs, headers, signal, ...rest } = options
+
+        let abortSignal = signal
+        if (timeoutMs) {
+            const timeoutSignal = AbortSignal.timeout(timeoutMs)
+            abortSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
+        }
+
+        const response = await baseFetch(url, {
+            ...rest,
+            signal: abortSignal,
+            headers: mergeTodoistHeaders(headers),
+        })
+
+        return toCustomFetchResponse(response)
+    }
+}
+
+export function createTodoistClient(
+    apiKey: string,
+    { baseUrl }: { baseUrl?: string } = {},
+): TodoistApi {
+    return new TodoistApi(apiKey, {
+        customFetch: createTrackedFetch(),
+        ...(baseUrl ? { baseUrl } : {}),
+    })
+}
+
+export { TODOIST_AI_VERSION }

--- a/src/usage-tracking.ts
+++ b/src/usage-tracking.ts
@@ -1,17 +1,32 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { randomUUID } from 'node:crypto'
-import {
-    type CustomFetch,
-    type CustomFetchResponse,
-    getDefaultDispatcher,
-    TodoistApi,
-} from '@doist/todoist-sdk'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+import { type CustomFetch, type CustomFetchResponse, TodoistApi } from '@doist/todoist-sdk'
 import packageJson from '../package.json' with { type: 'json' }
 
 const TODOIST_AI_NAME = 'todoist-ai'
 const TODOIST_AI_VERSION = packageJson.version
-const SESSION_ID = randomUUID()
 const toolContext = new AsyncLocalStorage<string>()
+const require = createRequire(import.meta.url)
+
+type UsageTrackingConfig = {
+    enabled?: boolean
+    platform?: string
+    sessionId?: string
+}
+
+type DispatcherModule = {
+    getDefaultDispatcher: () => Promise<unknown | undefined>
+}
+
+let defaultDispatcherPromise: Promise<unknown | undefined> | undefined
+const defaultDispatcherModuleLoader = async (): Promise<DispatcherModule> => {
+    const todoistSdkEntry = require.resolve('@doist/todoist-sdk')
+    const dispatcherModulePath = join(dirname(todoistSdkEntry), 'transport', 'http-dispatcher.js')
+    return require(dispatcherModulePath) as DispatcherModule
+}
+let dispatcherModuleLoader = defaultDispatcherModuleLoader
 
 function getUserAgent(): string {
     return `${TODOIST_AI_NAME}/${TODOIST_AI_VERSION}`
@@ -25,29 +40,147 @@ export function runWithUsageTrackingContext<T>(label: string, fn: () => T): T {
     return toolContext.run(normalizeUsageLabel(label), fn)
 }
 
-export function buildUsageTrackingHeaders(label?: string): Record<string, string> {
+export function buildUsageTrackingHeaders({
+    label,
+    platform = 'mcp',
+    sessionId = randomUUID(),
+}: {
+    label?: string
+    platform?: string
+    sessionId?: string
+} = {}): Record<string, string> {
     const normalizedLabel = label ? normalizeUsageLabel(label) : toolContext.getStore()
 
     return {
         'User-Agent': getUserAgent(),
-        'doist-platform': 'mcp',
+        'doist-platform': platform,
         'doist-version': TODOIST_AI_VERSION,
         'X-TD-Request-Id': randomUUID(),
-        'X-TD-Session-Id': SESSION_ID,
+        'X-TD-Session-Id': sessionId,
         'X-TD-MCP-Tool': normalizedLabel ?? 'unknown',
     }
 }
 
-function mergeTodoistHeaders(headersInit?: HeadersInit): Record<string, string> {
+function mergeTodoistHeaders(
+    headersInit: HeadersInit | undefined,
+    tracking: Required<Pick<UsageTrackingConfig, 'platform' | 'sessionId'>>,
+): Record<string, string> {
     const mergedHeaders = new Headers(headersInit)
-    for (const [key, value] of Object.entries(buildUsageTrackingHeaders())) {
+    for (const [key, value] of Object.entries(buildUsageTrackingHeaders(tracking))) {
         mergedHeaders.set(key, value)
     }
     return Object.fromEntries(mergedHeaders.entries())
 }
 
+function getTimeoutAbortReason(): DOMException {
+    return new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+}
+
+function mergeAbortSignals(
+    signal: AbortSignal | null | undefined,
+    timeoutMs: number | undefined,
+): {
+    signal: AbortSignal | undefined
+    cleanup: () => void
+} {
+    if (!signal && timeoutMs === undefined) {
+        return {
+            signal: undefined,
+            cleanup: () => {},
+        }
+    }
+
+    if (!signal && timeoutMs !== undefined) {
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(getTimeoutAbortReason()), timeoutMs)
+        return {
+            signal: controller.signal,
+            cleanup: () => clearTimeout(timeoutId),
+        }
+    }
+
+    if (signal && timeoutMs === undefined) {
+        return {
+            signal,
+            cleanup: () => {},
+        }
+    }
+
+    const controller = new AbortController()
+    const cleanups: Array<() => void> = []
+
+    const abort = (reason: unknown) => {
+        if (!controller.signal.aborted) {
+            controller.abort(reason)
+        }
+    }
+
+    if (signal?.aborted) {
+        abort(signal.reason)
+    } else if (signal) {
+        const onAbort = () => abort(signal.reason)
+        signal.addEventListener('abort', onAbort, { once: true })
+        cleanups.push(() => signal.removeEventListener('abort', onAbort))
+    }
+
+    const timeoutId = setTimeout(() => abort(getTimeoutAbortReason()), timeoutMs)
+    cleanups.push(() => clearTimeout(timeoutId))
+
+    return {
+        signal: controller.signal,
+        cleanup: () => {
+            for (const cleanup of cleanups) {
+                cleanup()
+            }
+        },
+    }
+}
+
+async function getSdkDefaultDispatcher(): Promise<unknown | undefined> {
+    if (!isNodeEnvironment()) {
+        return undefined
+    }
+
+    if (!defaultDispatcherPromise) {
+        defaultDispatcherPromise = dispatcherModuleLoader()
+            .then((dispatcherModule) => dispatcherModule.getDefaultDispatcher())
+            .catch((error) => {
+                defaultDispatcherPromise = undefined
+                throw error
+            })
+    }
+
+    return defaultDispatcherPromise
+}
+
+function isNodeEnvironment(): boolean {
+    return typeof process !== 'undefined' && Boolean(process.versions?.node)
+}
+
+export async function resetDefaultDispatcherForTests(): Promise<void> {
+    if (!defaultDispatcherPromise) {
+        return
+    }
+
+    const dispatcherPromise = defaultDispatcherPromise
+    defaultDispatcherPromise = undefined
+    await dispatcherPromise.then(
+        (dispatcher) =>
+            (dispatcher as { close?: () => void | Promise<void> } | undefined)?.close?.(),
+        () => undefined,
+    )
+}
+
+export function setDispatcherModuleLoaderForTests(loader: () => Promise<DispatcherModule>): void {
+    dispatcherModuleLoader = loader
+}
+
+export function resetDispatcherModuleLoaderForTests(): void {
+    dispatcherModuleLoader = defaultDispatcherModuleLoader
+}
+
 async function attachDispatcher(options: RequestInit): Promise<void> {
-    const dispatcher = await getDefaultDispatcher()
+    const dispatcher = await getSdkDefaultDispatcher()
     if (dispatcher !== undefined) {
         // @ts-expect-error - dispatcher is a valid option for Node's fetch but not in the TS types
         options.dispatcher = dispatcher
@@ -65,40 +198,54 @@ function toCustomFetchResponse(response: Response): CustomFetchResponse {
     }
 }
 
-export function createTrackedFetch(baseFetch: typeof fetch = globalThis.fetch): CustomFetch {
+export function createTrackedFetch(
+    baseFetch: typeof fetch = globalThis.fetch,
+    tracking: UsageTrackingConfig = {},
+): CustomFetch {
     // Only attach the EnvHttpProxyAgent dispatcher when running through the
     // real native fetch. Test stubs pass an explicit `baseFetch` and don't
     // need (or understand) the dispatcher option.
     const useDispatcher = baseFetch === globalThis.fetch
+    const { enabled = true, platform = 'mcp', sessionId = randomUUID() } = tracking
     return async (url, options = {}) => {
         const { timeout: timeoutMs, headers, signal, ...rest } = options
 
-        let abortSignal = signal
-        if (timeoutMs) {
-            const timeoutSignal = AbortSignal.timeout(timeoutMs)
-            abortSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
-        }
+        const { signal: abortSignal, cleanup } = mergeAbortSignals(signal, timeoutMs)
 
-        const fetchOptions: RequestInit = {
-            ...rest,
-            signal: abortSignal,
-            headers: mergeTodoistHeaders(headers),
-        }
-        if (useDispatcher) {
-            await attachDispatcher(fetchOptions)
-        }
+        try {
+            const fetchOptions: RequestInit = {
+                ...rest,
+                signal: abortSignal,
+                ...(enabled
+                    ? { headers: mergeTodoistHeaders(headers, { platform, sessionId }) }
+                    : headers !== undefined
+                      ? { headers }
+                      : {}),
+            }
+            if (useDispatcher) {
+                await attachDispatcher(fetchOptions)
+            }
 
-        const response = await baseFetch(url, fetchOptions)
-        return toCustomFetchResponse(response)
+            const response = await baseFetch(url, fetchOptions)
+            return toCustomFetchResponse(response)
+        } finally {
+            cleanup()
+        }
     }
 }
 
 export function createTodoistClient(
     apiKey: string,
-    { baseUrl }: { baseUrl?: string } = {},
+    {
+        baseUrl,
+        tracking,
+    }: {
+        baseUrl?: string
+        tracking?: UsageTrackingConfig
+    } = {},
 ): TodoistApi {
     return new TodoistApi(apiKey, {
-        customFetch: createTrackedFetch(),
+        customFetch: createTrackedFetch(globalThis.fetch, tracking),
         ...(baseUrl ? { baseUrl } : {}),
     })
 }

--- a/src/utils/validate-todoist-token.test.ts
+++ b/src/utils/validate-todoist-token.test.ts
@@ -78,6 +78,9 @@ describe('validateTodoistToken', () => {
 
         await validateTodoistToken('token', 'https://custom.api.com')
 
-        expect(TodoistApi).toHaveBeenCalledWith('token', { baseUrl: 'https://custom.api.com' })
+        expect(TodoistApi).toHaveBeenCalledWith('token', {
+            baseUrl: 'https://custom.api.com',
+            customFetch: expect.any(Function),
+        })
     })
 })

--- a/src/utils/validate-todoist-token.ts
+++ b/src/utils/validate-todoist-token.ts
@@ -1,5 +1,4 @@
-import { TodoistApi } from '@doist/todoist-sdk'
-
+import { createTodoistClient, runWithUsageTrackingContext } from '../usage-tracking.js'
 import { extractHttpStatusCode } from './retry.js'
 
 const AUTH_ERROR_CODES = new Set([401, 403])
@@ -29,9 +28,9 @@ function extractAuthStatusCode(error: unknown): number | undefined {
  * @throws On transient errors (network failures, 5xx) so the caller can decide.
  */
 async function validateTodoistToken(apiKey: string, baseUrl?: string): Promise<boolean> {
-    const client = new TodoistApi(apiKey, { baseUrl })
+    const client = createTodoistClient(apiKey, { baseUrl })
     try {
-        await client.getUser()
+        await runWithUsageTrackingContext('auth:validate-token', () => client.getUser())
         return true
     } catch (error) {
         const statusCode = extractAuthStatusCode(error)


### PR DESCRIPTION
# Pull Request

## Short description

Adds shared request-header tracking for Todoist-bound MCP calls by routing SDK clients through a tracked custom fetch. Requests now carry MCP attribution plus stable session and per-request IDs, and tool context is propagated through the MCP server, token validation, and local `run-tool` path. The change also drops `doist-os` from the MCP contract because it mostly reflects the hosted server environment rather than meaningful client usage. Validation: `npm run format:check`, `npm run type-check`, `npm test`, `npm run build`, plus local `scripts/run-tool.ts` checks for `user-info` and `find-projects` against staging.

## PR Checklist

- [x] Added tests for bugs / new features
- [x] Updated docs (README, etc.)
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.
