### PR TITLE
feat!: rename package to @doist/todoist-mcp

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
             "description": "Todoist for Claude Code — manage tasks, projects, labels, and workflows from your terminal.",
             "source": {
                 "source": "url",
-                "url": "https://github.com/doist/todoist-ai.git"
+                "url": "https://github.com/doist/todoist-mcp.git"
             }
         }
     ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,6 @@
         "name": "Doist",
         "url": "https://doist.com"
     },
-    "homepage": "https://github.com/doist/todoist-ai",
-    "repository": "https://github.com/doist/todoist-ai"
+    "homepage": "https://github.com/doist/todoist-mcp",
+    "repository": "https://github.com/doist/todoist-mcp"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Todoist AI MCP Server - Development Guidelines
+# Todoist MCP Server - Development Guidelines
 
 ## Tool Schema Design Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Todoist AI MCP Server - Development Guidelines
+# Todoist MCP Server - Development Guidelines
 
 > For repo structure, architecture, shared utilities, and where things live, read [`CODEBASE.md`](./CODEBASE.md) first. This file covers the _rules_; CODEBASE.md is the _map_.
 

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -6,12 +6,12 @@
 
 ## What this project is
 
-`@doist/todoist-ai` is an **MCP (Model Context Protocol) server** that exposes
+`@doist/todoist-mcp` is an **MCP (Model Context Protocol) server** that exposes
 Todoist as tools for LLMs. It wraps `@doist/todoist-sdk` and publishes two
 binaries:
 
-- `todoist-ai` → `dist/main.js` — stdio MCP server (primary)
-- `todoist-ai-http` → `dist/main-http.js` — Express HTTP wrapper
+- `todoist-mcp` → `dist/main.js` — stdio MCP server (primary)
+- `todoist-mcp-http` → `dist/main-http.js` — Express HTTP wrapper
 
 TypeScript · ESM-only · Node 18+ · `zod` v4 for schemas · MCP SDK ≥1.25.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Todoist AI and MCP SDK
+# Todoist MCP Server
+
+> **Note:** This package was previously named `@doist/todoist-ai`. The old name continues to work as a thin shim that re-exports from `@doist/todoist-mcp`, but new installs should use `@doist/todoist-mcp` directly.
 
 Library for connecting AI agents to Todoist. Includes tools that can be integrated into LLMs,
 enabling them to access and modify a Todoist account on the user's behalf.
@@ -11,7 +13,7 @@ integrate them to your own AI conversational interfaces.
 ### 1. Add this repository as a dependency
 
 ```sh
-npm install @doist/todoist-ai
+npm install @doist/todoist-mcp
 ```
 
 ### 2. Import the tools and plug them to an AI
@@ -19,7 +21,7 @@ npm install @doist/todoist-ai
 Here's an example using [Vercel's AI SDK](https://ai-sdk.dev/docs/ai-sdk-core/generating-text#streamtext).
 
 ```js
-import { findTasksByDate, addTasks } from '@doist/todoist-ai'
+import { findTasksByDate, addTasks } from '@doist/todoist-mcp'
 import { TodoistApi } from '@doist/todoist-sdk'
 import { streamText } from 'ai'
 
@@ -53,12 +55,12 @@ const result = streamText({
 You can run the MCP server directly with npx:
 
 ```bash
-npx @doist/todoist-ai
+npx @doist/todoist-mcp
 ```
 
 ### Setup Guide
 
-The Todoist AI MCP server is available as a streamable HTTP service for easy integration with various AI clients:
+The Todoist MCP server is available as a streamable HTTP service for easy integration with various AI clients:
 
 **Primary URL (Streamable HTTP):** `https://ai.todoist.net/mcp`
 
@@ -92,7 +94,7 @@ Then enable the server in Cursor settings if prompted.
 The fastest setup is the official Todoist plugin, which wires up the MCP server for you:
 
 ```bash
-/plugin marketplace add doist/todoist-ai
+/plugin marketplace add doist/todoist-mcp
 /plugin install todoist@doist
 ```
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -7,7 +7,7 @@ This document outlines the steps necessary to run this MCP server and connect to
 The easiest way to use this MCP server is with npx:
 
 ```bash
-npx @doist/todoist-ai
+npx @doist/todoist-mcp
 ```
 
 You'll need to set your Todoist API key as an environment variable `TODOIST_API_KEY`.
@@ -17,7 +17,7 @@ You'll need to set your Todoist API key as an environment variable `TODOIST_API_
 Start by cloning this repository and setting it up locally, if you haven't done so yet.
 
 ```sh
-git clone https://github.com/Doist/todoist-ai
+git clone https://github.com/Doist/todoist-mcp
 npm run setup
 ```
 
@@ -34,7 +34,7 @@ This will build the project and run the MCP inspector for manual testing.
 For convenience, we also include a function that initializes an MCP Server with all the tools available:
 
 ```js
-import { getMcpServer } from '@doist/todoist-ai'
+import { getMcpServer } from '@doist/todoist-mcp'
 
 async function main() {
     const server = getMcpServer({ todoistApiKey: process.env.TODOIST_API_KEY })
@@ -54,10 +54,10 @@ Add this section to your `mcp.json` config in Claude, Cursor, etc.:
 ```json
 {
     "mcpServers": {
-        "todoist-ai": {
+        "todoist-mcp": {
             "type": "stdio",
             "command": "npx",
-            "args": ["@doist/todoist-ai"],
+            "args": ["@doist/todoist-mcp"],
             "env": {
                 "TODOIST_API_KEY": "your-todoist-token-here"
             }
@@ -68,15 +68,15 @@ Add this section to your `mcp.json` config in Claude, Cursor, etc.:
 
 ### Using local installation
 
-Add this `todoist-ai-tools` section to your `mcp.json` config in Cursor, Claude, Raycast, etc.
+Add this `todoist-mcp-local` section to your `mcp.json` config in Cursor, Claude, Raycast, etc.
 
 ```json
 {
     "mcpServers": {
-        "todoist-ai-tools": {
+        "todoist-mcp-local": {
             "type": "stdio",
             "command": "node",
-            "args": ["/Users/<your_user_name>/code/todoist-ai-tools/dist/main.js"],
+            "args": ["/Users/<your_user_name>/code/todoist-mcp/dist/main.js"],
             "env": {
                 "TODOIST_API_KEY": "your-todoist-token-here"
             }
@@ -95,19 +95,19 @@ Update the configuration above as follows
 
 ## Using Streamable HTTP Server Transport
 
-You can run the MCP server as an HTTP service with configurable session timeouts. This is useful as an alternative to the hosted service at `ai.todoist.net/mcp`, especially if you experience frequent session disconnections ([#239](https://github.com/Doist/todoist-ai/issues/239)).
+You can run the MCP server as an HTTP service with configurable session timeouts. This is useful as an alternative to the hosted service at `ai.todoist.net/mcp`, especially if you experience frequent session disconnections ([#239](https://github.com/Doist/todoist-mcp/issues/239)).
 
 ### Quick Start with npx
 
 ```bash
 # Default: 30 minute session timeout
-TODOIST_API_KEY=your-key npx -p @doist/todoist-ai todoist-ai-http
+TODOIST_API_KEY=your-key npx -p @doist/todoist-mcp todoist-mcp-http
 
 # Custom timeout: 1 hour (3600000ms)
-TODOIST_API_KEY=your-key SESSION_TIMEOUT_MS=3600000 npx -p @doist/todoist-ai todoist-ai-http
+TODOIST_API_KEY=your-key SESSION_TIMEOUT_MS=3600000 npx -p @doist/todoist-mcp todoist-mcp-http
 
 # Custom port
-TODOIST_API_KEY=your-key PORT=8080 npx -p @doist/todoist-ai todoist-ai-http
+TODOIST_API_KEY=your-key PORT=8080 npx -p @doist/todoist-mcp todoist-mcp-http
 ```
 
 ### Running from Source

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@doist/todoist-ai",
+    "name": "@doist/todoist-mcp",
     "version": "8.12.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@doist/todoist-ai",
+            "name": "@doist/todoist-mcp",
             "version": "8.12.3",
             "license": "MIT",
             "dependencies": {
@@ -18,8 +18,8 @@
                 "zod": "4.3.6"
             },
             "bin": {
-                "todoist-ai": "dist/main.js",
-                "todoist-ai-http": "dist/main-http.js"
+                "todoist-mcp": "dist/main.js",
+                "todoist-mcp-http": "dist/main-http.js"
             },
             "devDependencies": {
                 "@modelcontextprotocol/inspector": "0.21.2",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-    "name": "@doist/todoist-ai",
+    "name": "@doist/todoist-mcp",
     "version": "8.12.3",
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "mcpName": "net.todoist/mcp",
     "bin": {
-        "todoist-ai": "dist/main.js",
-        "todoist-ai-http": "dist/main-http.js"
+        "todoist-mcp": "dist/main.js",
+        "todoist-mcp-http": "dist/main-http.js"
     },
     "files": [
         "dist",
@@ -18,13 +18,14 @@
         "README.md"
     ],
     "license": "MIT",
-    "description": "A collection of tools for Todoist using AI",
+    "description": "The official Todoist MCP server",
     "repository": {
         "type": "git",
-        "url": "https://github.com/Doist/todoist-ai"
+        "url": "https://github.com/Doist/todoist-mcp"
     },
     "keywords": [
         "todoist",
+        "mcp",
         "ai",
         "tools"
     ],

--- a/scripts/test-executable.cjs
+++ b/scripts/test-executable.cjs
@@ -2,68 +2,83 @@
 
 const { spawn } = require('node:child_process')
 const path = require('node:path')
+const fs = require('node:fs')
 
-console.log('Testing MCP server executable...')
+const repoRoot = path.join(__dirname, '..')
+const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'))
 
-const mainJs = path.join(__dirname, '..', 'dist', 'main.js')
-const child = spawn('node', [mainJs], {
-    stdio: ['pipe', 'pipe', 'pipe'],
-})
-
-let _stdoutOutput = ''
-let stderrOutput = ''
-let hasError = false
-
-child.stdout.on('data', (data) => {
-    _stdoutOutput += data.toString()
-})
-
-child.stderr.on('data', (data) => {
-    const output = data.toString()
-    stderrOutput += output
-
-    // Only consider it an error if it's not related to graceful shutdown
-    if (output.includes('Error:') && !output.includes('SIGTERM') && !output.includes('SIGKILL')) {
-        console.error('Server startup error detected:', output)
-        hasError = true
-    }
-})
-
-child.on('error', (error) => {
-    console.error('Failed to start MCP server:', error.message)
-    hasError = true
+const bins = Object.entries(pkg.bin ?? {})
+if (bins.length === 0) {
+    console.error('❌ No bin entries declared in package.json')
     process.exit(1)
-})
+}
 
-child.on('exit', (code, signal) => {
-    // Expected signals when we kill the process
-    if (signal === 'SIGTERM' || signal === 'SIGKILL') {
-        return // This is expected
+async function smokeTestBin(binName, relativePath) {
+    const binPath = path.join(repoRoot, relativePath)
+    if (!fs.existsSync(binPath)) {
+        throw new Error(`bin ${binName} points to missing file ${relativePath}`)
     }
 
-    // Unexpected exit codes during startup
-    if (code !== null && code !== 0) {
-        console.error(`Server exited unexpectedly with code ${code}`)
-        hasError = true
-    }
-})
+    console.log(`Testing bin "${binName}" → ${relativePath} ...`)
 
-// Kill the process after 2 seconds (MCP server should start successfully)
-setTimeout(() => {
-    if (hasError) {
-        console.error('❌ MCP server failed to start properly')
-        if (stderrOutput.trim()) {
-            console.error('Error output:', stderrOutput.trim())
+    return new Promise((resolve, reject) => {
+        const child = spawn('node', [binPath], {
+            stdio: ['pipe', 'pipe', 'pipe'],
+            env: { ...process.env, PORT: '0' },
+        })
+
+        let stderrOutput = ''
+        let hasError = false
+
+        child.stderr.on('data', (data) => {
+            const output = data.toString()
+            stderrOutput += output
+            if (
+                output.includes('Error:') &&
+                !output.includes('SIGTERM') &&
+                !output.includes('SIGKILL')
+            ) {
+                console.error(`Server startup error detected (${binName}):`, output)
+                hasError = true
+            }
+        })
+
+        child.on('error', (error) => {
+            reject(new Error(`Failed to start bin ${binName}: ${error.message}`))
+        })
+
+        child.on('exit', (code, signal) => {
+            if (signal === 'SIGTERM' || signal === 'SIGKILL') return
+            if (code !== null && code !== 0) {
+                hasError = true
+                console.error(`bin ${binName} exited unexpectedly with code ${code}`)
+            }
+        })
+
+        setTimeout(() => {
+            if (hasError) {
+                if (stderrOutput.trim()) console.error('Error output:', stderrOutput.trim())
+                child.kill('SIGTERM')
+                return reject(new Error(`bin ${binName} failed to start`))
+            }
+            child.kill('SIGTERM')
+            setTimeout(() => {
+                console.log(`✅ bin "${binName}" started successfully`)
+                resolve()
+            }, 200)
+        }, 2000)
+    })
+}
+
+;(async () => {
+    try {
+        for (const [name, relativePath] of bins) {
+            await smokeTestBin(name, relativePath)
         }
+        console.log('✅ All bin entries exercised successfully')
+        process.exit(0)
+    } catch (error) {
+        console.error(`❌ ${error.message}`)
         process.exit(1)
     }
-
-    // Gracefully terminate
-    child.kill('SIGTERM')
-
-    setTimeout(() => {
-        console.log('✅ MCP server executable test passed')
-        console.log('Server started successfully and is ready to accept connections')
-        process.exit(0)
-    }, 200) // Give it a moment to clean up
-}, 2000)
+})()

--- a/scripts/test-executable.cjs
+++ b/scripts/test-executable.cjs
@@ -2,83 +2,68 @@
 
 const { spawn } = require('node:child_process')
 const path = require('node:path')
-const fs = require('node:fs')
 
-const repoRoot = path.join(__dirname, '..')
-const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'))
+console.log('Testing MCP server executable...')
 
-const bins = Object.entries(pkg.bin ?? {})
-if (bins.length === 0) {
-    console.error('❌ No bin entries declared in package.json')
+const mainJs = path.join(__dirname, '..', 'dist', 'main.js')
+const child = spawn('node', [mainJs], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+})
+
+let _stdoutOutput = ''
+let stderrOutput = ''
+let hasError = false
+
+child.stdout.on('data', (data) => {
+    _stdoutOutput += data.toString()
+})
+
+child.stderr.on('data', (data) => {
+    const output = data.toString()
+    stderrOutput += output
+
+    // Only consider it an error if it's not related to graceful shutdown
+    if (output.includes('Error:') && !output.includes('SIGTERM') && !output.includes('SIGKILL')) {
+        console.error('Server startup error detected:', output)
+        hasError = true
+    }
+})
+
+child.on('error', (error) => {
+    console.error('Failed to start MCP server:', error.message)
+    hasError = true
     process.exit(1)
-}
+})
 
-async function smokeTestBin(binName, relativePath) {
-    const binPath = path.join(repoRoot, relativePath)
-    if (!fs.existsSync(binPath)) {
-        throw new Error(`bin ${binName} points to missing file ${relativePath}`)
+child.on('exit', (code, signal) => {
+    // Expected signals when we kill the process
+    if (signal === 'SIGTERM' || signal === 'SIGKILL') {
+        return // This is expected
     }
 
-    console.log(`Testing bin "${binName}" → ${relativePath} ...`)
+    // Unexpected exit codes during startup
+    if (code !== null && code !== 0) {
+        console.error(`Server exited unexpectedly with code ${code}`)
+        hasError = true
+    }
+})
 
-    return new Promise((resolve, reject) => {
-        const child = spawn('node', [binPath], {
-            stdio: ['pipe', 'pipe', 'pipe'],
-            env: { ...process.env, PORT: '0' },
-        })
-
-        let stderrOutput = ''
-        let hasError = false
-
-        child.stderr.on('data', (data) => {
-            const output = data.toString()
-            stderrOutput += output
-            if (
-                output.includes('Error:') &&
-                !output.includes('SIGTERM') &&
-                !output.includes('SIGKILL')
-            ) {
-                console.error(`Server startup error detected (${binName}):`, output)
-                hasError = true
-            }
-        })
-
-        child.on('error', (error) => {
-            reject(new Error(`Failed to start bin ${binName}: ${error.message}`))
-        })
-
-        child.on('exit', (code, signal) => {
-            if (signal === 'SIGTERM' || signal === 'SIGKILL') return
-            if (code !== null && code !== 0) {
-                hasError = true
-                console.error(`bin ${binName} exited unexpectedly with code ${code}`)
-            }
-        })
-
-        setTimeout(() => {
-            if (hasError) {
-                if (stderrOutput.trim()) console.error('Error output:', stderrOutput.trim())
-                child.kill('SIGTERM')
-                return reject(new Error(`bin ${binName} failed to start`))
-            }
-            child.kill('SIGTERM')
-            setTimeout(() => {
-                console.log(`✅ bin "${binName}" started successfully`)
-                resolve()
-            }, 200)
-        }, 2000)
-    })
-}
-
-;(async () => {
-    try {
-        for (const [name, relativePath] of bins) {
-            await smokeTestBin(name, relativePath)
+// Kill the process after 2 seconds (MCP server should start successfully)
+setTimeout(() => {
+    if (hasError) {
+        console.error('❌ MCP server failed to start properly')
+        if (stderrOutput.trim()) {
+            console.error('Error output:', stderrOutput.trim())
         }
-        console.log('✅ All bin entries exercised successfully')
-        process.exit(0)
-    } catch (error) {
-        console.error(`❌ ${error.message}`)
         process.exit(1)
     }
-})()
+
+    // Gracefully terminate
+    child.kill('SIGTERM')
+
+    setTimeout(() => {
+        console.log('✅ MCP server executable test passed')
+        console.log('Server started successfully and is ready to accept connections')
+        process.exit(0)
+    }, 200) // Give it a moment to clean up
+}, 2000)

--- a/scripts/validate-schemas.ts
+++ b/scripts/validate-schemas.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Schema Validation Script for Todoist AI MCP Server
+ * Schema Validation Script for Todoist MCP Server
  *
  * This script validates that all tool parameter schemas follow Gemini API compatibility rules.
  * Specifically, it checks that no Zod string schemas use both .nullable() and .optional().

--- a/shim/README.md
+++ b/shim/README.md
@@ -1,0 +1,24 @@
+# @doist/todoist-ai
+
+> **This package has been renamed to [`@doist/todoist-mcp`](https://npmjs.com/package/@doist/todoist-mcp).**
+
+Please update your dependency:
+
+```bash
+npm install @doist/todoist-mcp
+```
+
+And update your imports:
+
+```ts
+import { getMcpServer } from '@doist/todoist-mcp'
+```
+
+The CLI entrypoints have been renamed too:
+
+```bash
+npx @doist/todoist-mcp           # was: npx @doist/todoist-ai
+npx -p @doist/todoist-mcp todoist-mcp-http
+```
+
+This package continues to work as a thin shim that re-exports `@doist/todoist-mcp` and forwards the legacy CLI bins (`todoist-ai`, `todoist-ai-http`) to the new package, but it will not receive new features.

--- a/shim/bin/_launcher.js
+++ b/shim/bin/_launcher.js
@@ -1,11 +1,16 @@
 import { createRequire } from 'node:module'
-import { dirname, join } from 'node:path'
+import { dirname, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 const require = createRequire(import.meta.url)
 
-export async function runEntry(entry) {
+export async function runBin(binName) {
     const pkgJsonPath = require.resolve('@doist/todoist-mcp/package.json')
-    const entryPath = join(dirname(pkgJsonPath), 'dist', entry)
+    const pkg = require(pkgJsonPath)
+    const binEntry = pkg.bin?.[binName]
+    if (!binEntry) {
+        throw new Error(`@doist/todoist-mcp does not declare a "${binName}" bin`)
+    }
+    const entryPath = resolve(dirname(pkgJsonPath), binEntry)
     await import(pathToFileURL(entryPath).href)
 }

--- a/shim/bin/_launcher.js
+++ b/shim/bin/_launcher.js
@@ -1,0 +1,11 @@
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const require = createRequire(import.meta.url)
+
+export async function runEntry(entry) {
+    const pkgJsonPath = require.resolve('@doist/todoist-mcp/package.json')
+    const entryPath = join(dirname(pkgJsonPath), 'dist', entry)
+    await import(pathToFileURL(entryPath).href)
+}

--- a/shim/bin/todoist-ai-http.js
+++ b/shim/bin/todoist-ai-http.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
-import { runEntry } from './_launcher.js'
+import { runBin } from './_launcher.js'
 
-await runEntry('main-http.js')
+await runBin('todoist-mcp-http')

--- a/shim/bin/todoist-ai-http.js
+++ b/shim/bin/todoist-ai-http.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+
+const require = createRequire(import.meta.url)
+const pkgJsonPath = require.resolve('@doist/todoist-mcp/package.json')
+const binPath = join(dirname(pkgJsonPath), 'dist', 'main-http.js')
+
+const child = spawn(process.execPath, [binPath, ...process.argv.slice(2)], {
+    stdio: 'inherit',
+})
+child.on('exit', (code, signal) => {
+    if (signal) process.kill(process.pid, signal)
+    else process.exit(code ?? 0)
+})

--- a/shim/bin/todoist-ai-http.js
+++ b/shim/bin/todoist-ai-http.js
@@ -1,16 +1,4 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process'
-import { createRequire } from 'node:module'
-import { dirname, join } from 'node:path'
+import { runEntry } from './_launcher.js'
 
-const require = createRequire(import.meta.url)
-const pkgJsonPath = require.resolve('@doist/todoist-mcp/package.json')
-const binPath = join(dirname(pkgJsonPath), 'dist', 'main-http.js')
-
-const child = spawn(process.execPath, [binPath, ...process.argv.slice(2)], {
-    stdio: 'inherit',
-})
-child.on('exit', (code, signal) => {
-    if (signal) process.kill(process.pid, signal)
-    else process.exit(code ?? 0)
-})
+await runEntry('main-http.js')

--- a/shim/bin/todoist-ai.js
+++ b/shim/bin/todoist-ai.js
@@ -1,16 +1,4 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process'
-import { createRequire } from 'node:module'
-import { dirname, join } from 'node:path'
+import { runEntry } from './_launcher.js'
 
-const require = createRequire(import.meta.url)
-const pkgJsonPath = require.resolve('@doist/todoist-mcp/package.json')
-const binPath = join(dirname(pkgJsonPath), 'dist', 'main.js')
-
-const child = spawn(process.execPath, [binPath, ...process.argv.slice(2)], {
-    stdio: 'inherit',
-})
-child.on('exit', (code, signal) => {
-    if (signal) process.kill(process.pid, signal)
-    else process.exit(code ?? 0)
-})
+await runEntry('main.js')

--- a/shim/bin/todoist-ai.js
+++ b/shim/bin/todoist-ai.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
-import { runEntry } from './_launcher.js'
+import { runBin } from './_launcher.js'
 
-await runEntry('main.js')
+await runBin('todoist-mcp')

--- a/shim/bin/todoist-ai.js
+++ b/shim/bin/todoist-ai.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+
+const require = createRequire(import.meta.url)
+const pkgJsonPath = require.resolve('@doist/todoist-mcp/package.json')
+const binPath = join(dirname(pkgJsonPath), 'dist', 'main.js')
+
+const child = spawn(process.execPath, [binPath, ...process.argv.slice(2)], {
+    stdio: 'inherit',
+})
+child.on('exit', (code, signal) => {
+    if (signal) process.kill(process.pid, signal)
+    else process.exit(code ?? 0)
+})

--- a/shim/index.d.ts
+++ b/shim/index.d.ts
@@ -1,0 +1,1 @@
+export * from '@doist/todoist-mcp'

--- a/shim/index.js
+++ b/shim/index.js
@@ -1,1 +1,0 @@
-module.exports = require('@doist/todoist-mcp')

--- a/shim/index.js
+++ b/shim/index.js
@@ -1,0 +1,1 @@
+module.exports = require('@doist/todoist-mcp')

--- a/shim/index.mjs
+++ b/shim/index.mjs
@@ -1,0 +1,1 @@
+export * from '@doist/todoist-mcp'

--- a/shim/package.json
+++ b/shim/package.json
@@ -3,14 +3,12 @@
     "version": "9.0.0",
     "description": "DEPRECATED: renamed to @doist/todoist-mcp. Install @doist/todoist-mcp instead.",
     "type": "module",
-    "main": "./index.js",
-    "module": "./index.mjs",
+    "main": "./index.mjs",
     "types": "./index.d.ts",
     "exports": {
         ".": {
             "types": "./index.d.ts",
-            "import": "./index.mjs",
-            "require": "./index.js"
+            "import": "./index.mjs"
         }
     },
     "bin": {
@@ -18,7 +16,6 @@
         "todoist-ai-http": "./bin/todoist-ai-http.js"
     },
     "files": [
-        "index.js",
         "index.mjs",
         "index.d.ts",
         "bin",
@@ -26,7 +23,7 @@
     ],
     "license": "MIT",
     "dependencies": {
-        "@doist/todoist-mcp": ">=9.0.0"
+        "@doist/todoist-mcp": "^9.0.0"
     },
     "repository": {
         "type": "git",

--- a/shim/package.json
+++ b/shim/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "@doist/todoist-ai",
+    "version": "9.0.0",
+    "description": "DEPRECATED: renamed to @doist/todoist-mcp. Install @doist/todoist-mcp instead.",
+    "type": "module",
+    "main": "./index.js",
+    "module": "./index.mjs",
+    "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "import": "./index.mjs",
+            "require": "./index.js"
+        }
+    },
+    "bin": {
+        "todoist-ai": "./bin/todoist-ai.js",
+        "todoist-ai-http": "./bin/todoist-ai-http.js"
+    },
+    "files": [
+        "index.js",
+        "index.mjs",
+        "index.d.ts",
+        "bin",
+        "README.md"
+    ],
+    "license": "MIT",
+    "dependencies": {
+        "@doist/todoist-mcp": ">=9.0.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Doist/todoist-mcp"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/src/main-http.ts
+++ b/src/main-http.ts
@@ -11,7 +11,7 @@
  * - TODOIST_BASE_URL: Optional. Custom Todoist API base URL.
  * - PORT: Optional. Server port (default: 3000).
  *
- * @see https://github.com/Doist/todoist-ai/issues/239
+ * @see https://github.com/Doist/todoist-mcp/issues/239
  */
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import dotenv from 'dotenv'

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -54,7 +54,7 @@ import { updateSections } from './tools/update-sections.js'
 import { updateTasks } from './tools/update-tasks.js'
 import { userInfo } from './tools/user-info.js'
 import { viewAttachment } from './tools/view-attachment.js'
-import { TODOIST_AI_VERSION, createTodoistClient } from './usage-tracking.js'
+import { TODOIST_MCP_VERSION, createTodoistClient } from './usage-tracking.js'
 
 const instructions = `
 ## Todoist Task and Project Management Tools
@@ -172,7 +172,7 @@ function getMcpServer({
     features?: Features
 }) {
     const server = new McpServer(
-        { name: 'todoist-mcp-server', version: TODOIST_AI_VERSION },
+        { name: 'todoist-mcp-server', version: TODOIST_MCP_VERSION },
         {
             capabilities: {
                 tools: { listChanged: true },

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -18,7 +18,7 @@ describe('Claude Code plugin manifests', () => {
         expect(plugin.version).toBe(pkg.version)
         expect(plugin.description).toMatch(/Todoist/)
         expect(plugin.author?.name).toBe('Doist')
-        expect(plugin.repository).toMatch(/todoist-ai/)
+        expect(plugin.repository).toMatch(/todoist-mcp/)
     })
 
     it('marketplace.json wires the todoist plugin to this repo', () => {
@@ -29,7 +29,7 @@ describe('Claude Code plugin manifests', () => {
         const [plugin] = marketplace.plugins
         expect(plugin.name).toBe('todoist')
         expect(plugin.source.source).toBe('url')
-        expect(plugin.source.url).toMatch(/todoist-ai/)
+        expect(plugin.source.url).toMatch(/todoist-mcp/)
     })
 
     it('.mcp.json declares the HTTP transport for the remote server', () => {

--- a/src/tools/__tests__/find-tasks.test.ts
+++ b/src/tools/__tests__/find-tasks.test.ts
@@ -716,7 +716,7 @@ describe(`${FIND_TASKS} tool`, () => {
 
 ### Links
 [Wikipedia - Test Link](https://en.wikipedia.org/wiki/Test)
-[GitHub Repository](https://github.com/Doist/todoist-ai)
+[GitHub Repository](https://github.com/Doist/todoist-mcp)
 [Google Search](https://www.google.com)
 
 ### Text Formatting

--- a/src/usage-tracking.test.ts
+++ b/src/usage-tracking.test.ts
@@ -25,7 +25,7 @@ describe('usage tracking', () => {
             buildUsageTrackingHeaders({ sessionId: 'session-123' }),
         )
 
-        expect(headers['User-Agent']).toMatch(/^todoist-ai\/\d+\.\d+\.\d+$/)
+        expect(headers['User-Agent']).toMatch(/^todoist-mcp\/\d+\.\d+\.\d+$/)
         expect(headers['doist-platform']).toBe('mcp')
         expect(headers['doist-version']).toMatch(/^\d+\.\d+\.\d+$/)
         expect(headers['request-id']).toBeTruthy()

--- a/src/usage-tracking.ts
+++ b/src/usage-tracking.ts
@@ -5,8 +5,8 @@ import { dirname, join } from 'node:path'
 import { type CustomFetch, type CustomFetchResponse, TodoistApi } from '@doist/todoist-sdk'
 import packageJson from '../package.json' with { type: 'json' }
 
-const TODOIST_AI_NAME = 'todoist-ai'
-const TODOIST_AI_VERSION = packageJson.version
+const TODOIST_MCP_NAME = 'todoist-mcp'
+const TODOIST_MCP_VERSION = packageJson.version
 const toolContext = new AsyncLocalStorage<string>()
 const require = createRequire(import.meta.url)
 
@@ -29,7 +29,7 @@ const defaultDispatcherModuleLoader = async (): Promise<DispatcherModule> => {
 let dispatcherModuleLoader = defaultDispatcherModuleLoader
 
 function getUserAgent(): string {
-    return `${TODOIST_AI_NAME}/${TODOIST_AI_VERSION}`
+    return `${TODOIST_MCP_NAME}/${TODOIST_MCP_VERSION}`
 }
 
 export function normalizeUsageLabel(label: string): string {
@@ -54,7 +54,7 @@ export function buildUsageTrackingHeaders({
     return {
         'User-Agent': getUserAgent(),
         'doist-platform': platform,
-        'doist-version': TODOIST_AI_VERSION,
+        'doist-version': TODOIST_MCP_VERSION,
         'request-id': randomUUID(),
         'session-id': sessionId,
         'mcp-tool': normalizedLabel ?? 'unknown',
@@ -251,4 +251,4 @@ export function createTodoistClient(
     })
 }
 
-export { TODOIST_AI_VERSION }
+export { TODOIST_MCP_VERSION }


### PR DESCRIPTION
## Summary

- Renames npm package `@doist/todoist-ai` → `@doist/todoist-mcp`
- Renames CLI bins `todoist-ai` / `todoist-ai-http` → `todoist-mcp` / `todoist-mcp-http`
- Updates all repo URLs to `Doist/todoist-mcp` (pending manual repo rename)
- Updates `User-Agent` telemetry identifier to `todoist-mcp`
- Adds `shim/` directory with deprecation re-export package for one-time manual publish

Mirrors the approach used in Doist/todoist-sdk-typescript#532. The shim re-exports the new package for library consumers (`import { ... } from '@doist/todoist-ai'`) and forwards the legacy CLI bins via in-process dynamic `import()` so existing `npx @doist/todoist-ai` invocations keep working.

## Deliberately untouched

- `mcpName: net.todoist/mcp` (server identifier, not package name)
- Hosted `ai.todoist.net/mcp` URLs (`.mcp.json`, `src/mcp-apps/resources.ts`)
- `CHANGELOG.md` history

## Post-merge checklist

1. **Bootstrap `@doist/todoist-mcp` on npm + configure OIDC trusted publishing** ⚠️ blocking — must precede merge or first release will fail to publish.
2. **Merge this PR** → semantic-release publishes `@doist/todoist-mcp@9.0.0` (the `!` + `BREAKING CHANGE:` footer triggers a major bump).
3. **Rename GitHub repo** `Doist/todoist-ai` → `Doist/todoist-mcp` via Settings. GitHub redirects keep existing remotes working.
4. **Publish shim**: in a fresh checkout, `cd shim && npm publish` → publishes `@doist/todoist-ai@9.0.0` as the deprecation shim.
5. **Deprecate old**: `npm deprecate '@doist/todoist-ai@<9.0.0' "Package renamed to @doist/todoist-mcp. Please update."` (versions ≥9.0.0 stay live as the working shim).
8. **Update Todoist's public MCP registry entry** if it references the npm name.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run check` (oxlint + oxfmt + schema lint) passes
- [x] `npm test` — all 860 tests pass
- [x] `npm run build` succeeds
- [x] `npm run test:executable` — exercises both renamed bins (`todoist-mcp`, `todoist-mcp-http`) via the `bin` map in `package.json`
- [x] `shim/bin/*.js` syntax-check clean
- [ ] After publishing: verify `npx @doist/todoist-ai` (shim) still launches the MCP server via the new package
- [ ] After publishing: verify `import { ... } from '@doist/todoist-ai'` resolves to new package exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)