### PR TITLE
feat: upgrade @doist/todoist-sdk to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "8.10.0",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-sdk": "9.8.0",
+                "@doist/todoist-sdk": "10.1.0",
                 "@modelcontextprotocol/ext-apps": "1.2.2",
                 "date-fns": "4.1.0",
                 "dompurify": "3.3.3",
@@ -460,9 +460,9 @@
             }
         },
         "node_modules/@doist/todoist-sdk": {
-            "version": "9.8.0",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-9.8.0.tgz",
-            "integrity": "sha512-qCXWlV3BTZfF9xhgs4slHttf9kna4F0HN16+S4osbc8WxNNcZlzbre8PzewWuVyd4RskcGyMsEogZLZC8U/0Gg==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.1.0.tgz",
+            "integrity": "sha512-o4AM0YGcQLlNyHOZ126qCfa+FQHsgNOKWpfZCECtjm6a+7tsiU39E/em3Ihcaynh7nUkYRXEVC8RUQ0kkCkJXw==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-sdk": "9.8.0",
+        "@doist/todoist-sdk": "10.1.0",
         "@modelcontextprotocol/ext-apps": "1.2.2",
         "date-fns": "4.1.0",
         "dompurify": "3.3.3",

--- a/src/tools/__tests__/get-productivity-stats.test.ts
+++ b/src/tools/__tests__/get-productivity-stats.test.ts
@@ -61,9 +61,9 @@ function createMockStats(overrides: Partial<ProductivityStats> = {}): Productivi
             maxWeeklyStreak: { count: 12, start: '2025-09-01', end: '2025-11-24' },
             user: 'user123',
             userId: 'user123',
-            vacationMode: 0,
-            karmaDisabled: 0,
-            ignoreDays: [6, 7],
+            vacationMode: false,
+            karmaDisabled: false,
+            ignoreDays: ['Saturday', 'Sunday'],
         },
         karma: 86394,
         karmaTrend: 'up',
@@ -114,8 +114,8 @@ describe(`${GET_PRODUCTIVITY_STATS} tool`, () => {
         expect(sc?.goals.currentWeeklyStreak.count).toBe(6)
         expect(sc?.goals.maxDailyStreak.count).toBe(30)
         expect(sc?.goals.maxWeeklyStreak.count).toBe(12)
-        expect(sc?.goals.vacationMode).toBe(0)
-        expect(sc?.goals.karmaDisabled).toBe(0)
+        expect(sc?.goals.vacationMode).toBe(false)
+        expect(sc?.goals.karmaDisabled).toBe(false)
         expect(sc?.daysItems).toHaveLength(3)
         expect(sc?.weekItems).toHaveLength(2)
         expect(sc?.karmaGraphData).toHaveLength(2)

--- a/src/tools/get-productivity-stats.ts
+++ b/src/tools/get-productivity-stats.ts
@@ -50,8 +50,8 @@ const OutputSchema = {
             lastWeeklyStreak: StreakSchema.describe('Previous weekly goal streak.'),
             maxDailyStreak: StreakSchema.describe('Best daily goal streak ever.'),
             maxWeeklyStreak: StreakSchema.describe('Best weekly goal streak ever.'),
-            vacationMode: z.number().describe('Whether vacation mode is enabled (0 or 1).'),
-            karmaDisabled: z.number().describe('Whether karma tracking is disabled (0 or 1).'),
+            vacationMode: z.boolean().describe('Whether vacation mode is enabled.'),
+            karmaDisabled: z.boolean().describe('Whether karma tracking is disabled.'),
         })
         .describe('Goal and streak information.'),
     karma: z.number().describe('Current karma score.'),


### PR DESCRIPTION
## Summary
- Bump `@doist/todoist-sdk` from 9.8.0 → 10.1.0
- SDK v10 transforms a few productivity-stats fields into stronger types — updated `get-productivity-stats` output schema + test fixture to match:
  - `goals.vacationMode`: `number` (0/1) → `boolean`
  - `goals.karmaDisabled`: `number` (0/1) → `boolean`
  - `goals.ignoreDays` (SDK-internal): `number[]` → `DayOfWeek[]` (e.g. `"Saturday"`)

Technically this changes the MCP `outputSchema` for `get-productivity-stats`, but the impact on real consumers is minimal: most clients use `textContent` (unchanged), and the boolean values still behave the same way under truthiness checks. Releasing as a minor.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 841/841 pass
- [x] `npm run format:check` clean
- [x] `npm run build` succeeds
- [ ] Spot-check `get-productivity-stats` in a live MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)