### PR TITLE
fix: strip section response fields to match output schema

### DIFF
--- a/src/tools/add-sections.ts
+++ b/src/tools/add-sections.ts
@@ -2,7 +2,7 @@ import type { Section } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
 import { isInboxProjectId, resolveInboxProjectId } from '../tool-helpers.js'
-import { SectionSchema as SectionOutputSchema } from '../utils/output-schemas.js'
+import { SectionSchema as SectionOutputSchema, toSectionSummary } from '../utils/output-schemas.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 const SectionSchema = z.object({
@@ -56,7 +56,7 @@ const addSections = {
         return {
             textContent,
             structuredContent: {
-                sections: newSections.map(({ id, name }) => ({ id, name })),
+                sections: newSections.map(toSectionSummary),
                 totalCount: newSections.length,
             },
         }

--- a/src/tools/add-sections.ts
+++ b/src/tools/add-sections.ts
@@ -56,7 +56,7 @@ const addSections = {
         return {
             textContent,
             structuredContent: {
-                sections: newSections,
+                sections: newSections.map(({ id, name }) => ({ id, name })),
                 totalCount: newSections.length,
             },
         }

--- a/src/tools/get-overview.ts
+++ b/src/tools/get-overview.ts
@@ -8,7 +8,7 @@ import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
 import { mapTask, type Project } from '../tool-helpers.js'
 import { ApiLimits } from '../utils/constants.js'
-import { SectionSchema } from '../utils/output-schemas.js'
+import { SectionSchema, type SectionSummary, toSectionSummary } from '../utils/output-schemas.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 const ArgsSchema = {
@@ -234,12 +234,6 @@ function renderTaskTreeMarkdown(tasks: TaskTreeNode[], indent = ''): string[] {
     return lines
 }
 
-type SectionSummary = z.infer<typeof SectionSchema>
-
-function toSectionSummaries(sections: Section[]): SectionSummary[] {
-    return sections.map(({ id, name }) => ({ id, name }))
-}
-
 type ProjectStructure = {
     id: string
     name: string
@@ -288,7 +282,7 @@ function buildProjectStructure(
         parentId: isPersonalProject(project) ? (project.parentId ?? undefined) : undefined,
         folderId: isWorkspaceProject(project) ? (project.folderId ?? undefined) : undefined,
         childOrder: project.childOrder,
-        sections: toSectionSummaries(sectionsByProject[project.id] || []),
+        sections: (sectionsByProject[project.id] || []).map(toSectionSummary),
         children: project.children.map((child: ProjectWithChildren) =>
             buildProjectStructure(child, sectionsByProject),
         ),
@@ -358,7 +352,7 @@ async function generateAccountOverview(
             ? {
                   id: inbox.id,
                   name: inbox.name,
-                  sections: toSectionSummaries(sectionsByProject[inbox.id] || []),
+                  sections: (sectionsByProject[inbox.id] || []).map(toSectionSummary),
               }
             : null,
         projects: tree.map((project) =>
@@ -424,7 +418,7 @@ async function generateProjectOverview(
             id: project.id,
             name: project.name,
         },
-        sections: toSectionSummaries(sections),
+        sections: sections.map(toSectionSummary),
         tasks: allTasks.map((task) => ({
             ...task,
             children: [], // Tasks already include hierarchical info via parentId

--- a/src/tools/get-overview.ts
+++ b/src/tools/get-overview.ts
@@ -8,6 +8,7 @@ import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
 import { mapTask, type Project } from '../tool-helpers.js'
 import { ApiLimits } from '../utils/constants.js'
+import { SectionSchema } from '../utils/output-schemas.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 const ArgsSchema = {
@@ -86,14 +87,7 @@ const OutputSchema = {
         .object({
             id: z.string().describe('The inbox project ID.'),
             name: z.string().describe('The inbox project name.'),
-            sections: z
-                .array(
-                    z.object({
-                        id: z.string(),
-                        name: z.string(),
-                    }),
-                )
-                .describe('Sections in the inbox project.'),
+            sections: z.array(SectionSchema).describe('Sections in the inbox project.'),
         })
         .nullable()
         .optional()
@@ -112,12 +106,7 @@ const OutputSchema = {
         .optional()
         .describe('Project details (project overview only).'),
     sections: z
-        .array(
-            z.object({
-                id: z.string(),
-                name: z.string(),
-            }),
-        )
+        .array(SectionSchema)
         .optional()
         .describe('List of sections (project overview only).'),
     tasks: z.array(z.any()).optional().describe('List of tasks (project overview only).'),
@@ -245,13 +234,19 @@ function renderTaskTreeMarkdown(tasks: TaskTreeNode[], indent = ''): string[] {
     return lines
 }
 
+type SectionSummary = z.infer<typeof SectionSchema>
+
+function toSectionSummaries(sections: Section[]): SectionSummary[] {
+    return sections.map(({ id, name }) => ({ id, name }))
+}
+
 type ProjectStructure = {
     id: string
     name: string
     parentId?: string
     folderId?: string
     childOrder: number
-    sections: Section[]
+    sections: SectionSummary[]
     children: ProjectStructure[]
 }
 
@@ -260,7 +255,7 @@ type AccountOverviewStructured = Record<string, unknown> & {
     inbox: {
         id: string
         name: string
-        sections: Section[]
+        sections: SectionSummary[]
     } | null
     projects: ProjectStructure[]
     totalProjects: number
@@ -274,7 +269,7 @@ type ProjectOverviewStructured = Record<string, unknown> & {
         id: string
         name: string
     }
-    sections: Section[]
+    sections: SectionSummary[]
     tasks: Array<ReturnType<typeof mapTask> & { children: never[] }>
     stats: {
         totalTasks: number
@@ -293,7 +288,7 @@ function buildProjectStructure(
         parentId: isPersonalProject(project) ? (project.parentId ?? undefined) : undefined,
         folderId: isWorkspaceProject(project) ? (project.folderId ?? undefined) : undefined,
         childOrder: project.childOrder,
-        sections: sectionsByProject[project.id] || [],
+        sections: toSectionSummaries(sectionsByProject[project.id] || []),
         children: project.children.map((child: ProjectWithChildren) =>
             buildProjectStructure(child, sectionsByProject),
         ),
@@ -363,7 +358,7 @@ async function generateAccountOverview(
             ? {
                   id: inbox.id,
                   name: inbox.name,
-                  sections: sectionsByProject[inbox.id] || [],
+                  sections: toSectionSummaries(sectionsByProject[inbox.id] || []),
               }
             : null,
         projects: tree.map((project) =>
@@ -429,7 +424,7 @@ async function generateProjectOverview(
             id: project.id,
             name: project.name,
         },
-        sections: sections,
+        sections: toSectionSummaries(sections),
         tasks: allTasks.map((task) => ({
             ...task,
             children: [], // Tasks already include hierarchical info via parentId

--- a/src/tools/update-sections.ts
+++ b/src/tools/update-sections.ts
@@ -37,7 +37,7 @@ const updateSections = {
         return {
             textContent,
             structuredContent: {
-                sections: updatedSections,
+                sections: updatedSections.map(({ id, name }) => ({ id, name })),
                 totalCount: updatedSections.length,
                 updatedSectionIds: updatedSections.map((section) => section.id),
             },

--- a/src/tools/update-sections.ts
+++ b/src/tools/update-sections.ts
@@ -1,7 +1,7 @@
 import type { Section } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
-import { SectionSchema as SectionOutputSchema } from '../utils/output-schemas.js'
+import { SectionSchema as SectionOutputSchema, toSectionSummary } from '../utils/output-schemas.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 const SectionUpdateSchema = z.object({
@@ -37,7 +37,7 @@ const updateSections = {
         return {
             textContent,
             structuredContent: {
-                sections: updatedSections.map(({ id, name }) => ({ id, name })),
+                sections: updatedSections.map(toSectionSummary),
                 totalCount: updatedSections.length,
                 updatedSectionIds: updatedSections.map((section) => section.id),
             },

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -1,4 +1,4 @@
-import { LOCATION_TRIGGERS, REMINDER_TYPES } from '@doist/todoist-sdk'
+import { LOCATION_TRIGGERS, REMINDER_TYPES, type Section } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import { ColorOutputSchema } from './colors.js'
 import { PrioritySchema } from './priorities.js'
@@ -78,7 +78,7 @@ type SectionSummary = z.infer<typeof SectionSchema>
  * Strip an SDK Section (or any object with id/name) down to the fields
  * declared in SectionSchema. Keeps tool responses aligned with the schema.
  */
-function toSectionSummary({ id, name }: SectionSummary): SectionSummary {
+function toSectionSummary({ id, name }: Section): SectionSummary {
     return { id, name }
 }
 

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -72,6 +72,16 @@ const SectionSchema = z.object({
     name: z.string().describe('The name of the section.'),
 })
 
+type SectionSummary = z.infer<typeof SectionSchema>
+
+/**
+ * Strip an SDK Section (or any object with id/name) down to the fields
+ * declared in SectionSchema. Keeps tool responses aligned with the schema.
+ */
+function toSectionSummary({ id, name }: SectionSummary): SectionSummary {
+    return { id, name }
+}
+
 /**
  * Schema for a file attachment in a comment
  */
@@ -203,5 +213,7 @@ export {
     ProjectSchema,
     ReminderSchema,
     SectionSchema,
+    type SectionSummary,
     TaskSchema,
+    toSectionSummary,
 }


### PR DESCRIPTION
## Summary

- `add-sections`, `update-sections`, and `get-overview` declare section objects in their output schemas as `{id, name}` (via `SectionSchema`), but the structured responses included the full SDK `Section` (`userId`, `projectId`, `sectionOrder`, `isArchived`, `isDeleted`, `isCollapsed`, `url`).
- Strict MCP clients (e.g. Perplexity's structured-content validation with `additionalProperties: false`) rejected the responses.
- Map sections to `{id, name}` before returning so the runtime payload matches the declared schema.
- In `get-overview`, also collapse the duplicated inline section schemas to the shared `SectionSchema` and infer `SectionSummary` from it (single source of truth).
- `find-sections` was already stripping correctly — left untouched.

## Test plan

- [x] `npx tsc --noEmit`
- [x] Full vitest run (853 tests)
- [ ] Verify in a strict MCP client that section responses no longer fail structured-content validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)