### PR TITLE
fix(deps): update @doist/todoist-sdk to v10.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "10.1.4",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-sdk": "10.3.0",
+                "@doist/todoist-sdk": "10.3.3",
                 "@modelcontextprotocol/ext-apps": "1.2.2",
                 "date-fns": "4.1.0",
                 "dompurify": "3.3.3",
@@ -462,16 +462,16 @@
             }
         },
         "node_modules/@doist/todoist-sdk": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.3.0.tgz",
-            "integrity": "sha512-Nxovh0n7TYmfBbZiJLjaWfZGJrcG09tSO3MKmG8RgQGHMHBhkM0r1yCXpQWzXbuRQ8ZLD/0akg+4w0FosrFfOg==",
+            "version": "10.3.3",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.3.3.tgz",
+            "integrity": "sha512-0ClY3e3WTCipSHEYsdtTUECbQB8S9ysSYNPzprjqurZFOropnIZ68uEk1qQXMBeYNka6Pr5LAAvmWLa40KGK6A==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "6.3.0",
                 "emoji-regex": "10.6.0",
                 "form-data": "4.0.5",
                 "ts-custom-error": "^3.2.0",
-                "undici": "^7.16.0",
+                "undici": "7.24.8",
                 "uuid": "11.1.1",
                 "zod": "4.3.6"
             },
@@ -13790,9 +13790,9 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-            "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+            "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-sdk": "10.3.0",
+        "@doist/todoist-sdk": "10.3.3",
         "@modelcontextprotocol/ext-apps": "1.2.2",
         "date-fns": "4.1.0",
         "dompurify": "3.3.3",

--- a/src/usage-tracking.test.ts
+++ b/src/usage-tracking.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
     buildUsageTrackingHeaders,
+    createTodoistClient,
     createTrackedFetch,
     resetDispatcherModuleLoaderForTests,
     resetDefaultDispatcherForTests,
@@ -307,5 +308,62 @@ describe('usage tracking', () => {
         expect(headers.get('doist-platform')).toBeNull()
         expect(headers.get('mcp-tool')).toBeNull()
         expect(headers.get('session-id')).toBeNull()
+    })
+})
+
+// Regression guard for Doist/Issues#20430. The host allowlist and redirect
+// auth-stripping live in @doist/todoist-sdk, but these exercise the full
+// createTodoistClient -> createTrackedFetch -> SDK path so a future SDK bump
+// that loosens the behaviour fails loudly in this repo.
+describe('createTodoistClient viewAttachment safety (Doist/Issues#20430)', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('rejects non-attachment Todoist hosts without making a request', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        const client = createTodoistClient('test-token')
+
+        await expect(client.viewAttachment('https://api.todoist.com/api/v1/tasks')).rejects.toThrow(
+            /known Todoist attachment host/i,
+        )
+        await expect(client.viewAttachment('https://app.todoist.com/app')).rejects.toThrow(
+            /known Todoist attachment host/i,
+        )
+
+        expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('does not forward the auth token to the CDN on an attachment redirect', async () => {
+        const cdnUrl = 'https://todoist.b-cdn.net/uploads/file.png'
+        const fetchMock = vi
+            .fn<typeof fetch>()
+            // files.todoist.com authorizes, then redirects to the CDN...
+            .mockResolvedValueOnce(
+                new Response(null, { status: 302, headers: { location: cdnUrl } }),
+            )
+            // ...and the CDN serves the file.
+            .mockResolvedValueOnce(
+                new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+                    status: 200,
+                    headers: { 'content-type': 'image/png' },
+                }),
+            )
+        vi.spyOn(globalThis, 'fetch').mockImplementation(fetchMock)
+
+        const client = createTodoistClient('test-token')
+        await client.viewAttachment('https://files.todoist.com/user_upload/file.png')
+
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        const [firstUrl, firstInit] = fetchMock.mock.calls[0] ?? []
+        const [secondUrl, secondInit] = fetchMock.mock.calls[1] ?? []
+
+        // The authenticated host gets the token.
+        expect(firstUrl).toBe('https://files.todoist.com/user_upload/file.png')
+        expect(new Headers(firstInit?.headers).get('authorization')).toBe('Bearer test-token')
+
+        // The cross-origin CDN hop must not carry the token.
+        expect(secondUrl).toBe(cdnUrl)
+        expect(new Headers(secondInit?.headers).get('authorization')).toBeNull()
     })
 })


### PR DESCRIPTION
## Summary

Bumps `@doist/todoist-sdk` from 10.3.0 to 10.3.3 to pick up the `viewAttachment` hardening from [Doist/todoist-sdk-typescript#618](https://github.com/Doist/todoist-sdk-typescript/pull/618).

The `view-attachment` tool now:
- only fetches known attachment hosts (`files.todoist.com` + the attachment CDN origins), rejecting `api.todoist.com`, `app.todoist.com`, and other non-attachment `*.todoist.com` URLs — so the tool can no longer be used to return arbitrary authenticated API JSON;
- never forwards the auth token to the CDN, including via redirects on the `customFetch` path used by this server.

Raised in [Doist/Issues#20430](https://github.com/Doist/Issues/issues/20430).

## Testing

Full suite green (909 tests), type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)