### PR TITLE
chore: group oxlint and oxfmt renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,11 @@
         {
             "matchPackageNames": ["@types/node"],
             "allowedVersions": "< 23"
+        },
+        {
+            "matchPackageNames": ["oxlint", "oxfmt"],
+            "groupName": "ox toolchain",
+            "description": "Group oxlint and oxfmt updates into a single PR"
         }
     ],
     "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary
- Add a renovate `packageRule` grouping `oxlint` and `oxfmt` updates into a single PR, so the ox toolchain bumps together.

Mirrors Doist/automations#3164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)