### PR TITLE
fix: forward arrayBuffer on tracked-fetch wrapper for binary attachments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "8.12.2",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-sdk": "10.1.1",
+                "@doist/todoist-sdk": "10.1.5",
                 "@modelcontextprotocol/ext-apps": "1.2.2",
                 "date-fns": "4.1.0",
                 "dompurify": "3.3.3",
@@ -461,9 +461,9 @@
             }
         },
         "node_modules/@doist/todoist-sdk": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.1.1.tgz",
-            "integrity": "sha512-V60AjoJG5QjiJ2iYB8IIC4hLA4B5PLUybYysc1GU2qC3xjN7Zy3juRukKo8PO+O1VMXeb8EACMri5U/0GPnLkA==",
+            "version": "10.1.5",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.1.5.tgz",
+            "integrity": "sha512-32e1D4qMRaGsQJt0IPM/X2eTUpjMjQRRHXK/RDSIRVH2015pTo0oakzA+bUcoIRYy+BfWLGw0d9Gowg2oP+EkA==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "6.3.0",
@@ -471,7 +471,7 @@
                 "form-data": "4.0.5",
                 "ts-custom-error": "^3.2.0",
                 "undici": "^7.16.0",
-                "uuid": "11.1.0",
+                "uuid": "11.1.1",
                 "zod": "4.3.6"
             },
             "engines": {
@@ -13966,9 +13966,9 @@
             "license": "MIT"
         },
         "node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-sdk": "10.1.1",
+        "@doist/todoist-sdk": "10.1.5",
         "@modelcontextprotocol/ext-apps": "1.2.2",
         "date-fns": "4.1.0",
         "dompurify": "3.3.3",

--- a/src/usage-tracking.test.ts
+++ b/src/usage-tracking.test.ts
@@ -102,6 +102,30 @@ describe('usage tracking', () => {
         expect(capturedSessionIds[0]).not.toBe(capturedSessionIds[1])
     })
 
+    it('forwards arrayBuffer so binary attachments are not corrupted', async () => {
+        // PNG magic + a stretch of high bytes that would be replaced with
+        // U+FFFD by any UTF-8 text round-trip on the response body.
+        const binaryBytes = new Uint8Array([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0xff, 0xfe,
+            0xfd, 0x80,
+        ])
+        const trackedFetch = createTrackedFetch(
+            async () =>
+                new Response(binaryBytes, {
+                    status: 200,
+                    headers: { 'content-type': 'image/png' },
+                }),
+        )
+
+        const response = await trackedFetch('https://files.todoist.com/file.png')
+        const buffer = await response.arrayBuffer?.()
+
+        expect(buffer).toBeDefined()
+        if (buffer) {
+            expect(new Uint8Array(buffer)).toEqual(binaryBytes)
+        }
+    })
+
     it('isolates concurrent tool contexts', async () => {
         const capturedTools: string[] = []
         const trackedFetch = createTrackedFetch(

--- a/src/usage-tracking.ts
+++ b/src/usage-tracking.ts
@@ -195,6 +195,7 @@ function toCustomFetchResponse(response: Response): CustomFetchResponse {
         headers: Object.fromEntries(response.headers.entries()),
         text: () => response.text(),
         json: () => response.json(),
+        arrayBuffer: () => response.arrayBuffer(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Bumps `@doist/todoist-sdk` to **10.1.5** ([Doist/todoist-sdk-typescript#602](https://github.com/Doist/todoist-sdk-typescript/pull/602)).
- Forwards `arrayBuffer()` from the tracked-fetch wrapper in `src/usage-tracking.ts` so the SDK's binary endpoints (`viewAttachment`, `downloadBackup`) get a binary-safe response instead of falling back to the pre-10.1.5 lossy `text()` → `TextEncoder` round-trip.

## Bug

Reported in #476. Every byte ≥ `0x80` in a Todoist file attachment was replaced with `EF BF BD` (UTF-8 replacement char U+FFFD) by the time it reached Claude's image processor — surfacing as `400 Could not process image` for every PNG/JPEG/PDF returned by `view-attachment` on the hosted `ai.todoist.net/mcp` deployment.

Root cause was a cooperating pair: the SDK's `UploadClient.viewAttachment` customFetch branch read the body via `response.text()` (UTF-8 decode with `errors=replace`) and re-encoded with `TextEncoder` (fixed in [Doist/todoist-sdk-typescript#602](https://github.com/Doist/todoist-sdk-typescript/pull/602)), and this repo's `toCustomFetchResponse` wrapper only forwarded `text/json/headers`, never giving the SDK a chance to read the body as bytes.

## End-to-end verification

Local run against a real 3.38 MB PNG attachment via `createTodoistClient` (the path used by the hosted MCP):

| Metric | Before | After |
| --- | --- | --- |
| Decoded length | 6,267,715 B (1.85×) | 3,382,996 B (exact) |
| Magic bytes | `EF BF BD 50 4E 47 0D 0A …` | `89 50 4E 47 0D 0A 1A 0A` ✅ |
| `EF BF BD` count in payload | 1,472,311 | 0 ✅ |

## Test plan

- [x] `npm run type-check` — clean.
- [x] `npm test` — 859/859 pass.
- [x] `npm run format:check` — clean.
- [x] End-to-end: `view-attachment` against a real PNG comment URL, decoded base64, magic bytes match, no replacement chars.
- [ ] Post-deploy: rerun the `tools/call view-attachment` curl from #476 against `ai.todoist.net/mcp` and verify `EF BF BD` count is 0.

Closes #476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)