### PR TITLE
feat!: reorder MCP tool response content blocks (JSON first, summary last)

### DIFF
--- a/src/mcp-helpers.test.ts
+++ b/src/mcp-helpers.test.ts
@@ -1,5 +1,46 @@
+import type { ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { registerTool, stripEmailsFromObject, stripEmailsFromText } from './mcp-helpers.js'
+
+type RegisterToolArgs = Parameters<typeof registerTool>[0]
+type ToolFixture = RegisterToolArgs['tool']
+
+/**
+ * Build a minimal `TodoistTool` fixture for `registerTool` tests. Returns a
+ * shared scaffold (parameters, annotations, server/client casts) so individual
+ * tests only have to specify the bits they actually exercise.
+ */
+function buildToolFixture(overrides: {
+    name?: string
+    description?: string
+    outputSchema?: Record<string, unknown>
+    execute: ToolFixture['execute']
+}): ToolFixture {
+    const { name = 'test-tool', description = 'Test tool', outputSchema, execute } = overrides
+
+    return {
+        name,
+        description,
+        parameters: {},
+        ...(outputSchema ? { outputSchema } : {}),
+        annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+        },
+        execute,
+    } as unknown as ToolFixture
+}
+
+/**
+ * Capture the callback `registerTool` registers with the MCP server.
+ */
+function captureRegisterToolMock() {
+    const mock = vi.fn()
+    const server = { registerTool: mock } as unknown as RegisterToolArgs['server']
+    const client = {} as RegisterToolArgs['client']
+    return { mock, server, client }
+}
 
 describe('stripEmailsFromObject', () => {
     it.each([
@@ -54,74 +95,50 @@ describe('stripEmailsFromText', () => {
 
 describe('registerTool config', () => {
     it('omits outputSchema when the tool does not declare one', () => {
-        const registerToolMock = vi.fn()
+        const { mock, server, client } = captureRegisterToolMock()
 
         registerTool({
-            tool: {
+            tool: buildToolFixture({
                 name: 'no-schema-tool',
                 description: 'Tool without output schema',
-                parameters: {},
-                annotations: {
-                    readOnlyHint: true,
-                    destructiveHint: false,
-                    idempotentHint: true,
-                },
                 execute: async () => ({ textContent: 'ok' }),
-            },
-            server: {
-                registerTool: registerToolMock,
-            } as unknown as Parameters<typeof registerTool>[0]['server'],
-            client: {} as Parameters<typeof registerTool>[0]['client'],
+            }),
+            server,
+            client,
         })
 
-        expect(registerToolMock).toHaveBeenCalledTimes(1)
-        const config = registerToolMock.mock.calls[0]?.[1] as Record<string, unknown>
+        expect(mock).toHaveBeenCalledTimes(1)
+        const config = mock.mock.calls[0]?.[1] as Record<string, unknown>
         expect(Object.hasOwn(config, 'outputSchema')).toBe(false)
     })
 
     it('includes outputSchema when the tool declares one', () => {
-        const registerToolMock = vi.fn()
+        const { mock, server, client } = captureRegisterToolMock()
         const outputSchema = {}
 
         registerTool({
-            tool: {
+            tool: buildToolFixture({
                 name: 'schema-tool',
                 description: 'Tool with output schema',
-                parameters: {},
                 outputSchema,
-                annotations: {
-                    readOnlyHint: true,
-                    destructiveHint: false,
-                    idempotentHint: true,
-                },
                 execute: async () => ({ textContent: 'ok' }),
-            },
-            server: {
-                registerTool: registerToolMock,
-            } as unknown as Parameters<typeof registerTool>[0]['server'],
-            client: {} as Parameters<typeof registerTool>[0]['client'],
+            }),
+            server,
+            client,
         })
 
-        const config = registerToolMock.mock.calls[0]?.[1] as Record<string, unknown>
+        const config = mock.mock.calls[0]?.[1] as Record<string, unknown>
         expect(config.outputSchema).toBe(outputSchema)
     })
 })
 
 describe('registerTool error path', () => {
     it('applies centralized API formatting in MCP callback errors', async () => {
-        const registerToolMock = vi.fn()
+        const { mock, server, client } = captureRegisterToolMock()
 
         registerTool({
-            tool: {
-                name: 'test-tool',
-                description: 'Test tool',
-                parameters: {},
+            tool: buildToolFixture({
                 outputSchema: {},
-                annotations: {
-                    readOnlyHint: true,
-                    destructiveHint: false,
-                    idempotentHint: true,
-                },
                 execute: async () => {
                     throw {
                         httpStatusCode: 500,
@@ -130,16 +147,14 @@ describe('registerTool error path', () => {
                         },
                     }
                 },
-            },
-            server: {
-                registerTool: registerToolMock,
-            } as unknown as Parameters<typeof registerTool>[0]['server'],
-            client: {} as Parameters<typeof registerTool>[0]['client'],
+            }),
+            server,
+            client,
         })
 
-        expect(registerToolMock).toHaveBeenCalledTimes(1)
+        expect(mock).toHaveBeenCalledTimes(1)
 
-        const callback = registerToolMock.mock.calls[0]?.[2] as (
+        const callback = mock.mock.calls[0]?.[2] as (
             args: Record<string, unknown>,
             context: unknown,
         ) => Promise<{
@@ -163,49 +178,43 @@ describe('registerTool content ordering', () => {
         vi.resetModules()
     })
 
-    async function invokeCallback({
-        textContent,
-        structuredContent,
-    }: {
+    type InvokeArgs = {
         textContent?: string
         structuredContent?: Record<string, unknown>
-    }) {
+        contentItems?: ContentBlock[]
+    }
+
+    async function invokeCallback({ textContent, structuredContent, contentItems }: InvokeArgs) {
+        // resetModules() before the import so the freshly-stubbed env vars
+        // are read at module evaluation (the USE_STRUCTURED_CONTENT and
+        // NODE_ENV checks both run at import time).
         vi.resetModules()
         const { registerTool: registerToolFresh } = await import('./mcp-helpers.js')
-        const registerToolMock = vi.fn()
+        const { mock, server, client } = captureRegisterToolMock()
 
         registerToolFresh({
-            tool: {
+            tool: buildToolFixture({
                 name: 'ordering-tool',
-                description: 'Tool for ordering tests',
-                parameters: {},
                 outputSchema: {},
-                annotations: {
-                    readOnlyHint: true,
-                    destructiveHint: false,
-                    idempotentHint: true,
-                },
-                execute: async () => ({ textContent, structuredContent }),
-            } as unknown as Parameters<typeof registerToolFresh>[0]['tool'],
-            server: {
-                registerTool: registerToolMock,
-            } as unknown as Parameters<typeof registerToolFresh>[0]['server'],
-            client: {} as Parameters<typeof registerToolFresh>[0]['client'],
+                execute: async () => ({ textContent, structuredContent, contentItems }),
+            }),
+            server,
+            client,
         })
 
-        const callback = registerToolMock.mock.calls[0]?.[2] as (
+        const callback = mock.mock.calls[0]?.[2] as (
             args: Record<string, unknown>,
             context: unknown,
         ) => Promise<{
-            content?: Array<{ type: string; text: string }>
+            content?: ContentBlock[]
             structuredContent?: Record<string, unknown>
         }>
 
         return callback({}, {})
     }
 
-    it('puts stringified JSON first and human summary last when legacy content mode is on', async () => {
-        // Simulate production default: USE_STRUCTURED_CONTENT unset, NODE_ENV != 'test'
+    it('puts stringified JSON first and human summary last in legacy content mode', async () => {
+        // Simulate production default: USE_STRUCTURED_CONTENT unset, NODE_ENV != 'test'.
         vi.stubEnv('NODE_ENV', 'production')
         vi.stubEnv('USE_STRUCTURED_CONTENT', '')
 
@@ -216,20 +225,55 @@ describe('registerTool content ordering', () => {
         })
 
         expect(output.structuredContent).toEqual(structuredContent)
-        expect(output.content).toBeDefined()
         const content = output.content ?? []
-        expect(content.length).toBe(2)
+        expect(content).toHaveLength(2)
 
         // content[0] is the stringified JSON — surfaces to clients that only
         // read the first block (e.g. OpenAI Responses API).
-        expect(content[0]?.type).toBe('text')
-        expect(JSON.parse(content[0]?.text ?? '')).toEqual(structuredContent)
+        const first = content[0] as { type: string; text: string }
+        expect(first.type).toBe('text')
+        expect(JSON.parse(first.text)).toEqual(structuredContent)
 
         // Last block is the prose summary.
-        expect(content[content.length - 1]?.text).toBe('Tasks matching filter: 1.')
+        const last = content[content.length - 1] as { type: string; text: string }
+        expect(last.text).toBe('Tasks matching filter: 1.')
+    })
+
+    it('keeps contentItems ahead of the JSON dup and summary in legacy content mode', async () => {
+        // Same production-default env: USE_STRUCTURED_CONTENT off, not in test mode.
+        vi.stubEnv('NODE_ENV', 'production')
+        vi.stubEnv('USE_STRUCTURED_CONTENT', '')
+
+        const structuredContent = { fileName: 'attachment.png' }
+        const image: ContentBlock = {
+            type: 'image',
+            data: 'base64data',
+            mimeType: 'image/png',
+        }
+
+        const output = await invokeCallback({
+            textContent: 'Attachment: attachment.png',
+            structuredContent,
+            contentItems: [image],
+        })
+
+        const content = output.content ?? []
+        expect(content).toHaveLength(3)
+
+        // Order: tool-authored contentItem first, then JSON dup, then prose summary.
+        expect(content[0]).toEqual(image)
+        const json = content[1] as { type: string; text: string }
+        expect(json.type).toBe('text')
+        expect(JSON.parse(json.text)).toEqual(structuredContent)
+        const summary = content[2] as { type: string; text: string }
+        expect(summary.text).toBe('Attachment: attachment.png')
     })
 
     it('omits the JSON dup block when USE_STRUCTURED_CONTENT mode is on', async () => {
+        // Stub NODE_ENV explicitly so the assertion exercises the env-flag
+        // branch (USE_STRUCTURED_CONTENT='true') rather than relying on the
+        // vitest default of NODE_ENV='test', which also enables the branch.
+        vi.stubEnv('NODE_ENV', 'production')
         vi.stubEnv('USE_STRUCTURED_CONTENT', 'true')
 
         const structuredContent = { tasks: [], totalCount: 0 }
@@ -240,7 +284,8 @@ describe('registerTool content ordering', () => {
 
         expect(output.structuredContent).toEqual(structuredContent)
         const content = output.content ?? []
-        expect(content.length).toBe(1)
-        expect(content[0]?.text).toBe('No tasks.')
+        expect(content).toHaveLength(1)
+        const only = content[0] as { type: string; text: string }
+        expect(only.text).toBe('No tasks.')
     })
 })

--- a/src/mcp-helpers.test.ts
+++ b/src/mcp-helpers.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { registerTool, stripEmailsFromObject, stripEmailsFromText } from './mcp-helpers.js'
 
 describe('stripEmailsFromObject', () => {
@@ -153,5 +154,93 @@ describe('registerTool error path', () => {
         expect(output.content[0]?.text).toContain(
             'Try next: Todoist API may be temporarily unavailable. Retry shortly.',
         )
+    })
+})
+
+describe('registerTool content ordering', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs()
+        vi.resetModules()
+    })
+
+    async function invokeCallback({
+        textContent,
+        structuredContent,
+    }: {
+        textContent?: string
+        structuredContent?: Record<string, unknown>
+    }) {
+        vi.resetModules()
+        const { registerTool: registerToolFresh } = await import('./mcp-helpers.js')
+        const registerToolMock = vi.fn()
+
+        registerToolFresh({
+            tool: {
+                name: 'ordering-tool',
+                description: 'Tool for ordering tests',
+                parameters: {},
+                outputSchema: {},
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                },
+                execute: async () => ({ textContent, structuredContent }),
+            } as unknown as Parameters<typeof registerToolFresh>[0]['tool'],
+            server: {
+                registerTool: registerToolMock,
+            } as unknown as Parameters<typeof registerToolFresh>[0]['server'],
+            client: {} as Parameters<typeof registerToolFresh>[0]['client'],
+        })
+
+        const callback = registerToolMock.mock.calls[0]?.[2] as (
+            args: Record<string, unknown>,
+            context: unknown,
+        ) => Promise<{
+            content?: Array<{ type: string; text: string }>
+            structuredContent?: Record<string, unknown>
+        }>
+
+        return callback({}, {})
+    }
+
+    it('puts stringified JSON first and human summary last when legacy content mode is on', async () => {
+        // Simulate production default: USE_STRUCTURED_CONTENT unset, NODE_ENV != 'test'
+        vi.stubEnv('NODE_ENV', 'production')
+        vi.stubEnv('USE_STRUCTURED_CONTENT', '')
+
+        const structuredContent = { tasks: [{ id: '1', title: 'Buy milk' }], totalCount: 1 }
+        const output = await invokeCallback({
+            textContent: 'Tasks matching filter: 1.',
+            structuredContent,
+        })
+
+        expect(output.structuredContent).toEqual(structuredContent)
+        expect(output.content).toBeDefined()
+        const content = output.content ?? []
+        expect(content.length).toBe(2)
+
+        // content[0] is the stringified JSON — surfaces to clients that only
+        // read the first block (e.g. OpenAI Responses API).
+        expect(content[0]?.type).toBe('text')
+        expect(JSON.parse(content[0]?.text ?? '')).toEqual(structuredContent)
+
+        // Last block is the prose summary.
+        expect(content[content.length - 1]?.text).toBe('Tasks matching filter: 1.')
+    })
+
+    it('omits the JSON dup block when USE_STRUCTURED_CONTENT mode is on', async () => {
+        vi.stubEnv('USE_STRUCTURED_CONTENT', 'true')
+
+        const structuredContent = { tasks: [], totalCount: 0 }
+        const output = await invokeCallback({
+            textContent: 'No tasks.',
+            structuredContent,
+        })
+
+        expect(output.structuredContent).toEqual(structuredContent)
+        const content = output.content ?? []
+        expect(content.length).toBe(1)
+        expect(content[0]?.text).toBe('No tasks.')
     })
 })

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -92,19 +92,20 @@ function getToolOutput<StructuredContent extends Record<string, unknown>>({
 
     const contentArray: Array<Record<string, unknown>> = []
 
-    // Stringified JSON goes first so clients that only surface content[0]
-    // (e.g. OpenAI Responses API, which strips structuredContent) get the
-    // structured payload rather than the prose summary.
+    // Tool-authored content items (images, embedded resources) come first
+    // so they retain primacy for clients that read content[0].
+    if (contentItems) {
+        contentArray.push(...contentItems)
+    }
+
+    // Stringified JSON ahead of the prose summary so clients that only surface
+    // a text-type content[0] (e.g. OpenAI Responses API, which strips
+    // structuredContent) get the structured payload rather than the summary.
     if (!USE_STRUCTURED_CONTENT && structuredContent) {
         contentArray.push({
             type: 'text' as const,
             text: JSON.stringify(sanitizedContent),
         })
-    }
-
-    // Append any extra content items (images, embedded resources, etc.)
-    if (contentItems) {
-        contentArray.push(...contentItems)
     }
 
     if (textContent) {

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -92,8 +92,14 @@ function getToolOutput<StructuredContent extends Record<string, unknown>>({
 
     const contentArray: Array<Record<string, unknown>> = []
 
-    if (textContent) {
-        contentArray.push({ type: 'text' as const, text: textContent })
+    // Stringified JSON goes first so clients that only surface content[0]
+    // (e.g. OpenAI Responses API, which strips structuredContent) get the
+    // structured payload rather than the prose summary.
+    if (!USE_STRUCTURED_CONTENT && structuredContent) {
+        contentArray.push({
+            type: 'text' as const,
+            text: JSON.stringify(sanitizedContent),
+        })
     }
 
     // Append any extra content items (images, embedded resources, etc.)
@@ -101,23 +107,15 @@ function getToolOutput<StructuredContent extends Record<string, unknown>>({
         contentArray.push(...contentItems)
     }
 
+    if (textContent) {
+        contentArray.push({ type: 'text' as const, text: textContent })
+    }
+
     if (contentArray.length > 0) {
         result.content = contentArray
     }
 
     if (structuredContent) result.structuredContent = sanitizedContent
-
-    // Legacy support: also include JSON in content when USE_STRUCTURED_CONTENT is false
-    if (!USE_STRUCTURED_CONTENT && structuredContent) {
-        const json = JSON.stringify(sanitizedContent)
-        if (!result.content) {
-            result.content = []
-        }
-        ;(result.content as Array<{ type: 'text'; text: string }>).push({
-            type: 'text',
-            text: json,
-        })
-    }
 
     return result
 }


### PR DESCRIPTION
## Summary

- Swap legacy `content[]` ordering inside `getToolOutput()` so the stringified JSON of `structuredContent` lives at `content[0]` and the human-readable prose summary moves to the last block. Tools that return additional content items (e.g. `view-attachment` returning an image) keep those tool-authored blocks first, with the JSON `text` item following them.
- Unblocks MCP clients that only surface `content[0]` — notably **OpenAI's Responses API**, which strips `structuredContent` and `_meta` entirely before exposing the result to callers. Today those clients receive only the prose summary; after this change they get the structured payload they actually need.
- No new public API, no feature flag, no query parameter. Single-file behavior change to the wire shape of every tool result.

## Why a default change beats a flag

- The [MCP spec (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25/server/tools) is silent on `content[]` ordering. The only normative line is that a server SHOULD also return serialized JSON in a TextContent block when returning `structuredContent` — which we still do.
- Modern clients (Claude Code v2.0.21+, Codex, Cursor) prefer `structuredContent` and largely ignore `content[]` when both are present — unaffected by this change.
- Our own MCP client (`automations`) reads `structuredContent` first and falls back to an order-agnostic scan of `content[]` — verified safe.
- Sibling MCP servers (`memory`, `github`) already lead with JSON; the leading prose summary was a Todoist-only choice.

## Risk

Low. The only consumers that would notice are clients that (a) read only `content[0]`, (b) feed it to an LLM, (c) preferred prose over JSON. LLMs parse JSON cleanly. Any consumer piping `content[0]` straight to a UI without an LLM in the loop would see raw JSON instead of prose — this pattern is rare and not observed in known integrations.

## Refs

- Background discussion: [SEP-1624](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1624)


## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — all 863 tests pass (includes ordering assertions: legacy mode → JSON at `content[0]`, contentItems-first with image → `[image, JSON, summary]`, structured-only mode → no JSON dup block)
- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [ ] Manual end-to-end against `https://ai.todoist.net/mcp` once `@doist/todoist-mcp` bump lands in `todoist-ai-integrations`
- [ ] Smoke `~/automations` after the AI integrations bump (expected unaffected — `structuredContent`-first consumer)

## BREAKING CHANGE

The order of items inside a tool result's `content[]` array has changed. Previously `content[0]` was a human-readable prose summary and `content[1]` was the stringified JSON of `structuredContent`. From this release, when a tool returns structured content the array order is:

1. Any tool-authored non-text content items (images, embedded resources) — unchanged for tools that use them
2. Stringified JSON of `structuredContent`
3. Human-readable prose summary (always the last `text` item)

Consumers that read `content[]` entries by hard-coded index — for example, expecting `content[0]` to be a prose string suitable for display to a human — will need to either:

- prefer `structuredContent` (recommended for any client implementing MCP spec `2025-03-26` or later), or
- locate the prose summary by taking the last `text` content item rather than `content[0]`, or
- locate the JSON payload by parsing the first `text` content item whose body is valid JSON rather than relying on a fixed index.

The MCP spec is silent on `content[]` ordering, and modern clients (Claude Code v2.0.21+, Codex, Cursor) prefer `structuredContent` and are unaffected. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)