### PR TITLE
fix: Always serve the most recent app resource

### DIFF
--- a/src/mcp-apps/resources.test.ts
+++ b/src/mcp-apps/resources.test.ts
@@ -16,7 +16,7 @@ describe('registerTaskListApp', () => {
         registerTaskListApp(server)
 
         expect(consoleErrorSpy).not.toHaveBeenCalled()
-        expect(registerResourceSpy).toHaveBeenCalledTimes(1)
+        expect(registerResourceSpy).toHaveBeenCalledTimes(2)
         expect(registerResourceSpy.mock.calls[0]?.[2]).toMatchObject({
             description: 'Interactive task list widget',
             _meta: {
@@ -77,5 +77,47 @@ describe('registerTaskListApp', () => {
         expect(
             (result.contents[0]?._meta as { ui?: Record<string, unknown> } | undefined)?.ui,
         ).not.toHaveProperty('domain')
+
+        const fallbackTemplate = registerResourceSpy.mock.calls[1]?.[1] as
+            | { uriTemplate?: { toString: () => string } }
+            | undefined
+        const fallbackConfig = registerResourceSpy.mock.calls[1]?.[2]
+        const fallbackReadCallback = registerResourceSpy.mock.calls[1]?.[3] as
+            | ((uri: URL) => Promise<{ contents: Array<{ uri: string; text: string }> }>)
+            | undefined
+
+        expect(fallbackTemplate?.uriTemplate?.toString()).toBe('ui://todoist/task-list@{hash}')
+        expect(fallbackConfig).toMatchObject({
+            description: 'Interactive task list widget compatibility fallback',
+            mimeType: 'text/html;profile=mcp-app',
+            _meta: {
+                ui: {
+                    prefersBorder: true,
+                    csp: {
+                        connectDomains: [],
+                        resourceDomains: [],
+                    },
+                },
+                'openai/widgetDescription': 'Interactive task list widget',
+                'openai/widgetPrefersBorder': true,
+                'openai/widgetCSP': {
+                    connect_domains: [],
+                    resource_domains: [],
+                },
+                'openai/widgetDomain': 'https://ai.todoist.net',
+            },
+        })
+
+        expect(fallbackReadCallback).toBeDefined()
+        if (!fallbackReadCallback) {
+            throw new Error('fallback registerResource callback was not captured')
+        }
+
+        const staleUri = 'ui://todoist/task-list@stale1234567'
+        const fallbackResult = await fallbackReadCallback(new URL(staleUri))
+
+        expect(fallbackResult.contents).toHaveLength(1)
+        expect(fallbackResult.contents[0]?.uri).toBe(staleUri)
+        expect(fallbackResult.contents[0]?.text).toContain('<div id="root"></div>')
     })
 })

--- a/src/mcp-apps/resources.ts
+++ b/src/mcp-apps/resources.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { RESOURCE_MIME_TYPE, registerAppResource } from '@modelcontextprotocol/ext-apps/server'
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { ResourceTemplate, type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const TASK_LIST_HTML_PATHS = [
@@ -36,6 +36,7 @@ function loadTaskListHtml() {
 const taskListHtml = loadTaskListHtml()
 const taskListHash = createHash('sha256').update(taskListHtml).digest('hex').slice(0, 12)
 const taskListResourceUri = `ui://todoist/task-list@${taskListHash}`
+const taskListResourceUriTemplate = 'ui://todoist/task-list@{hash}'
 const taskListResourceDescription = 'Interactive task list widget'
 const taskListWidgetDomain = 'https://ai.todoist.net'
 const taskListResourceMeta = {
@@ -56,6 +57,19 @@ const taskListResourceMeta = {
     'openai/widgetDomain': taskListWidgetDomain,
 }
 
+function createTaskListResourceResult(uri: string) {
+    return {
+        contents: [
+            {
+                uri,
+                mimeType: RESOURCE_MIME_TYPE,
+                text: taskListHtml,
+                _meta: taskListResourceMeta,
+            },
+        ],
+    }
+}
+
 /**
  * Register the task list MCP App resource on the server.
  */
@@ -68,16 +82,18 @@ function registerTaskListApp(server: McpServer) {
             description: taskListResourceDescription,
             _meta: taskListResourceMeta,
         },
-        async () => ({
-            contents: [
-                {
-                    uri: taskListResourceUri,
-                    mimeType: RESOURCE_MIME_TYPE,
-                    text: taskListHtml,
-                    _meta: taskListResourceMeta,
-                },
-            ],
-        }),
+        async () => createTaskListResourceResult(taskListResourceUri),
+    )
+
+    server.registerResource(
+        'todoist-task-list-hash-fallback',
+        new ResourceTemplate(taskListResourceUriTemplate, { list: undefined }),
+        {
+            description: `${taskListResourceDescription} compatibility fallback`,
+            mimeType: RESOURCE_MIME_TYPE,
+            _meta: taskListResourceMeta,
+        },
+        async (uri) => createTaskListResourceResult(uri.toString()),
     )
 }
 


### PR DESCRIPTION
## Short description

We inject all client-side dependencies (e.g., React) in a single HTML file that we serve as an app resource. That file gets it content-hash appended. Any dependency update produces a new hash, invalidating existing files. This is good as long as MCP clients can correctly request the newest version. However, if their caching/snapshotting policy is too aggressive, it can lead to unreachable resources being referenced.

This is what happened during our submission to ChatGPT. We got rejected because their submission process kept requesting stale resources. Now there are two ways to solve this:

1. Keep old app resources around "indefinitely" (e.g., a year) so they can get served correctly
2. Introduce a catch-all resource that serves the most recent app resource independent of the requested hash

While (1) is clearer, it requires some infrastructure changes to how we deploy our MCP server that I wasn't willing to embark on right now. (2) should work just as fine, and arguably, it's better if clients always get the most recent version.

## Test plan

- `resources/list` advertises the current exact app resource
- `resources/templates/list` advertises the fallback
- `resources/read` for the current URI returns a valid html / mcp app
- `resources/read` for stale URI (e.g., `ui://todoist/task-list@deadbeefcafe` also returns a valid html / mcp pp

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

- [x] Added tests for bugs / new features
