### PR TITLE
fix: surface view-attachment file body in content blocks

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -68,11 +68,14 @@ src/
 ## Tool contract (`src/todoist-tool.ts`)
 
 ```ts
-type TodoistTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape> = {
+type TodoistTool<
+    Params extends z.ZodRawShape,
+    Output extends z.ZodRawShape = Record<string, never>,
+> = {
     name: string
     description: string
     parameters: Params // Zod raw shape (NOT z.object)
-    outputSchema: Output // Zod raw shape
+    outputSchema?: Output // Zod raw shape; omit for tools that return only content blocks (e.g. view-attachment)
     annotations: {
         // required hints
         readOnlyHint: boolean

--- a/src/mcp-helpers.test.ts
+++ b/src/mcp-helpers.test.ts
@@ -51,6 +51,61 @@ describe('stripEmailsFromText', () => {
     })
 })
 
+describe('registerTool config', () => {
+    it('omits outputSchema when the tool does not declare one', () => {
+        const registerToolMock = vi.fn()
+
+        registerTool({
+            tool: {
+                name: 'no-schema-tool',
+                description: 'Tool without output schema',
+                parameters: {},
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                },
+                execute: async () => ({ textContent: 'ok' }),
+            },
+            server: {
+                registerTool: registerToolMock,
+            } as unknown as Parameters<typeof registerTool>[0]['server'],
+            client: {} as Parameters<typeof registerTool>[0]['client'],
+        })
+
+        expect(registerToolMock).toHaveBeenCalledTimes(1)
+        const config = registerToolMock.mock.calls[0]?.[1] as Record<string, unknown>
+        expect(Object.hasOwn(config, 'outputSchema')).toBe(false)
+    })
+
+    it('includes outputSchema when the tool declares one', () => {
+        const registerToolMock = vi.fn()
+        const outputSchema = {}
+
+        registerTool({
+            tool: {
+                name: 'schema-tool',
+                description: 'Tool with output schema',
+                parameters: {},
+                outputSchema,
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                },
+                execute: async () => ({ textContent: 'ok' }),
+            },
+            server: {
+                registerTool: registerToolMock,
+            } as unknown as Parameters<typeof registerTool>[0]['server'],
+            client: {} as Parameters<typeof registerTool>[0]['client'],
+        })
+
+        const config = registerToolMock.mock.calls[0]?.[1] as Record<string, unknown>
+        expect(config.outputSchema).toBe(outputSchema)
+    })
+})
+
 describe('registerTool error path', () => {
     it('applies centralized API formatting in MCP callback errors', async () => {
         const registerToolMock = vi.fn()

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -260,7 +260,7 @@ function registerTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape
     const toolConfig = {
         description: tool.description,
         inputSchema: tool.parameters,
-        outputSchema: tool.outputSchema as Output,
+        ...(tool.outputSchema ? { outputSchema: tool.outputSchema as Output } : {}),
         annotations: getMcpAnnotations(tool),
         ...(tool._meta ? { _meta: tool._meta } : {}),
     }

--- a/src/todoist-tool.ts
+++ b/src/todoist-tool.ts
@@ -17,7 +17,7 @@ type RequiredToolAnnotations = ToolAnnotations & {
 /**
  * A Todoist tool that can be used in an MCP server or other conversational AI interfaces.
  */
-type TodoistTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape> = {
+type TodoistTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape = z.ZodRawShape> = {
     /**
      * The name of the tool.
      */
@@ -42,7 +42,7 @@ type TodoistTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape> = {
      *
      * This is used to describe the structured output format that the tool will return.
      */
-    outputSchema: Output
+    outputSchema?: Output
 
     /**
      * MCP ToolAnnotations hints for this tool.

--- a/src/todoist-tool.ts
+++ b/src/todoist-tool.ts
@@ -17,7 +17,10 @@ type RequiredToolAnnotations = ToolAnnotations & {
 /**
  * A Todoist tool that can be used in an MCP server or other conversational AI interfaces.
  */
-type TodoistTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape = z.ZodRawShape> = {
+type TodoistTool<
+    Params extends z.ZodRawShape,
+    Output extends z.ZodRawShape = Record<string, never>,
+> = {
     /**
      * The name of the tool.
      */

--- a/src/tools/__tests__/view-attachment.test.ts
+++ b/src/tools/__tests__/view-attachment.test.ts
@@ -243,6 +243,7 @@ describe('view-attachment tool', () => {
                 type: 'text',
                 text: '<h1>Hello</h1>',
             })
+            expect((result as Record<string, unknown>).structuredContent).toBeUndefined()
         })
     })
 
@@ -418,7 +419,7 @@ describe('view-attachment tool', () => {
                 type: 'text',
                 text: 'hello',
             })
-            expect(result.textContent).toContain('KB')
+            expect(result.textContent).toContain('0.0KB')
         })
     })
 

--- a/src/tools/__tests__/view-attachment.test.ts
+++ b/src/tools/__tests__/view-attachment.test.ts
@@ -100,9 +100,8 @@ describe('view-attachment tool', () => {
                 data: Buffer.from(imageData).toString('base64'),
                 mimeType: 'image/png',
             })
-            expect(result.structuredContent.contentDelivery).toBe('image')
-            expect(result.structuredContent.fileType).toBe('image/png')
-            expect(result.structuredContent.fileName).toBe('file.png')
+            expect(result.textContent).toContain('file.png')
+            expect(result.textContent).toContain('image/png')
         })
 
         it('should return ImageContent for JPEG files', async () => {
@@ -123,7 +122,6 @@ describe('view-attachment tool', () => {
                 type: 'image',
                 mimeType: 'image/jpeg',
             })
-            expect(result.structuredContent.contentDelivery).toBe('image')
         })
 
         it('should return ImageContent for GIF files', async () => {
@@ -185,8 +183,7 @@ describe('view-attachment tool', () => {
                 type: 'text',
                 text: textContent,
             })
-            expect(result.structuredContent.contentDelivery).toBe('text')
-            expect(result.structuredContent.fileType).toBe('text/plain')
+            expect(result.textContent).toContain('text/plain')
         })
 
         it('should return TextContent for JSON files', async () => {
@@ -207,7 +204,6 @@ describe('view-attachment tool', () => {
                 type: 'text',
                 text: jsonContent,
             })
-            expect(result.structuredContent.contentDelivery).toBe('text')
         })
 
         it('should return TextContent for CSV files', async () => {
@@ -243,7 +239,10 @@ describe('view-attachment tool', () => {
                 mockTodoistApi,
             )
 
-            expect(result.structuredContent.contentDelivery).toBe('text')
+            expect(result.contentItems?.[0]).toEqual({
+                type: 'text',
+                text: '<h1>Hello</h1>',
+            })
         })
     })
 
@@ -270,8 +269,7 @@ describe('view-attachment tool', () => {
                     blob: Buffer.from(pdfData).toString('base64'),
                 },
             })
-            expect(result.structuredContent.contentDelivery).toBe('embedded_resource')
-            expect(result.structuredContent.fileType).toBe('application/pdf')
+            expect(result.textContent).toContain('application/pdf')
         })
 
         it('should return EmbeddedResource for unknown binary types', async () => {
@@ -291,7 +289,6 @@ describe('view-attachment tool', () => {
                 type: 'resource',
                 resource: { mimeType: 'application/zip' },
             })
-            expect(result.structuredContent.contentDelivery).toBe('embedded_resource')
         })
     })
 
@@ -309,8 +306,8 @@ describe('view-attachment tool', () => {
                 mockTodoistApi,
             )
 
-            expect(result.structuredContent.fileType).toBe('text/plain')
-            expect(result.structuredContent.contentDelivery).toBe('text')
+            expect(result.textContent).toContain('text/plain')
+            expect(result.contentItems?.[0]).toMatchObject({ type: 'text' })
         })
 
         it('should fall back to URL extension when content-type is application/octet-stream', async () => {
@@ -327,8 +324,8 @@ describe('view-attachment tool', () => {
                 mockTodoistApi,
             )
 
-            expect(result.structuredContent.fileType).toBe('image/png')
-            expect(result.structuredContent.contentDelivery).toBe('image')
+            expect(result.textContent).toContain('image/png')
+            expect(result.contentItems?.[0]).toMatchObject({ type: 'image', mimeType: 'image/png' })
         })
 
         it('should use application/octet-stream when no content-type and no extension match', async () => {
@@ -344,8 +341,8 @@ describe('view-attachment tool', () => {
                 mockTodoistApi,
             )
 
-            expect(result.structuredContent.fileType).toBe('application/octet-stream')
-            expect(result.structuredContent.contentDelivery).toBe('embedded_resource')
+            expect(result.textContent).toContain('application/octet-stream')
+            expect(result.contentItems?.[0]).toMatchObject({ type: 'resource' })
         })
 
         it('should fall back to URL extension for PDF when content-type is generic', async () => {
@@ -361,7 +358,7 @@ describe('view-attachment tool', () => {
                 mockTodoistApi,
             )
 
-            expect(result.structuredContent.fileType).toBe('application/pdf')
+            expect(result.textContent).toContain('application/pdf')
         })
     })
 
@@ -382,7 +379,6 @@ describe('view-attachment tool', () => {
             )
 
             expect(result.contentItems).toBeUndefined()
-            expect(result.structuredContent.contentDelivery).toBe('metadata_only')
             expect(result.textContent).toContain('too large')
             expect(result.textContent).toContain('10MB')
         })
@@ -402,11 +398,10 @@ describe('view-attachment tool', () => {
             )
 
             expect(result.contentItems).toBeUndefined()
-            expect(result.structuredContent.contentDelivery).toBe('metadata_only')
             expect(result.textContent).toContain('too large')
         })
 
-        it('should use actual body size for fileSize in structured content', async () => {
+        it('should use actual body size for fileSize in text content', async () => {
             mockTodoistApi.viewAttachment.mockResolvedValue(
                 createMockResponse({
                     contentType: 'text/plain',
@@ -419,7 +414,10 @@ describe('view-attachment tool', () => {
                 mockTodoistApi,
             )
 
-            expect(result.structuredContent.fileSize).toBe(5)
+            expect(result.contentItems?.[0]).toEqual({
+                type: 'text',
+                text: 'hello',
+            })
             expect(result.textContent).toContain('KB')
         })
     })
@@ -450,7 +448,7 @@ describe('view-attachment tool', () => {
         })
     })
 
-    describe('text content and structured output', () => {
+    describe('text content', () => {
         it('should include file name from URL in text content', async () => {
             mockTodoistApi.viewAttachment.mockResolvedValue(
                 createMockResponse({
@@ -466,7 +464,6 @@ describe('view-attachment tool', () => {
 
             expect(result.textContent).toContain('screenshot.png')
             expect(result.textContent).toContain('image/png')
-            expect(result.structuredContent.fileName).toBe('screenshot.png')
         })
 
         it('should handle URLs without file names gracefully', async () => {

--- a/src/tools/view-attachment.ts
+++ b/src/tools/view-attachment.ts
@@ -77,20 +77,10 @@ function getFileNameFromUrl(url: string): string | undefined {
 
 const ArgsSchema = {
     fileUrl: z
-        .string()
         .url()
         .describe(
             "The URL of the attachment file to view. Get this from the fileUrl field in a comment's fileAttachment.",
         ),
-}
-
-const OutputSchema = {
-    fileName: z.string().optional().describe('The name of the file.'),
-    fileType: z.string().optional().describe('The MIME type of the file.'),
-    fileSize: z.number().optional().describe('The size of the file in bytes.'),
-    contentDelivery: z
-        .enum(['image', 'text', 'embedded_resource', 'metadata_only'])
-        .describe('How the content was delivered.'),
 }
 
 const viewAttachment = {
@@ -98,7 +88,6 @@ const viewAttachment = {
     description:
         "View a file attachment from a Todoist comment. Pass the fileUrl from a comment's fileAttachment field. Supports images (returned inline), text files (returned as text), and binary files like PDFs (returned as embedded resources).",
     parameters: ArgsSchema,
-    outputSchema: OutputSchema,
     annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -111,7 +100,6 @@ const viewAttachment = {
         const headerFileSize = contentLength ? Number.parseInt(contentLength, 10) : undefined
         const fileName = getFileNameFromUrl(fileUrl)
 
-        // Determine MIME type from Content-Type header, fall back to URL extension
         const rawContentType = response.headers['content-type']
         const headerMime = rawContentType ? parseMimeType(rawContentType) : undefined
         const mimeType =
@@ -119,38 +107,23 @@ const viewAttachment = {
                 ? headerMime
                 : (getMimeTypeFromUrl(fileUrl) ?? headerMime ?? 'application/octet-stream')
 
-        // Early reject if content-length header exceeds limit
         if (headerFileSize && headerFileSize > MAX_FILE_SIZE) {
             return {
                 textContent: `Attachment "${fileName ?? fileUrl}" is too large to display inline (${(headerFileSize / 1024 / 1024).toFixed(1)}MB, limit is 10MB). File type: ${mimeType}`,
-                structuredContent: {
-                    fileName,
-                    fileType: mimeType,
-                    fileSize: headerFileSize,
-                    contentDelivery: 'metadata_only' as const,
-                },
             }
         }
 
-        // Read body and enforce size limit on actual bytes
         const buffer = Buffer.from(await response.arrayBuffer())
         const fileSize = buffer.byteLength
 
         if (fileSize > MAX_FILE_SIZE) {
             return {
                 textContent: `Attachment "${fileName ?? fileUrl}" is too large to display inline (${(fileSize / 1024 / 1024).toFixed(1)}MB, limit is 10MB). File type: ${mimeType}`,
-                structuredContent: {
-                    fileName,
-                    fileType: mimeType,
-                    fileSize,
-                    contentDelivery: 'metadata_only' as const,
-                },
             }
         }
 
         const category = getContentCategory(mimeType)
         const contentItems: ContentBlock[] = []
-        let contentDelivery: 'image' | 'text' | 'embedded_resource'
 
         if (category === 'image') {
             contentItems.push({
@@ -158,13 +131,11 @@ const viewAttachment = {
                 data: buffer.toString('base64'),
                 mimeType,
             })
-            contentDelivery = 'image'
         } else if (category === 'text') {
             contentItems.push({
                 type: 'text',
                 text: buffer.toString('utf-8'),
             })
-            contentDelivery = 'text'
         } else {
             contentItems.push({
                 type: 'resource',
@@ -174,22 +145,15 @@ const viewAttachment = {
                     blob: buffer.toString('base64'),
                 },
             })
-            contentDelivery = 'embedded_resource'
         }
 
         const textContent = `Attachment: ${fileName ?? 'unknown'} (${mimeType}, ${(fileSize / 1024).toFixed(1)}KB)`
 
         return {
             textContent,
-            structuredContent: {
-                fileName,
-                fileType: mimeType,
-                fileSize,
-                contentDelivery,
-            },
             contentItems,
         }
     },
-} satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
+} satisfies TodoistTool<typeof ArgsSchema>
 
 export { viewAttachment }


### PR DESCRIPTION
## Summary

- Fixes #466. `view-attachment` was returning the file body in `content[]` blocks **and** a structured-content metadata envelope; MCP clients that prefer `structuredContent` (e.g. ChatGPT, Claude Code) surfaced only the metadata and the file body looked missing.
- Drop `outputSchema`/`structuredContent` from `view-attachment` so the typed image/text/resource content blocks become the canonical answer.
- Make `outputSchema` optional on the `TodoistTool` interface (no behavior change for other tools, all already declare one).
- `registerTool()` now omits `outputSchema` when undefined.
- Replace deprecated `z.string().url()` with `z.url()` in the args schema.

## Why content blocks, not a richer structured schema

`content[]` is the MCP-spec'd carrier for media: `image` (inline render), `resource` (embedded with mimeType/uri), `text` (raw body). Cramming base64 image/binary into `structuredContent` loses the rendering hint and bloats JSON. Text-only would split the response shape across two carriers.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm test` — 841/841 pass
- [x] `npm run format:check` — clean
- [x] Local repro via `scripts/run-tool.ts view-attachment` — HTML body present in `contentItems[0]`, no structured envelope
- [x] Raw HTTP `tools/call` against deployed server — confirmed prior shape included redundant metadata text + structuredContent; new shape leaves only header text + file body
- [ ] Post-deploy: re-run the original failing case from #466 (forwarded-email HTML attachment) through a real MCP client; confirm the body is rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)