### PR TITLE
chore: add Claude Code plugin manifest and marketplace entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+    "name": "doist",
+    "owner": {
+        "name": "Doist",
+        "url": "https://doist.com"
+    },
+    "plugins": [
+        {
+            "name": "todoist",
+            "description": "Todoist for Claude Code — manage tasks, projects, labels, and workflows from your terminal.",
+            "source": {
+                "source": "url",
+                "url": "https://github.com/doist/todoist-ai.git"
+            }
+        }
+    ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+    "name": "todoist",
+    "version": "8.12.1",
+    "description": "Todoist for Claude Code — manage tasks, projects, labels, and workflows from your terminal.",
+    "author": {
+        "name": "Doist",
+        "url": "https://doist.com"
+    },
+    "homepage": "https://github.com/doist/todoist-ai",
+    "repository": "https://github.com/doist/todoist-ai"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+    "mcpServers": {
+        "todoist": {
+            "type": "http",
+            "url": "https://ai.todoist.net/mcp"
+        }
+    }
+}

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -20,7 +20,9 @@ TypeScript · ESM-only · Node 18+ · `zod` v4 for schemas · MCP SDK ≥1.25.
 ```
 /
 ├─ src/                   # All source. See tree below.
-├─ scripts/               # run-tool.ts (direct tool invocation), validate-schemas.ts, test-executable.cjs
+├─ scripts/               # run-tool.ts (direct tool invocation), validate-schemas.ts, test-executable.cjs, bump-plugin-version.mjs (semantic-release plugin manifest sync)
+├─ .claude-plugin/        # Claude Code plugin manifest (plugin.json) + marketplace entry (marketplace.json)
+├─ .mcp.json              # MCP server declaration consumed by the Claude Code plugin (HTTP transport → ai.todoist.net/mcp)
 ├─ dist/                  # Build output (Vite). Never edit.
 ├─ CLAUDE.md              # Prescriptive rules (schema design, testing, field clearing)
 ├─ AGENTS.md              # Fuller agent guidelines — includes the authoritative new-tool checklist
@@ -160,7 +162,7 @@ New tool? Full checklist in `AGENTS.md`. Short version: copy `add-tasks.ts`; imp
 - **Type-check:** `npm run type-check` (runs `tsc --noEmit`).
 - **Format/lint:** `npm run format:check` / `npm run format:fix` — uses **oxlint + oxfmt**, not eslint/prettier.
 - **Schema lint:** `npm run lint:schemas` — validates every tool's Zod schema via `scripts/validate-schemas.ts`. Runs automatically on `src/tools/*.ts` via lint-staged.
-- **Release:** `semantic-release` on merge to `main` (GitHub Actions). Commits must follow Conventional Commits — enforced by `check-semantic-pull-request.yml`.
+- **Release:** `semantic-release` on merge to `main` (GitHub Actions). Commits must follow Conventional Commits — enforced by `check-semantic-pull-request.yml`. The pipeline runs `scripts/bump-plugin-version.mjs` (via `@semantic-release/exec`) to keep `.claude-plugin/plugin.json` in lockstep with `package.json`; both files are committed back together.
 - **Husky:** `prepare` script installs Husky. Actual commit-time behavior is in `.husky/pre-commit`, which runs `lint-staged` then `npm run type-check`.
 
 ## Run a tool without MCP

--- a/README.md
+++ b/README.md
@@ -89,15 +89,22 @@ Then enable the server in Cursor settings if prompted.
 
 #### Claude Code (CLI)
 
-Firstly configure Claude so it has a new MCP available using this command:
+The fastest setup is the official Todoist plugin, which wires up the MCP server for you:
+
+```bash
+/plugin marketplace add doist/todoist-ai
+/plugin install todoist@doist
+```
+
+OAuth runs in your browser the first time you use a Todoist tool. See [Anthropic's plugin docs](https://code.claude.com/docs/en/plugins-reference) for more.
+
+If you'd rather configure the MCP server manually, run:
 
 ```bash
 claude mcp add --transport http todoist https://ai.todoist.net/mcp
 ```
 
-Then launch `claude`, execute `/mcp`, then select the `todoist` MCP server.
-
-This will take you through a wizard to authenticate using your browser with Todoist. Once complete you will be able to use todoist in `claude`.
+Then launch `claude`, execute `/mcp`, and select the `todoist` MCP server to authenticate.
 
 #### Visual Studio Code
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
             "devDependencies": {
                 "@modelcontextprotocol/inspector": "0.21.2",
                 "@semantic-release/changelog": "6.0.3",
+                "@semantic-release/exec": "7.1.0",
                 "@semantic-release/git": "10.0.1",
                 "@types/dompurify": "3.2.0",
                 "@types/express": "5.0.6",
@@ -3781,6 +3782,178 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14.17"
+            }
+        },
+        "node_modules/@semantic-release/exec": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-7.1.0.tgz",
+            "integrity": "sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@semantic-release/error": "^4.0.0",
+                "aggregate-error": "^3.0.0",
+                "debug": "^4.0.0",
+                "execa": "^9.0.0",
+                "lodash-es": "^4.17.21",
+                "parse-json": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=20.8.1"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=24.1.0"
+            }
+        },
+        "node_modules/@semantic-release/exec/node_modules/@semantic-release/error": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+            "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@semantic-release/exec/node_modules/execa": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+            "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "figures": "^6.1.0",
+                "get-stream": "^9.0.0",
+                "human-signals": "^8.0.1",
+                "is-plain-obj": "^4.1.0",
+                "is-stream": "^4.0.1",
+                "npm-run-path": "^6.0.0",
+                "pretty-ms": "^9.2.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^4.0.0",
+                "yoctocolors": "^2.1.1"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.5.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/@semantic-release/exec/node_modules/get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/exec/node_modules/human-signals": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+            "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@semantic-release/exec/node_modules/is-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/exec/node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/exec/node_modules/parse-json": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+            "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.26.2",
+                "index-to-position": "^1.1.0",
+                "type-fest": "^4.39.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/exec/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/exec/node_modules/strip-final-newline": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/exec/node_modules/unicorn-magic": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@semantic-release/git": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "devDependencies": {
         "@modelcontextprotocol/inspector": "0.21.2",
         "@semantic-release/changelog": "6.0.3",
+        "@semantic-release/exec": "7.1.0",
         "@semantic-release/git": "10.0.1",
         "@types/dompurify": "3.2.0",
         "@types/express": "5.0.6",

--- a/release.config.js
+++ b/release.config.js
@@ -9,9 +9,21 @@ export default {
         '@semantic-release/changelog',
         '@semantic-release/npm',
         [
+            '@semantic-release/exec',
+            {
+                // oxlint-disable-next-line no-template-curly-in-string -- semantic-release template
+                prepareCmd: 'node scripts/bump-plugin-version.mjs ${nextRelease.version}',
+            },
+        ],
+        [
             '@semantic-release/git',
             {
-                assets: ['CHANGELOG.md', 'package.json', 'package-lock.json'],
+                assets: [
+                    'CHANGELOG.md',
+                    'package.json',
+                    'package-lock.json',
+                    '.claude-plugin/plugin.json',
+                ],
                 // oxlint-disable-next-line no-template-curly-in-string -- semantic-release template
                 message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
             },

--- a/scripts/bump-plugin-version.mjs
+++ b/scripts/bump-plugin-version.mjs
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 import { readFileSync, writeFileSync } from 'node:fs'
 
-const version = process.argv[2]
+const [version, manifestPath = '.claude-plugin/plugin.json'] = process.argv.slice(2)
+
 if (!version) {
-    console.error('Usage: bump-plugin-version.mjs <version>')
+    console.error('Usage: bump-plugin-version.mjs <version> [manifestPath]')
     process.exit(1)
 }
 
-const path = '.claude-plugin/plugin.json'
-const manifest = JSON.parse(readFileSync(path, 'utf8'))
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
 manifest.version = version
-writeFileSync(path, `${JSON.stringify(manifest, null, 4)}\n`)
-console.log(`Updated ${path} to ${version}`)
+writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 4)}\n`)
+console.log(`Updated ${manifestPath} to ${version}`)

--- a/scripts/bump-plugin-version.mjs
+++ b/scripts/bump-plugin-version.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const version = process.argv[2]
+if (!version) {
+    console.error('Usage: bump-plugin-version.mjs <version>')
+    process.exit(1)
+}
+
+const path = '.claude-plugin/plugin.json'
+const manifest = JSON.parse(readFileSync(path, 'utf8'))
+manifest.version = version
+writeFileSync(path, `${JSON.stringify(manifest, null, 4)}\n`)
+console.log(`Updated ${path} to ${version}`)

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = process.cwd()
+
+function readJson(relative: string) {
+    return JSON.parse(readFileSync(join(repoRoot, relative), 'utf8'))
+}
+
+describe('Claude Code plugin manifests', () => {
+    it('plugin.json shape and version match package.json', () => {
+        const plugin = readJson('.claude-plugin/plugin.json')
+        const pkg = readJson('package.json')
+        expect(plugin.name).toBe('todoist')
+        expect(plugin.version).toBe(pkg.version)
+        expect(plugin.description).toMatch(/Todoist/)
+        expect(plugin.author?.name).toBe('Doist')
+        expect(plugin.repository).toMatch(/todoist-ai/)
+    })
+
+    it('marketplace.json wires the todoist plugin to this repo', () => {
+        const marketplace = readJson('.claude-plugin/marketplace.json')
+        expect(marketplace.name).toBe('doist')
+        expect(marketplace.owner?.name).toBe('Doist')
+        expect(marketplace.plugins).toHaveLength(1)
+        const [plugin] = marketplace.plugins
+        expect(plugin.name).toBe('todoist')
+        expect(plugin.source.source).toBe('url')
+        expect(plugin.source.url).toMatch(/todoist-ai/)
+    })
+
+    it('.mcp.json declares the HTTP transport for the remote server', () => {
+        const mcp = readJson('.mcp.json')
+        expect(mcp.mcpServers?.todoist?.type).toBe('http')
+        expect(mcp.mcpServers?.todoist?.url).toBe('https://ai.todoist.net/mcp')
+    })
+})
+
+describe('release config plugin-version sync', () => {
+    it('release.config.js wires the bump script and includes the manifest in git assets', () => {
+        const source = readFileSync(join(repoRoot, 'release.config.js'), 'utf8')
+        expect(source).toContain('@semantic-release/exec')
+        expect(source).toContain('scripts/bump-plugin-version.mjs')
+        expect(source).toContain('.claude-plugin/plugin.json')
+    })
+})
+
+describe('bump-plugin-version script', () => {
+    it('updates the version field of the target manifest in place', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'plugin-bump-'))
+        const path = join(dir, 'plugin.json')
+        writeFileSync(
+            path,
+            `${JSON.stringify({ name: 'todoist', version: '0.0.0', description: 'x' }, null, 4)}\n`,
+        )
+
+        execFileSync('node', ['scripts/bump-plugin-version.mjs', '1.2.3', path], {
+            cwd: repoRoot,
+        })
+
+        const updated = JSON.parse(readFileSync(path, 'utf8'))
+        expect(updated.version).toBe('1.2.3')
+        expect(updated.name).toBe('todoist')
+        expect(updated.description).toBe('x')
+    })
+
+    it('exits with error when version arg is missing', () => {
+        expect(() =>
+            execFileSync('node', ['scripts/bump-plugin-version.mjs'], {
+                cwd: repoRoot,
+                stdio: 'pipe',
+            }),
+        ).toThrow()
+    })
+})


### PR DESCRIPTION
## Summary

- Wraps the existing remote MCP server (`https://ai.todoist.net/mcp`) as a Claude Code plugin so users can install it via `/plugin` with OAuth handled automatically.
- Adds a `doist` marketplace entry hosted in this repo, exposing the `todoist` plugin.
- Wires `@semantic-release/exec` into the release pipeline so `.claude-plugin/plugin.json` version stays in sync with `package.json`.

## What's added

- `.claude-plugin/plugin.json` — plugin manifest (name, version mirrors `package.json`, description, author, repo).
- `.claude-plugin/marketplace.json` — `doist` marketplace, `todoist` plugin entry pointing at this repo.
- `.mcp.json` — HTTP transport declaration for the plugin's MCP server.
- `scripts/bump-plugin-version.mjs` — small helper invoked by semantic-release to rewrite the plugin manifest version.
- `release.config.js` — adds `@semantic-release/exec` step (after npm bump, before git commit) and includes `.claude-plugin/plugin.json` in git assets.
- README "Claude Code (CLI)" section updated with `/plugin` install steps; the manual `claude mcp add` instructions are kept as a fallback.

No changes to MCP server behavior. Picked `chore:` because there's nothing publishable here — the server itself is unchanged.

## Test plan

- [ ] Run locally: `claude --plugin-dir .` from repo root.
- [ ] Inside Claude Code: `/plugin` lists `todoist` as installed.
- [ ] `/mcp` shows `todoist` (will prompt for OAuth on first use).
- [ ] Or, install via marketplace once merged:
  ```
  /plugin marketplace add doist/todoist-ai
  /plugin install todoist@doist
  ```
- [ ] Manual fallback (`claude mcp add --transport http todoist https://ai.todoist.net/mcp`) still works.
- [ ] Confirm next semantic-release run bumps both `package.json` and `.claude-plugin/plugin.json` (smoke-tested locally with the bump script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)