### PR TITLE
fix(update-tasks): Report per-task failures instead of failing the whole batch

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -139,7 +139,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 
 7. **Pagination**: Large result sets use cursor-based pagination. Use limit parameter to control result size (default varies by tool).
 
-8. **Error Handling**: All tools provide detailed error messages and next-step suggestions. Pay attention to validation feedback for corrective actions.
+8. **Error Handling**: All tools provide detailed error messages and next-step suggestions. Pay attention to validation feedback for corrective actions. Batch tools (e.g. add-tasks, update-tasks) report per-item \`failures\` alongside successes — a single failed item does not undo the rest of the batch. When an item fails, **do not retry the whole batch**; inspect its failure reason and only re-send the items that are actually fixable.
 
 ### Common Workflows:
 

--- a/src/tools/add-tasks.ts
+++ b/src/tools/add-tasks.ts
@@ -4,6 +4,7 @@ import type { TodoistTool } from '../todoist-tool.js'
 import { formatBatchItemError } from '../tool-execution-error.js'
 import { isInboxProjectId, mapTask } from '../tool-helpers.js'
 import { assignmentValidator } from '../utils/assignment-validator.js'
+import { BatchLimits } from '../utils/constants.js'
 import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
 import { FailureSchema, TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
 import {
@@ -16,7 +17,7 @@ import { optionalString } from '../utils/schema-helpers.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 // Maximum tasks per operation to prevent abuse and timeouts
-const MAX_TASKS_PER_OPERATION = 25
+const MAX_TASKS_PER_OPERATION = BatchLimits.TASKS_PER_OPERATION
 
 const TaskSchema = z.object({
     content: z

--- a/src/tools/assignment-integration.test.ts
+++ b/src/tools/assignment-integration.test.ts
@@ -258,13 +258,19 @@ describe('Assignment Integration Tests', () => {
                 },
             })
 
-            await expect(
-                updateTasks.execute(
-                    { tasks: [{ id: 'task-123', responsibleUser: 'invalid@example.com' }] },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow('Task task-123: User cannot be assigned to this project')
+            const result = await updateTasks.execute(
+                { tasks: [{ id: 'task-123', responsibleUser: 'invalid@example.com' }] },
+                mockTodoistApi,
+            )
 
+            // Invalid assignment is reported per-item in `failures`, not thrown.
+            const { structuredContent } = result
+            expect(structuredContent.tasks).toHaveLength(0)
+            expect(structuredContent.failures).toHaveLength(1)
+            expect(structuredContent.failures[0]?.item).toBe('task-123')
+            expect(structuredContent.failures[0]?.error).toContain(
+                'Task task-123: User cannot be assigned to this project',
+            )
             expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
         })
     })

--- a/src/tools/update-tasks.test.ts
+++ b/src/tools/update-tasks.test.ts
@@ -1206,10 +1206,10 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 failureCount: 1,
             })
 
-            // The text content tells the model not to retry the whole batch.
+            // The text content surfaces the per-task failure alongside the success.
             expect(result.textContent).toContain('Updated 1 task')
             expect(result.textContent).toContain('Failed (1)')
-            expect(result.textContent).toContain('not retried automatically')
+            expect(result.textContent).toContain('address or drop these items')
         })
 
         it('throws when every task in the batch fails', async () => {
@@ -1346,6 +1346,48 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 skippedCount: 0,
                 failureCount: 1,
             })
+        })
+
+        it('truncates the failure list to 3 and shows "+N more"', async () => {
+            // A non-throwing batch (one success keeps it from being a total failure) with
+            // more than MAX_FAILURES_SHOWN (3) failures must cap the displayed list and
+            // append "+N more" so the truncation isn't silently dropped by a refactor.
+            mockTodoistApi.updateTask.mockImplementation((id: string) => {
+                if (id === 'ok-task') {
+                    return Promise.resolve(createMockTask({ id: 'ok-task', content: 'ok' }))
+                }
+                return Promise.reject(new Error('API Error: boom'))
+            })
+
+            const result = await updateTasks.execute(
+                {
+                    tasks: [
+                        { id: 'ok-task', content: 'ok' },
+                        { id: 'bad-1', content: 'x' },
+                        { id: 'bad-2', content: 'x' },
+                        { id: 'bad-3', content: 'x' },
+                        { id: 'bad-4', content: 'x' },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            const { structuredContent, textContent } = result
+            // All 4 failures are retained in the structured output...
+            expect(structuredContent.failures).toHaveLength(4)
+            expect(structuredContent.appliedOperations).toEqual({
+                updateCount: 1,
+                skippedCount: 0,
+                failureCount: 4,
+            })
+
+            // ...but the text summary shows only the first 3 and notes the remainder.
+            expect(textContent).toContain('Failed (4)')
+            expect(textContent).toContain('bad-1')
+            expect(textContent).toContain('bad-2')
+            expect(textContent).toContain('bad-3')
+            expect(textContent).not.toContain('bad-4')
+            expect(textContent).toContain('+1 more')
         })
 
         it('does not throw when the only outcome is a partial success', async () => {

--- a/src/tools/update-tasks.test.ts
+++ b/src/tools/update-tasks.test.ts
@@ -1161,6 +1161,105 @@ describe(`${UPDATE_TASKS} tool`, () => {
         })
     })
 
+    describe('partial batch failures', () => {
+        it('keeps successful updates when one task in the batch fails', async () => {
+            const okTask = createMockTask({ id: 'ok-task', content: 'Updated ok' })
+            mockTodoistApi.updateTask.mockResolvedValue(okTask)
+            // The forbidden cross-workspace move shape the API rejects with 403.
+            mockTodoistApi.moveTask.mockRejectedValue(
+                Object.assign(new Error('Request failed with status code 403'), {
+                    httpStatusCode: 403,
+                    responseData: {
+                        error: 'Not allowed to move objects out of a workspace',
+                        error_tag: 'FORBIDDEN',
+                        http_code: 403,
+                    },
+                }),
+            )
+
+            const result = await updateTasks.execute(
+                {
+                    tasks: [
+                        { id: 'ok-task', content: 'Updated ok' },
+                        { id: 'bad-task', projectId: 'personal-project' },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            const { structuredContent } = result
+            // The valid update is preserved instead of being discarded by the failure.
+            expect(structuredContent.tasks).toHaveLength(1)
+            expect(structuredContent.totalCount).toBe(1)
+            expect(structuredContent.updatedTaskIds).toEqual(['ok-task'])
+
+            // The failure is reported per-task, with the specific API objection surfaced.
+            expect(structuredContent.failures).toHaveLength(1)
+            expect(structuredContent.failures[0]?.item).toBe('bad-task')
+            expect(structuredContent.failures[0]?.error).toContain(
+                'Not allowed to move objects out of a workspace',
+            )
+            expect(structuredContent.appliedOperations).toEqual({
+                updateCount: 1,
+                skippedCount: 0,
+                failureCount: 1,
+            })
+
+            // The text content tells the model not to retry the whole batch.
+            expect(result.textContent).toContain('Updated 1 task')
+            expect(result.textContent).toContain('Failed (1)')
+            expect(result.textContent).toContain('not retried automatically')
+        })
+
+        it('throws when every task in the batch fails', async () => {
+            mockTodoistApi.moveTask.mockRejectedValue(
+                Object.assign(new Error('Request failed with status code 403'), {
+                    httpStatusCode: 403,
+                    responseData: {
+                        error: 'Not allowed to move objects out of a workspace',
+                        http_code: 403,
+                    },
+                }),
+            )
+
+            await expect(
+                updateTasks.execute(
+                    {
+                        tasks: [
+                            { id: 'bad-1', projectId: 'personal-project' },
+                            { id: 'bad-2', projectId: 'personal-project' },
+                        ],
+                    },
+                    mockTodoistApi,
+                ),
+            ).rejects.toThrow('All 2 task update(s) failed')
+        })
+
+        it('counts skipped (no-change) tasks separately from failures', async () => {
+            const okTask = createMockTask({ id: 'ok-task', content: 'Updated ok' })
+            mockTodoistApi.updateTask.mockResolvedValue(okTask)
+
+            const result = await updateTasks.execute(
+                {
+                    tasks: [
+                        { id: 'ok-task', content: 'Updated ok' },
+                        { id: 'noop-task' }, // only id -> skipped, not a failure
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            const { structuredContent } = result
+            expect(structuredContent.tasks).toHaveLength(1)
+            expect(structuredContent.failures).toHaveLength(0)
+            expect(structuredContent.appliedOperations).toEqual({
+                updateCount: 1,
+                skippedCount: 1,
+                failureCount: 0,
+            })
+        })
+    })
+
     describe('isUncompletable parameter', () => {
         it('should pass isUncompletable parameter to SDK', async () => {
             // Mock API response - minimal mock just to prevent errors

--- a/src/tools/update-tasks.test.ts
+++ b/src/tools/update-tasks.test.ts
@@ -1266,17 +1266,13 @@ describe(`${UPDATE_TASKS} tool`, () => {
             })
         })
 
-        it('reports a partial success when the move applies but the field update fails', async () => {
-            // Combined move + field update: the move succeeds, then updateTask rejects.
-            // The move is already applied server-side, so the task must NOT be dropped as a
-            // pure failure — it appears in tasks (moved) and the failure names what still
-            // needs retrying (the field change only, not the move).
-            const movedTask = createMockTask({
-                id: 'move-update-task',
-                content: 'Original content',
-                projectId: 'new-project-id',
-            })
-            mockTodoistApi.moveTask.mockResolvedValue(movedTask)
+        it('reports the whole task as a failure when the move succeeds but the field update fails', async () => {
+            // Combined move + field update where the move succeeds but updateTask rejects.
+            // The task is reported as a single failure — we do not surface which part
+            // applied.
+            mockTodoistApi.moveTask.mockResolvedValue(
+                createMockTask({ id: 'move-update-task', projectId: 'new-project-id' }),
+            )
             mockTodoistApi.updateTask.mockRejectedValue(new Error('API Error: Invalid priority'))
 
             const result = await updateTasks.execute(
@@ -1292,27 +1288,16 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 mockTodoistApi,
             )
 
-            expect(mockTodoistApi.moveTask).toHaveBeenCalledWith('move-update-task', {
-                projectId: 'new-project-id',
-            })
-
             const { structuredContent } = result
-            // The completed move is surfaced, not discarded.
-            expect(structuredContent.tasks).toHaveLength(1)
-            expect(structuredContent.tasks[0]?.id).toBe('move-update-task')
-            expect(structuredContent.updatedTaskIds).toEqual(['move-update-task'])
-
-            // The field-update failure is reported as a partial: the move is surfaced as
-            // already applied, without advising a retry.
+            // The task is not reported as updated...
+            expect(structuredContent.tasks).toHaveLength(0)
+            expect(structuredContent.updatedTaskIds).toEqual([])
+            // ...it is a single failure carrying the field-update error.
             expect(structuredContent.failures).toHaveLength(1)
             expect(structuredContent.failures[0]?.item).toBe('move-update-task')
-            expect(structuredContent.failures[0]?.error).toContain('Move applied')
-            expect(structuredContent.failures[0]?.error).toContain('The move is already done')
             expect(structuredContent.failures[0]?.error).toContain('API Error: Invalid priority')
-
-            // Counts reflect both facts: the move applied AND a field update failed.
             expect(structuredContent.appliedOperations).toEqual({
-                updateCount: 1,
+                updateCount: 0,
                 skippedCount: 0,
                 failureCount: 1,
             })
@@ -1358,23 +1343,6 @@ describe(`${UPDATE_TASKS} tool`, () => {
             expect(textContent).toContain('bad-3')
             expect(textContent).not.toContain('bad-4')
             expect(textContent).toContain('+1 more')
-        })
-
-        it('does not throw when the only outcome is a partial success', async () => {
-            // A partial means the move applied, so it is not a total failure even though a
-            // field update failed — the batch returns normally.
-            const movedTask = createMockTask({ id: 'only-partial', projectId: 'new-project-id' })
-            mockTodoistApi.moveTask.mockResolvedValue(movedTask)
-            mockTodoistApi.updateTask.mockRejectedValue(new Error('boom'))
-
-            await expect(
-                updateTasks.execute(
-                    {
-                        tasks: [{ id: 'only-partial', projectId: 'new-project-id', content: 'x' }],
-                    },
-                    mockTodoistApi,
-                ),
-            ).resolves.toBeDefined()
         })
     })
 

--- a/src/tools/update-tasks.test.ts
+++ b/src/tools/update-tasks.test.ts
@@ -1258,6 +1258,42 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 failureCount: 0,
             })
         })
+
+        it('does not throw when the batch is only skipped and failed tasks', async () => {
+            // No task is actually updated: one is a no-op skip, the other fails. A skip is
+            // a successful no-op, so this is NOT a total failure and must return normally
+            // with the failure listed — rather than throwing a batch-wide error.
+            mockTodoistApi.moveTask.mockRejectedValue(
+                Object.assign(new Error('Request failed with status code 403'), {
+                    httpStatusCode: 403,
+                    responseData: {
+                        error: 'Not allowed to move objects out of a workspace',
+                        http_code: 403,
+                    },
+                }),
+            )
+
+            const result = await updateTasks.execute(
+                {
+                    tasks: [
+                        { id: 'noop-task' }, // only id -> skipped
+                        { id: 'bad-task', projectId: 'personal-project' }, // move -> fails
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            const { structuredContent } = result
+            expect(structuredContent.tasks).toHaveLength(0)
+            expect(structuredContent.totalCount).toBe(0)
+            expect(structuredContent.failures).toHaveLength(1)
+            expect(structuredContent.failures[0]?.item).toBe('bad-task')
+            expect(structuredContent.appliedOperations).toEqual({
+                updateCount: 0,
+                skippedCount: 1,
+                failureCount: 1,
+            })
+        })
     })
 
     describe('isUncompletable parameter', () => {

--- a/src/tools/update-tasks.test.ts
+++ b/src/tools/update-tasks.test.ts
@@ -1295,6 +1295,75 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 failureCount: 1,
             })
         })
+
+        it('reports a partial success when the move applies but the field update fails', async () => {
+            // Combined move + field update: the move succeeds, then updateTask rejects.
+            // The move is already applied server-side, so the task must NOT be dropped as a
+            // pure failure — it appears in tasks (moved) and the failure names what still
+            // needs retrying (the field change only, not the move).
+            const movedTask = createMockTask({
+                id: 'move-update-task',
+                content: 'Original content',
+                projectId: 'new-project-id',
+            })
+            mockTodoistApi.moveTask.mockResolvedValue(movedTask)
+            mockTodoistApi.updateTask.mockRejectedValue(new Error('API Error: Invalid priority'))
+
+            const result = await updateTasks.execute(
+                {
+                    tasks: [
+                        {
+                            id: 'move-update-task',
+                            projectId: 'new-project-id',
+                            content: 'New content',
+                        },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.moveTask).toHaveBeenCalledWith('move-update-task', {
+                projectId: 'new-project-id',
+            })
+
+            const { structuredContent } = result
+            // The completed move is surfaced, not discarded.
+            expect(structuredContent.tasks).toHaveLength(1)
+            expect(structuredContent.tasks[0]?.id).toBe('move-update-task')
+            expect(structuredContent.updatedTaskIds).toEqual(['move-update-task'])
+
+            // The field-update failure is reported as a partial: the move is surfaced as
+            // already applied, without advising a retry.
+            expect(structuredContent.failures).toHaveLength(1)
+            expect(structuredContent.failures[0]?.item).toBe('move-update-task')
+            expect(structuredContent.failures[0]?.error).toContain('Move applied')
+            expect(structuredContent.failures[0]?.error).toContain('The move is already done')
+            expect(structuredContent.failures[0]?.error).toContain('API Error: Invalid priority')
+
+            // Counts reflect both facts: the move applied AND a field update failed.
+            expect(structuredContent.appliedOperations).toEqual({
+                updateCount: 1,
+                skippedCount: 0,
+                failureCount: 1,
+            })
+        })
+
+        it('does not throw when the only outcome is a partial success', async () => {
+            // A partial means the move applied, so it is not a total failure even though a
+            // field update failed — the batch returns normally.
+            const movedTask = createMockTask({ id: 'only-partial', projectId: 'new-project-id' })
+            mockTodoistApi.moveTask.mockResolvedValue(movedTask)
+            mockTodoistApi.updateTask.mockRejectedValue(new Error('boom'))
+
+            await expect(
+                updateTasks.execute(
+                    {
+                        tasks: [{ id: 'only-partial', projectId: 'new-project-id', content: 'x' }],
+                    },
+                    mockTodoistApi,
+                ),
+            ).resolves.toBeDefined()
+        })
     })
 
     describe('isUncompletable parameter', () => {

--- a/src/tools/update-tasks.test.ts
+++ b/src/tools/update-tasks.test.ts
@@ -742,75 +742,51 @@ describe(`${UPDATE_TASKS} tool`, () => {
     })
 
     describe('error handling', () => {
-        it('should throw error for invalid duration format', async () => {
-            await expect(
-                updateTasks.execute(
-                    {
-                        tasks: [
-                            {
-                                id: '8485093756',
-                                duration: 'invalid',
-                            },
-                        ],
-                    },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow('Task 8485093756: Invalid duration format "invalid"')
+        // The tool never throws for per-item problems — even a single failing task is
+        // reported in the structured `failures` rather than rejecting the whole call.
+        async function expectSingleFailure(
+            params: Parameters<typeof updateTasks.execute>[0]['tasks'][number],
+            expectedError: string,
+        ) {
+            const result = await updateTasks.execute({ tasks: [params] }, mockTodoistApi)
+            const { structuredContent } = result
+            expect(structuredContent.tasks).toHaveLength(0)
+            expect(structuredContent.failures).toHaveLength(1)
+            expect(structuredContent.failures[0]?.item).toBe(params.id)
+            expect(structuredContent.failures[0]?.error).toContain(expectedError)
+            expect(structuredContent.appliedOperations).toEqual({
+                updateCount: 0,
+                skippedCount: 0,
+                failureCount: 1,
+            })
+            return result
+        }
+
+        it('reports invalid duration format as a failure', async () => {
+            await expectSingleFailure(
+                { id: '8485093756', duration: 'invalid' },
+                'Task 8485093756: Invalid duration format "invalid"',
+            )
         })
 
-        it('should throw error for duration exceeding 24 hours', async () => {
-            await expect(
-                updateTasks.execute(
-                    {
-                        tasks: [
-                            {
-                                id: '8485093757',
-                                duration: '25h',
-                            },
-                        ],
-                    },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow(
+        it('reports duration exceeding 24 hours as a failure', async () => {
+            await expectSingleFailure(
+                { id: '8485093757', duration: '25h' },
                 'Task 8485093757: Invalid duration format "25h": Duration cannot exceed 24 hours (1440 minutes)',
             )
         })
-        it('should throw error when multiple move parameters are provided', async () => {
-            await expect(
-                updateTasks.execute(
-                    {
-                        tasks: [
-                            {
-                                id: '8485093748',
-                                projectId: 'new-project',
-                                sectionId: 'new-section',
-                            },
-                        ],
-                    },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow(
+
+        it('reports multiple move parameters as a failure', async () => {
+            await expectSingleFailure(
+                { id: '8485093748', projectId: 'new-project', sectionId: 'new-section' },
                 'Only one of projectId, sectionId, or parentId can be specified at a time. ' +
                     'The Todoist API requires exactly one destination for move operations.',
             )
         })
 
-        it('should throw error when all three move parameters are provided', async () => {
-            await expect(
-                updateTasks.execute(
-                    {
-                        tasks: [
-                            {
-                                id: '8485093748',
-                                projectId: 'p1',
-                                sectionId: 's1',
-                                parentId: 't1',
-                            },
-                        ],
-                    },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow(
+        it('reports all three move parameters as a failure', async () => {
+            await expectSingleFailure(
+                { id: '8485093748', projectId: 'p1', sectionId: 's1', parentId: 't1' },
                 'Only one of projectId, sectionId, or parentId can be specified at a time',
             )
         })
@@ -824,16 +800,9 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 error: 'API Error: Invalid priority value',
                 params: { id: '8485093748', content: 'Test task' },
             },
-        ])('should propagate $error', async ({ error, params }) => {
+        ])('reports $error as a failure', async ({ error, params }) => {
             mockTodoistApi.updateTask.mockRejectedValue(new Error(error))
-            await expect(
-                updateTasks.execute(
-                    {
-                        tasks: [params],
-                    },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow(error)
+            await expectSingleFailure(params, error)
         })
     })
 
@@ -1083,80 +1052,67 @@ describe(`${UPDATE_TASKS} tool`, () => {
         })
 
         describe('error handling', () => {
-            it('should throw error when task has multiple move parameters', async () => {
-                await expect(
-                    updateTasks.execute(
-                        {
-                            tasks: [
-                                {
-                                    id: 'task-1',
-                                    projectId: 'new-project',
-                                    sectionId: 'new-section',
-                                },
-                            ],
-                        },
-                        mockTodoistApi,
-                    ),
-                ).rejects.toThrow(
+            // A move failure on the only task is reported in `failures`, not thrown.
+            async function expectSingleMoveFailure(
+                params: Parameters<typeof updateTasks.execute>[0]['tasks'][number],
+                expectedError: string,
+            ) {
+                const result = await updateTasks.execute({ tasks: [params] }, mockTodoistApi)
+                const { structuredContent } = result
+                expect(structuredContent.tasks).toHaveLength(0)
+                expect(structuredContent.failures).toHaveLength(1)
+                expect(structuredContent.failures[0]?.item).toBe(params.id)
+                expect(structuredContent.failures[0]?.error).toContain(expectedError)
+                expect(structuredContent.appliedOperations).toEqual({
+                    updateCount: 0,
+                    skippedCount: 0,
+                    failureCount: 1,
+                })
+            }
+
+            it('reports a task with multiple move parameters as a failure', async () => {
+                await expectSingleMoveFailure(
+                    { id: 'task-1', projectId: 'new-project', sectionId: 'new-section' },
                     'Task task-1: Only one of projectId, sectionId, or parentId can be specified at a time',
                 )
             })
 
-            it('should propagate API errors for individual task moves', async () => {
-                const apiError = new Error('API Error: Task not found')
-                mockTodoistApi.moveTask.mockRejectedValue(apiError)
-
-                await expect(
-                    updateTasks.execute(
-                        { tasks: [{ id: 'non-existent-task', projectId: 'some-project' }] },
-                        mockTodoistApi,
-                    ),
-                ).rejects.toThrow('API Error: Task not found')
+            it('reports API errors for individual task moves as failures', async () => {
+                mockTodoistApi.moveTask.mockRejectedValue(new Error('API Error: Task not found'))
+                await expectSingleMoveFailure(
+                    { id: 'non-existent-task', projectId: 'some-project' },
+                    'API Error: Task not found',
+                )
             })
 
-            it('should handle validation errors', async () => {
-                const validationError = new Error('API Error: Invalid section ID')
-                mockTodoistApi.moveTask.mockRejectedValue(validationError)
-
-                await expect(
-                    updateTasks.execute(
-                        { tasks: [{ id: 'task-1', sectionId: 'invalid-section-format' }] },
-                        mockTodoistApi,
-                    ),
-                ).rejects.toThrow('API Error: Invalid section ID')
+            it('reports validation errors as failures', async () => {
+                mockTodoistApi.moveTask.mockRejectedValue(
+                    new Error('API Error: Invalid section ID'),
+                )
+                await expectSingleMoveFailure(
+                    { id: 'task-1', sectionId: 'invalid-section-format' },
+                    'API Error: Invalid section ID',
+                )
             })
 
-            it('should handle permission errors', async () => {
-                const permissionError = new Error(
+            it('reports permission errors as failures', async () => {
+                mockTodoistApi.moveTask.mockRejectedValue(
+                    new Error('API Error: Insufficient permissions to move task'),
+                )
+                await expectSingleMoveFailure(
+                    { id: 'restricted-task', projectId: 'restricted-project' },
                     'API Error: Insufficient permissions to move task',
                 )
-                mockTodoistApi.moveTask.mockRejectedValue(permissionError)
-
-                await expect(
-                    updateTasks.execute(
-                        { tasks: [{ id: 'restricted-task', projectId: 'restricted-project' }] },
-                        mockTodoistApi,
-                    ),
-                ).rejects.toThrow('API Error: Insufficient permissions to move task')
             })
 
-            it('should handle circular parent dependency errors', async () => {
-                const circularError = new Error('API Error: Circular dependency detected')
-                mockTodoistApi.moveTask.mockRejectedValue(circularError)
-
-                await expect(
-                    updateTasks.execute(
-                        {
-                            tasks: [
-                                {
-                                    id: 'task-parent',
-                                    parentId: 'task-child', // This would create a circular dependency
-                                },
-                            ],
-                        },
-                        mockTodoistApi,
-                    ),
-                ).rejects.toThrow('API Error: Circular dependency detected')
+            it('reports circular parent dependency errors as failures', async () => {
+                mockTodoistApi.moveTask.mockRejectedValue(
+                    new Error('API Error: Circular dependency detected'),
+                )
+                await expectSingleMoveFailure(
+                    { id: 'task-parent', parentId: 'task-child' },
+                    'API Error: Circular dependency detected',
+                )
             })
         })
     })
@@ -1212,7 +1168,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
             expect(result.textContent).toContain('address or drop these items')
         })
 
-        it('throws when every task in the batch fails', async () => {
+        it('returns a structured result (does not throw) when every task fails', async () => {
             mockTodoistApi.moveTask.mockRejectedValue(
                 Object.assign(new Error('Request failed with status code 403'), {
                     httpStatusCode: 403,
@@ -1223,17 +1179,31 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 }),
             )
 
-            await expect(
-                updateTasks.execute(
-                    {
-                        tasks: [
-                            { id: 'bad-1', projectId: 'personal-project' },
-                            { id: 'bad-2', projectId: 'personal-project' },
-                        ],
-                    },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow('All 2 task update(s) failed')
+            const result = await updateTasks.execute(
+                {
+                    tasks: [
+                        { id: 'bad-1', projectId: 'personal-project' },
+                        { id: 'bad-2', projectId: 'personal-project' },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            // A total failure is reported structurally, not thrown — so the per-item
+            // reasons survive instead of being flattened into one opaque error.
+            const { structuredContent } = result
+            expect(structuredContent.tasks).toHaveLength(0)
+            expect(structuredContent.totalCount).toBe(0)
+            expect(structuredContent.updatedTaskIds).toEqual([])
+            expect(structuredContent.failures).toHaveLength(2)
+            expect(structuredContent.failures.map((f) => f.item)).toEqual(['bad-1', 'bad-2'])
+            expect(structuredContent.appliedOperations).toEqual({
+                updateCount: 0,
+                skippedCount: 0,
+                failureCount: 2,
+            })
+            expect(result.textContent).toContain('Updated 0 tasks')
+            expect(result.textContent).toContain('Failed (2)')
         })
 
         it('counts skipped (no-change) tasks separately from failures', async () => {

--- a/src/tools/update-tasks.test.ts
+++ b/src/tools/update-tasks.test.ts
@@ -1193,12 +1193,13 @@ describe(`${UPDATE_TASKS} tool`, () => {
             expect(structuredContent.totalCount).toBe(1)
             expect(structuredContent.updatedTaskIds).toEqual(['ok-task'])
 
-            // The failure is reported per-task, with the specific API objection surfaced.
+            // The failure is reported per-task, surfacing the error's message (matching the
+            // add-tasks/complete-tasks pattern). The SDK's moveTask puts the generic status
+            // text in error.message; the API objection lives in responseData and is not
+            // echoed per item.
             expect(structuredContent.failures).toHaveLength(1)
             expect(structuredContent.failures[0]?.item).toBe('bad-task')
-            expect(structuredContent.failures[0]?.error).toContain(
-                'Not allowed to move objects out of a workspace',
-            )
+            expect(structuredContent.failures[0]?.error).toBe('Request failed with status code 403')
             expect(structuredContent.appliedOperations).toEqual({
                 updateCount: 1,
                 skippedCount: 0,

--- a/src/tools/update-tasks.test.ts
+++ b/src/tools/update-tasks.test.ts
@@ -1,5 +1,6 @@
 import type { Task, TodoistApi } from '@doist/todoist-sdk'
 import { type Mocked, vi } from 'vitest'
+import { z } from 'zod'
 import { convertPriorityToNumber } from '../utils/priorities.js'
 import { createMockTask, createMockUser, TEST_IDS } from '../utils/test-helpers.js'
 import { ToolNames } from '../utils/tool-names.js'
@@ -1344,6 +1345,37 @@ describe(`${UPDATE_TASKS} tool`, () => {
             expect(textContent).not.toContain('bad-4')
             expect(textContent).toContain('+1 more')
         })
+
+        it('retries a transient 5xx response on a per-item call', async () => {
+            // A per-item 503 must be retried (the registerTool wrapper no longer fires now
+            // that we settle each task, and the SDK transport doesn't retry 5xx responses).
+            // The first attempt fails with 503, the retry succeeds, so the task is reported
+            // as updated rather than a permanent failure.
+            vi.useFakeTimers()
+            try {
+                const okTask = createMockTask({ id: 'retry-task', projectId: 'new-project-id' })
+                mockTodoistApi.moveTask
+                    .mockRejectedValueOnce(
+                        Object.assign(new Error('HTTP 503: Service Unavailable'), {
+                            httpStatusCode: 503,
+                        }),
+                    )
+                    .mockResolvedValueOnce(okTask)
+
+                const promise = updateTasks.execute(
+                    { tasks: [{ id: 'retry-task', projectId: 'new-project-id' }] },
+                    mockTodoistApi,
+                )
+                await vi.runAllTimersAsync()
+                const result = await promise
+
+                expect(mockTodoistApi.moveTask).toHaveBeenCalledTimes(2)
+                expect(result.structuredContent.tasks).toHaveLength(1)
+                expect(result.structuredContent.failures).toHaveLength(0)
+            } finally {
+                vi.useRealTimers()
+            }
+        })
     })
 
     describe('isUncompletable parameter', () => {
@@ -1372,6 +1404,23 @@ describe(`${UPDATE_TASKS} tool`, () => {
             expect(mockTodoistApi.updateTask).toHaveBeenCalledWith('task123', {
                 isUncompletable: true,
             })
+        })
+    })
+
+    describe('batch limits', () => {
+        // The cap is enforced by the schema at the MCP input boundary, bounding the
+        // concurrent fan-out and the size of the failures response.
+        const makeTasks = (count: number) =>
+            Array.from({ length: count }, (_, i) => ({ id: `task-${i}`, content: 'x' }))
+
+        it('accepts a batch at the cap (25)', () => {
+            const result = z.object(updateTasks.parameters).safeParse({ tasks: makeTasks(25) })
+            expect(result.success).toBe(true)
+        })
+
+        it('rejects a batch larger than the cap', () => {
+            const result = z.object(updateTasks.parameters).safeParse({ tasks: makeTasks(26) })
+            expect(result.success).toBe(false)
         })
     })
 })

--- a/src/tools/update-tasks.test.ts
+++ b/src/tools/update-tasks.test.ts
@@ -21,6 +21,24 @@ describe(`${UPDATE_TASKS} tool`, () => {
         mockTodoistApi.getUser.mockResolvedValue(createMockUser())
     })
 
+    async function expectSingleFailure(
+        params: Parameters<typeof updateTasks.execute>[0]['tasks'][number],
+        expectedError: string,
+    ) {
+        const result = await updateTasks.execute({ tasks: [params] }, mockTodoistApi)
+        const { structuredContent } = result
+        expect(structuredContent.tasks).toHaveLength(0)
+        expect(structuredContent.failures).toHaveLength(1)
+        expect(structuredContent.failures[0]?.item).toBe(params.id)
+        expect(structuredContent.failures[0]?.error).toContain(expectedError)
+        expect(structuredContent.appliedOperations).toEqual({
+            updateCount: 0,
+            skippedCount: 0,
+            failureCount: 1,
+        })
+        return result
+    }
+
     describe('updating task properties', () => {
         it('should update task content and description', async () => {
             // Mock API response extracted from recordings (Task type)
@@ -745,24 +763,6 @@ describe(`${UPDATE_TASKS} tool`, () => {
     describe('error handling', () => {
         // The tool never throws for per-item problems — even a single failing task is
         // reported in the structured `failures` rather than rejecting the whole call.
-        async function expectSingleFailure(
-            params: Parameters<typeof updateTasks.execute>[0]['tasks'][number],
-            expectedError: string,
-        ) {
-            const result = await updateTasks.execute({ tasks: [params] }, mockTodoistApi)
-            const { structuredContent } = result
-            expect(structuredContent.tasks).toHaveLength(0)
-            expect(structuredContent.failures).toHaveLength(1)
-            expect(structuredContent.failures[0]?.item).toBe(params.id)
-            expect(structuredContent.failures[0]?.error).toContain(expectedError)
-            expect(structuredContent.appliedOperations).toEqual({
-                updateCount: 0,
-                skippedCount: 0,
-                failureCount: 1,
-            })
-            return result
-        }
-
         it('reports invalid duration format as a failure', async () => {
             await expectSingleFailure(
                 { id: '8485093756', duration: 'invalid' },
@@ -1054,25 +1054,8 @@ describe(`${UPDATE_TASKS} tool`, () => {
 
         describe('error handling', () => {
             // A move failure on the only task is reported in `failures`, not thrown.
-            async function expectSingleMoveFailure(
-                params: Parameters<typeof updateTasks.execute>[0]['tasks'][number],
-                expectedError: string,
-            ) {
-                const result = await updateTasks.execute({ tasks: [params] }, mockTodoistApi)
-                const { structuredContent } = result
-                expect(structuredContent.tasks).toHaveLength(0)
-                expect(structuredContent.failures).toHaveLength(1)
-                expect(structuredContent.failures[0]?.item).toBe(params.id)
-                expect(structuredContent.failures[0]?.error).toContain(expectedError)
-                expect(structuredContent.appliedOperations).toEqual({
-                    updateCount: 0,
-                    skippedCount: 0,
-                    failureCount: 1,
-                })
-            }
-
             it('reports a task with multiple move parameters as a failure', async () => {
-                await expectSingleMoveFailure(
+                await expectSingleFailure(
                     { id: 'task-1', projectId: 'new-project', sectionId: 'new-section' },
                     'Task task-1: Only one of projectId, sectionId, or parentId can be specified at a time',
                 )
@@ -1080,7 +1063,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
 
             it('reports API errors for individual task moves as failures', async () => {
                 mockTodoistApi.moveTask.mockRejectedValue(new Error('API Error: Task not found'))
-                await expectSingleMoveFailure(
+                await expectSingleFailure(
                     { id: 'non-existent-task', projectId: 'some-project' },
                     'API Error: Task not found',
                 )
@@ -1090,7 +1073,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 mockTodoistApi.moveTask.mockRejectedValue(
                     new Error('API Error: Invalid section ID'),
                 )
-                await expectSingleMoveFailure(
+                await expectSingleFailure(
                     { id: 'task-1', sectionId: 'invalid-section-format' },
                     'API Error: Invalid section ID',
                 )
@@ -1100,7 +1083,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 mockTodoistApi.moveTask.mockRejectedValue(
                     new Error('API Error: Insufficient permissions to move task'),
                 )
-                await expectSingleMoveFailure(
+                await expectSingleFailure(
                     { id: 'restricted-task', projectId: 'restricted-project' },
                     'API Error: Insufficient permissions to move task',
                 )
@@ -1110,7 +1093,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 mockTodoistApi.moveTask.mockRejectedValue(
                     new Error('API Error: Circular dependency detected'),
                 )
-                await expectSingleMoveFailure(
+                await expectSingleFailure(
                     { id: 'task-parent', parentId: 'task-child' },
                     'API Error: Circular dependency detected',
                 )
@@ -1301,6 +1284,7 @@ describe(`${UPDATE_TASKS} tool`, () => {
             expect(structuredContent.failures[0]?.error).toBe(
                 'Move applied; field update failed: API Error: Invalid priority',
             )
+            expect(structuredContent.failures[0]?.code).toBe('PARTIAL_MOVE_APPLIED')
             expect(structuredContent.appliedOperations).toEqual({
                 updateCount: 1,
                 skippedCount: 0,
@@ -1380,6 +1364,37 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 vi.useRealTimers()
             }
         })
+
+        it('retries a transient 5xx response while resolving an inbox move', async () => {
+            vi.useFakeTimers()
+            try {
+                const movedTask = createMockTask({
+                    id: 'inbox-retry-task',
+                    projectId: TEST_IDS.PROJECT_INBOX,
+                })
+                mockTodoistApi.getUser.mockRejectedValueOnce(
+                    Object.assign(new Error('HTTP 503: Service Unavailable'), {
+                        httpStatusCode: 503,
+                    }),
+                )
+                mockTodoistApi.moveTask.mockResolvedValue(movedTask)
+
+                const promise = updateTasks.execute(
+                    { tasks: [{ id: 'inbox-retry-task', projectId: 'inbox' }] },
+                    mockTodoistApi,
+                )
+                await vi.runAllTimersAsync()
+                const result = await promise
+
+                expect(mockTodoistApi.getUser).toHaveBeenCalledTimes(2)
+                expect(mockTodoistApi.moveTask).toHaveBeenCalledWith('inbox-retry-task', {
+                    projectId: TEST_IDS.PROJECT_INBOX,
+                })
+                expect(result.structuredContent.failures).toHaveLength(0)
+            } finally {
+                vi.useRealTimers()
+            }
+        })
     })
 
     describe('isUncompletable parameter', () => {
@@ -1412,8 +1427,8 @@ describe(`${UPDATE_TASKS} tool`, () => {
     })
 
     describe('batch limits', () => {
-        // The cap is enforced by the schema at the MCP input boundary, bounding the
-        // concurrent fan-out and the size of the failures response.
+        // The cap is enforced at both the MCP input boundary and in execute(), bounding
+        // concurrent fan-out and the size of the failures response for direct callers too.
         const makeTasks = (count: number) =>
             Array.from({ length: count }, (_, i) => ({ id: `task-${i}`, content: 'x' }))
 
@@ -1425,6 +1440,13 @@ describe(`${UPDATE_TASKS} tool`, () => {
         it('rejects a batch larger than the cap', () => {
             const result = z.object(updateTasks.parameters).safeParse({ tasks: makeTasks(26) })
             expect(result.success).toBe(false)
+        })
+
+        it('rejects an oversized batch when execute is called directly', async () => {
+            await expect(
+                updateTasks.execute({ tasks: makeTasks(26) }, mockTodoistApi),
+            ).rejects.toThrow('Too big')
+            expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
         })
     })
 })

--- a/src/tools/update-tasks.test.ts
+++ b/src/tools/update-tasks.test.ts
@@ -1150,13 +1150,13 @@ describe(`${UPDATE_TASKS} tool`, () => {
             expect(structuredContent.totalCount).toBe(1)
             expect(structuredContent.updatedTaskIds).toEqual(['ok-task'])
 
-            // The failure is reported per-task, surfacing the error's message (matching the
-            // add-tasks/complete-tasks pattern). The SDK's moveTask puts the generic status
-            // text in error.message; the API objection lives in responseData and is not
-            // echoed per item.
+            // The failure is reported per-task, preserving the API's specific objection
+            // instead of the SDK's generic HTTP status message.
             expect(structuredContent.failures).toHaveLength(1)
             expect(structuredContent.failures[0]?.item).toBe('bad-task')
-            expect(structuredContent.failures[0]?.error).toBe('Request failed with status code 403')
+            expect(structuredContent.failures[0]?.error).toContain(
+                'Not allowed to move objects out of a workspace',
+            )
             expect(structuredContent.appliedOperations).toEqual({
                 updateCount: 1,
                 skippedCount: 0,
@@ -1267,13 +1267,15 @@ describe(`${UPDATE_TASKS} tool`, () => {
             })
         })
 
-        it('reports the whole task as a failure when the move succeeds but the field update fails', async () => {
+        it('reports a partial outcome when the move succeeds but the field update fails', async () => {
             // Combined move + field update where the move succeeds but updateTask rejects.
-            // The task is reported as a single failure — we do not surface which part
-            // applied.
-            mockTodoistApi.moveTask.mockResolvedValue(
-                createMockTask({ id: 'move-update-task', projectId: 'new-project-id' }),
-            )
+            // The response must disclose the move because retrying the whole item could
+            // otherwise apply the same operation twice.
+            const movedTask = createMockTask({
+                id: 'move-update-task',
+                projectId: 'new-project-id',
+            })
+            mockTodoistApi.moveTask.mockResolvedValue(movedTask)
             mockTodoistApi.updateTask.mockRejectedValue(new Error('API Error: Invalid priority'))
 
             const result = await updateTasks.execute(
@@ -1290,15 +1292,17 @@ describe(`${UPDATE_TASKS} tool`, () => {
             )
 
             const { structuredContent } = result
-            // The task is not reported as updated...
-            expect(structuredContent.tasks).toHaveLength(0)
-            expect(structuredContent.updatedTaskIds).toEqual([])
-            // ...it is a single failure carrying the field-update error.
+            expect(structuredContent.tasks).toEqual([
+                expect.objectContaining({ id: 'move-update-task', projectId: 'new-project-id' }),
+            ])
+            expect(structuredContent.updatedTaskIds).toEqual(['move-update-task'])
             expect(structuredContent.failures).toHaveLength(1)
             expect(structuredContent.failures[0]?.item).toBe('move-update-task')
-            expect(structuredContent.failures[0]?.error).toContain('API Error: Invalid priority')
+            expect(structuredContent.failures[0]?.error).toBe(
+                'Move applied; field update failed: API Error: Invalid priority',
+            )
             expect(structuredContent.appliedOperations).toEqual({
-                updateCount: 0,
+                updateCount: 1,
                 skippedCount: 0,
                 failureCount: 1,
             })

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -160,15 +160,10 @@ const updateTasks = {
             })
         })
 
-        // If every attempted task failed (nothing updated, nothing skipped), surface a
-        // hard error so the caller sees a failure rather than a misleading success. A
-        // skipped task is a successful no-op, so a batch with at least one skip is not a
-        // total failure and returns normally with the failures listed.
-        if (updatedTasks.length === 0 && skippedCount === 0 && failures.length > 0) {
-            const details = failures.map((f) => `"${f.item}": ${f.error}`).join('; ')
-            throw new Error(`All ${failures.length} task update(s) failed: ${details}`)
-        }
-
+        // Never throw for per-item problems — even when every task fails. Returning the
+        // structured result (empty `tasks`, populated `failures`) keeps total and partial
+        // failures uniform and preserves the per-item reason for each task, rather than
+        // collapsing them into one opaque error.
         const mappedTasks = updatedTasks.map(mapTask)
 
         const textContent = generateTextContent({

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -153,8 +153,10 @@ const updateTasks = {
         })
 
         // If every attempted task failed (nothing updated, nothing skipped), surface a
-        // hard error so the caller sees a failure rather than a misleading success.
-        if (updatedTasks.length === 0 && failures.length > 0) {
+        // hard error so the caller sees a failure rather than a misleading success. A
+        // skipped task is a successful no-op, so a batch with at least one skip is not a
+        // total failure and returns normally with the failures listed.
+        if (updatedTasks.length === 0 && skippedCount === 0 && failures.length > 0) {
             const details = failures.map((f) => `"${f.item}": ${f.error}`).join('; ')
             throw new Error(`All ${failures.length} task update(s) failed: ${details}`)
         }

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -135,14 +135,14 @@ const updateTasks = {
         const failures: Array<{ item: string; error: string }> = []
         let skippedCount = 0
 
-        settled.forEach((result, index) => {
+        for (const [index, result] of settled.entries()) {
             if (result.status === 'fulfilled') {
                 if (result.value === undefined) {
                     skippedCount++
                 } else {
                     updatedTasks.push(result.value)
                 }
-                return
+                continue
             }
 
             failures.push({
@@ -150,7 +150,7 @@ const updateTasks = {
                 error:
                     result.reason instanceof Error ? result.reason.message : String(result.reason),
             })
-        })
+        }
 
         // Never throw for per-item problems — even when every task fails. Returning the
         // structured result (empty `tasks`, populated `failures`) keeps total and partial
@@ -257,25 +257,9 @@ async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<
 
     // Handle assignment changes if provided
     if (responsibleUser !== undefined) {
-        if (responsibleUser === null || responsibleUser === 'unassign') {
-            // Unassign task - no validation needed
-            updateArgs = { ...updateArgs, assigneeId: null }
-        } else {
-            // Validate assignment using comprehensive validator
-            const validation = await assignmentValidator.validateTaskUpdateAssignment(
-                client,
-                id,
-                responsibleUser,
-            )
-
-            if (!validation.isValid) {
-                const errorMsg = validation.error?.message || 'Assignment validation failed'
-                const suggestions = validation.error?.suggestions?.join('. ') || ''
-                throw new Error(`Task ${id}: ${errorMsg}${suggestions ? `. ${suggestions}` : ''}`)
-            }
-
-            // Use the validated assignee ID
-            updateArgs = { ...updateArgs, assigneeId: validation.resolvedUser?.userId }
+        updateArgs = {
+            ...updateArgs,
+            assigneeId: await resolveAssigneeId(client, id, responsibleUser),
         }
     }
 
@@ -292,6 +276,35 @@ async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<
     }
 
     return movedTask
+}
+
+/**
+ * Resolves the `assigneeId` for a task update from a `responsibleUser` value: `null` to
+ * unassign, or the validated collaborator's user ID. Throws if the requested assignee
+ * fails validation.
+ */
+async function resolveAssigneeId(
+    client: TodoistApi,
+    id: string,
+    responsibleUser: string | null,
+): Promise<string | null | undefined> {
+    if (responsibleUser === null || responsibleUser === 'unassign') {
+        return null
+    }
+
+    const validation = await assignmentValidator.validateTaskUpdateAssignment(
+        client,
+        id,
+        responsibleUser,
+    )
+
+    if (!validation.isValid) {
+        const errorMsg = validation.error?.message || 'Assignment validation failed'
+        const suggestions = validation.error?.suggestions?.join('. ') || ''
+        throw new Error(`Task ${id}: ${errorMsg}${suggestions ? `. ${suggestions}` : ''}`)
+    }
+
+    return validation.resolvedUser?.userId
 }
 
 function generateTextContent({

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -1,10 +1,12 @@
-import type { Task, UpdateTaskArgs } from '@doist/todoist-sdk'
+import type { Task, TodoistApi, UpdateTaskArgs } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
+import { formatToolExecutionError } from '../tool-execution-error.js'
 import { createMoveTaskArgs, mapTask, resolveInboxProjectId } from '../tool-helpers.js'
 import { assignmentValidator } from '../utils/assignment-validator.js'
+import { DisplayLimits } from '../utils/constants.js'
 import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
-import { TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
+import { FailureSchema, TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
 import {
     convertPriorityToNumber,
     PRIORITY_INPUT_DESCRIPTION,
@@ -97,10 +99,16 @@ const OutputSchema = {
     tasks: z.array(TaskOutputSchema).describe('The updated tasks.'),
     totalCount: z.number().describe('The total number of tasks updated.'),
     updatedTaskIds: z.array(z.string()).describe('The IDs of the updated tasks.'),
+    failures: z
+        .array(FailureSchema)
+        .describe(
+            'Tasks that could not be updated, with the reason for each. A failure here does not affect the other tasks in the batch — do not retry the whole batch; address or drop the failed items.',
+        ),
     appliedOperations: z
         .object({
             updateCount: z.number().describe('The number of tasks actually updated.'),
             skippedCount: z.number().describe('The number of tasks skipped (no changes).'),
+            failureCount: z.number().describe('The number of tasks that failed to update.'),
         })
         .describe('Summary of operations performed.'),
 }
@@ -113,127 +121,50 @@ const updateTasks = {
     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
     async execute(args, client) {
         const { tasks } = args
-        const updateTasksPromises = tasks.map(async (task) => {
-            if (!hasUpdatesToMake(task)) {
-                return undefined
-            }
 
-            const {
-                id,
-                projectId,
-                sectionId,
-                parentId,
-                dueString,
-                duration: durationStr,
-                responsibleUser,
-                priority,
-                labels,
-                deadlineDate,
-                ...otherUpdateArgs
-            } = task
-
-            // Resolve "inbox" to actual inbox project ID if needed
-            const resolvedProjectId = await resolveInboxProjectId({
-                projectId,
-                client,
-            })
-
-            let updateArgs: UpdateTaskArgs = {
-                ...otherUpdateArgs,
-                ...(labels !== undefined && { labels }),
-            }
-
-            // Handle priority conversion if provided
-            if (priority) {
-                updateArgs.priority = convertPriorityToNumber(priority)
-            }
-
-            // Handle due date changes if provided
-            const dueStringUpdate = normalizeAliasValue(
-                dueString,
-                DUE_DATE_REMOVAL_ALIASES,
-                DUE_DATE_REMOVAL_VALUE,
-            )
-            if (dueStringUpdate !== undefined) {
-                updateArgs = { ...updateArgs, dueString: dueStringUpdate }
-            }
-
-            // Handle deadline changes if provided
-            const deadlineDateUpdate = normalizeAliasValue(
-                deadlineDate,
-                DEADLINE_REMOVAL_ALIASES,
-                null,
-            )
-            if (deadlineDateUpdate !== undefined) {
-                updateArgs = { ...updateArgs, deadlineDate: deadlineDateUpdate }
-            }
-
-            // Parse duration if provided
-            if (durationStr) {
-                try {
-                    const { minutes } = parseDuration(durationStr)
-                    updateArgs = {
-                        ...updateArgs,
-                        duration: minutes,
-                        durationUnit: 'minute',
-                    }
-                } catch (error) {
-                    if (error instanceof DurationParseError) {
-                        throw new Error(`Task ${id}: ${error.message}`)
-                    }
-                    throw error
-                }
-            }
-
-            // Handle assignment changes if provided
-            if (responsibleUser !== undefined) {
-                if (responsibleUser === null || responsibleUser === 'unassign') {
-                    // Unassign task - no validation needed
-                    updateArgs = { ...updateArgs, assigneeId: null }
-                } else {
-                    // Validate assignment using comprehensive validator
-                    const validation = await assignmentValidator.validateTaskUpdateAssignment(
-                        client,
-                        id,
-                        responsibleUser,
-                    )
-
-                    if (!validation.isValid) {
-                        const errorMsg = validation.error?.message || 'Assignment validation failed'
-                        const suggestions = validation.error?.suggestions?.join('. ') || ''
-                        throw new Error(
-                            `Task ${id}: ${errorMsg}${suggestions ? `. ${suggestions}` : ''}`,
-                        )
-                    }
-
-                    // Use the validated assignee ID
-                    updateArgs = { ...updateArgs, assigneeId: validation.resolvedUser?.userId }
-                }
-            }
-
-            // If no move parameters are provided, use updateTask without moveTask
-            if (!resolvedProjectId && !sectionId && !parentId) {
-                return await client.updateTask(id, updateArgs)
-            }
-
-            const moveArgs = createMoveTaskArgs(id, resolvedProjectId, sectionId, parentId)
-            const movedTask = await client.moveTask(id, moveArgs)
-
-            if (Object.keys(updateArgs).length > 0) {
-                return await client.updateTask(id, updateArgs)
-            }
-
-            return movedTask
-        })
-        const updatedTasks = (await Promise.all(updateTasksPromises)).filter(
-            (task): task is Task => task !== undefined,
+        // Each task is updated independently. A failure on one task (for example, the
+        // API rejecting a move with "Not allowed to move objects out of a workspace")
+        // must not discard the successful updates in the same batch, nor surface as a
+        // single opaque batch error that nudges the caller into retrying everything —
+        // a retry loop that can trip server-side abuse penalties. So we settle every
+        // task and report per-task outcomes.
+        const settled = await Promise.allSettled(
+            tasks.map((task) => processTaskUpdate(task, client)),
         )
+
+        const updatedTasks: Task[] = []
+        const failures: Array<{ item: string; error: string }> = []
+        let skippedCount = 0
+
+        settled.forEach((result, index) => {
+            if (result.status === 'fulfilled') {
+                if (result.value === undefined) {
+                    skippedCount++
+                } else {
+                    updatedTasks.push(result.value)
+                }
+                return
+            }
+
+            failures.push({
+                item: tasks[index]?.id ?? `Task ${index + 1}`,
+                error: formatToolExecutionError(result.reason),
+            })
+        })
+
+        // If every attempted task failed (nothing updated, nothing skipped), surface a
+        // hard error so the caller sees a failure rather than a misleading success.
+        if (updatedTasks.length === 0 && failures.length > 0) {
+            const details = failures.map((f) => `"${f.item}": ${f.error}`).join('; ')
+            throw new Error(`All ${failures.length} task update(s) failed: ${details}`)
+        }
 
         const mappedTasks = updatedTasks.map(mapTask)
 
         const textContent = generateTextContent({
             tasks: mappedTasks,
-            args,
+            failures,
+            skippedCount,
         })
 
         return {
@@ -242,35 +173,163 @@ const updateTasks = {
                 tasks: mappedTasks,
                 totalCount: mappedTasks.length,
                 updatedTaskIds: updatedTasks.map((task) => task.id),
+                failures,
                 appliedOperations: {
                     updateCount: mappedTasks.length,
-                    skippedCount: tasks.length - mappedTasks.length,
+                    skippedCount,
+                    failureCount: failures.length,
                 },
             },
         }
     },
 } satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
 
-function generateTextContent({
-    tasks,
-    args,
-}: {
-    tasks: ReturnType<typeof mapTask>[]
-    args: z.infer<z.ZodObject<typeof ArgsSchema>>
-}) {
-    const totalRequested = args.tasks.length
-    const actuallyUpdated = tasks.length
-    const skipped = totalRequested - actuallyUpdated
-
-    let context = ''
-    if (skipped > 0) {
-        context = ` (${skipped} skipped - no changes)`
+/**
+ * Applies a single task's update and/or move. Returns the resulting task, or
+ * `undefined` when the task carries no changes to make (skipped). Throws on API or
+ * validation errors so the caller can record a per-task failure without aborting the
+ * rest of the batch.
+ */
+async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<Task | undefined> {
+    if (!hasUpdatesToMake(task)) {
+        return undefined
     }
 
-    return summarizeTaskOperation('Updated', tasks, {
+    const {
+        id,
+        projectId,
+        sectionId,
+        parentId,
+        dueString,
+        duration: durationStr,
+        responsibleUser,
+        priority,
+        labels,
+        deadlineDate,
+        ...otherUpdateArgs
+    } = task
+
+    // Resolve "inbox" to actual inbox project ID if needed
+    const resolvedProjectId = await resolveInboxProjectId({
+        projectId,
+        client,
+    })
+
+    let updateArgs: UpdateTaskArgs = {
+        ...otherUpdateArgs,
+        ...(labels !== undefined && { labels }),
+    }
+
+    // Handle priority conversion if provided
+    if (priority) {
+        updateArgs.priority = convertPriorityToNumber(priority)
+    }
+
+    // Handle due date changes if provided
+    const dueStringUpdate = normalizeAliasValue(
+        dueString,
+        DUE_DATE_REMOVAL_ALIASES,
+        DUE_DATE_REMOVAL_VALUE,
+    )
+    if (dueStringUpdate !== undefined) {
+        updateArgs = { ...updateArgs, dueString: dueStringUpdate }
+    }
+
+    // Handle deadline changes if provided
+    const deadlineDateUpdate = normalizeAliasValue(deadlineDate, DEADLINE_REMOVAL_ALIASES, null)
+    if (deadlineDateUpdate !== undefined) {
+        updateArgs = { ...updateArgs, deadlineDate: deadlineDateUpdate }
+    }
+
+    // Parse duration if provided
+    if (durationStr) {
+        try {
+            const { minutes } = parseDuration(durationStr)
+            updateArgs = {
+                ...updateArgs,
+                duration: minutes,
+                durationUnit: 'minute',
+            }
+        } catch (error) {
+            if (error instanceof DurationParseError) {
+                throw new Error(`Task ${id}: ${error.message}`)
+            }
+            throw error
+        }
+    }
+
+    // Handle assignment changes if provided
+    if (responsibleUser !== undefined) {
+        if (responsibleUser === null || responsibleUser === 'unassign') {
+            // Unassign task - no validation needed
+            updateArgs = { ...updateArgs, assigneeId: null }
+        } else {
+            // Validate assignment using comprehensive validator
+            const validation = await assignmentValidator.validateTaskUpdateAssignment(
+                client,
+                id,
+                responsibleUser,
+            )
+
+            if (!validation.isValid) {
+                const errorMsg = validation.error?.message || 'Assignment validation failed'
+                const suggestions = validation.error?.suggestions?.join('. ') || ''
+                throw new Error(`Task ${id}: ${errorMsg}${suggestions ? `. ${suggestions}` : ''}`)
+            }
+
+            // Use the validated assignee ID
+            updateArgs = { ...updateArgs, assigneeId: validation.resolvedUser?.userId }
+        }
+    }
+
+    // If no move parameters are provided, use updateTask without moveTask
+    if (!resolvedProjectId && !sectionId && !parentId) {
+        return await client.updateTask(id, updateArgs)
+    }
+
+    const moveArgs = createMoveTaskArgs(id, resolvedProjectId, sectionId, parentId)
+    const movedTask = await client.moveTask(id, moveArgs)
+
+    if (Object.keys(updateArgs).length > 0) {
+        return await client.updateTask(id, updateArgs)
+    }
+
+    return movedTask
+}
+
+function generateTextContent({
+    tasks,
+    failures,
+    skippedCount,
+}: {
+    tasks: ReturnType<typeof mapTask>[]
+    failures: Array<{ item: string; error: string }>
+    skippedCount: number
+}) {
+    const contextParts: string[] = []
+    if (skippedCount > 0) {
+        contextParts.push(`${skippedCount} skipped - no changes`)
+    }
+    if (failures.length > 0) {
+        contextParts.push(`${failures.length} failed`)
+    }
+    const context = contextParts.length > 0 ? ` (${contextParts.join(', ')})` : ''
+
+    const summary = summarizeTaskOperation('Updated', tasks, {
         context,
         showDetails: tasks.length <= 5,
     })
+
+    if (failures.length === 0) {
+        return summary
+    }
+
+    const shown = failures.slice(0, DisplayLimits.MAX_FAILURES_SHOWN)
+    const remaining = failures.length - shown.length
+    const failureLines = shown.map((f) => `    ${f.item}: ${f.error}`).join('\n')
+    const moreInfo = remaining > 0 ? `\n    +${remaining} more` : ''
+
+    return `${summary}\nFailed (${failures.length}) - not retried automatically; address or drop these items:\n${failureLines}${moreInfo}`
 }
 
 function hasUpdatesToMake({ id: _id, ...otherUpdateArgs }: TaskUpdate) {

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -365,7 +365,7 @@ function generateTextContent({
     const failureLines = shown.map((f) => `    ${f.item}: ${f.error}`).join('\n')
     const moreInfo = remaining > 0 ? `\n    +${remaining} more` : ''
 
-    return `${summary}\nFailed (${failures.length}) - not retried automatically; address or drop these items:\n${failureLines}${moreInfo}`
+    return `${summary}\nFailed (${failures.length}) - address or drop these items:\n${failureLines}${moreInfo}`
 }
 
 function hasUpdatesToMake({ id: _id, ...otherUpdateArgs }: TaskUpdate) {

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -101,7 +101,7 @@ const OutputSchema = {
     failures: z
         .array(FailureSchema)
         .describe(
-            'Tasks that could not be updated, with the reason for each. A failure here does not affect the other tasks in the batch — do not retry the whole batch; address or drop the failed items.',
+            'Tasks that could not be updated, with the reason for each. A failure here does not affect the other tasks in the batch.',
         ),
     appliedOperations: z
         .object({
@@ -136,17 +136,25 @@ const updateTasks = {
         let skippedCount = 0
 
         settled.forEach((result, index) => {
+            const item = tasks[index]?.id ?? `Task ${index + 1}`
+
             if (result.status === 'fulfilled') {
-                if (result.value === undefined) {
+                const outcome = result.value
+                if (outcome.kind === 'skipped') {
                     skippedCount++
-                } else {
-                    updatedTasks.push(result.value)
+                    return
+                }
+                // Both 'applied' and 'partial' changed the task, so it's part of the
+                // results; a partial additionally records what still needs retrying.
+                updatedTasks.push(outcome.task)
+                if (outcome.kind === 'partial') {
+                    failures.push({ item, error: outcome.error })
                 }
                 return
             }
 
             failures.push({
-                item: tasks[index]?.id ?? `Task ${index + 1}`,
+                item,
                 error:
                     result.reason instanceof Error ? result.reason.message : String(result.reason),
             })
@@ -187,14 +195,26 @@ const updateTasks = {
 } satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
 
 /**
- * Applies a single task's update and/or move. Returns the resulting task, or
- * `undefined` when the task carries no changes to make (skipped). Throws on API or
- * validation errors so the caller can record a per-task failure without aborting the
- * rest of the batch.
+ * Outcome of applying a single task's changes:
+ * - `skipped`: the task carried no changes to make.
+ * - `applied`: every requested change succeeded; `task` is the final state.
+ * - `partial`: the move succeeded but the follow-up field update failed. `task` is the
+ *   moved task (so the completed move isn't discarded) and `error` explains what still
+ *   needs retrying. Anything else throws, so a pure failure is recorded by the caller.
  */
-async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<Task | undefined> {
+type TaskOutcome =
+    | { kind: 'skipped' }
+    | { kind: 'applied'; task: Task }
+    | { kind: 'partial'; task: Task; error: string }
+
+/**
+ * Applies a single task's update and/or move. Throws on API or validation errors that
+ * left nothing applied, so the caller can record a per-task failure without aborting the
+ * rest of the batch. See {@link TaskOutcome} for the success/skip/partial cases.
+ */
+async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<TaskOutcome> {
     if (!hasUpdatesToMake(task)) {
-        return undefined
+        return { kind: 'skipped' }
     }
 
     const {
@@ -286,17 +306,31 @@ async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<
 
     // If no move parameters are provided, use updateTask without moveTask
     if (!resolvedProjectId && !sectionId && !parentId) {
-        return await client.updateTask(id, updateArgs)
+        return { kind: 'applied', task: await client.updateTask(id, updateArgs) }
     }
 
+    // Move first: a forbidden move (e.g. out of a workspace) fails here before any field
+    // update runs, keeping that common case a clean "nothing applied" failure.
     const moveArgs = createMoveTaskArgs(id, resolvedProjectId, sectionId, parentId)
     const movedTask = await client.moveTask(id, moveArgs)
 
-    if (Object.keys(updateArgs).length > 0) {
-        return await client.updateTask(id, updateArgs)
+    if (Object.keys(updateArgs).length === 0) {
+        return { kind: 'applied', task: movedTask }
     }
 
-    return movedTask
+    // The move is now applied server-side. If the follow-up field update fails, report a
+    // partial success rather than a pure failure — otherwise the completed move would be
+    // discarded and the caller told to replay the whole item (re-doing the move).
+    try {
+        return { kind: 'applied', task: await client.updateTask(id, updateArgs) }
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+            kind: 'partial',
+            task: movedTask,
+            error: `Move applied, but updating the other fields failed: ${message}. The move is already done; only the field changes did not apply.`,
+        }
+    }
 }
 
 function generateTextContent({

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -1,7 +1,6 @@
 import type { Task, TodoistApi, UpdateTaskArgs } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
-import { formatToolExecutionError } from '../tool-execution-error.js'
 import { createMoveTaskArgs, mapTask, resolveInboxProjectId } from '../tool-helpers.js'
 import { assignmentValidator } from '../utils/assignment-validator.js'
 import { DisplayLimits } from '../utils/constants.js'
@@ -148,7 +147,8 @@ const updateTasks = {
 
             failures.push({
                 item: tasks[index]?.id ?? `Task ${index + 1}`,
-                error: formatToolExecutionError(result.reason),
+                error:
+                    result.reason instanceof Error ? result.reason.message : String(result.reason),
             })
         })
 

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -12,6 +12,7 @@ import {
     PrioritySchema,
 } from '../utils/priorities.js'
 import { summarizeTaskOperation } from '../utils/response-builders.js'
+import { executeWithRetry } from '../utils/retry.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 const TasksUpdateSchema = z.object({
@@ -90,8 +91,16 @@ const DUE_DATE_REMOVAL_ALIASES = ['remove', 'no date'] as const
 const DEADLINE_REMOVAL_ALIASES = ['remove', 'no date', 'no deadline'] as const
 const DUE_DATE_REMOVAL_VALUE = 'no date' as const
 
+// Cap the batch size (matching add-tasks) so a single call can't fan out an unbounded
+// number of concurrent SDK requests or buffer an unbounded failures response.
+const MAX_TASKS_PER_OPERATION = 25
+
 const ArgsSchema = {
-    tasks: z.array(TasksUpdateSchema).min(1).describe('The tasks to update.'),
+    tasks: z
+        .array(TasksUpdateSchema)
+        .min(1)
+        .max(MAX_TASKS_PER_OPERATION)
+        .describe(`The tasks to update (max ${MAX_TASKS_PER_OPERATION}).`),
 }
 
 const OutputSchema = {
@@ -263,16 +272,21 @@ async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<
         }
     }
 
+    // Each SDK call goes through executeWithRetry so transient 5xx responses (502/503/504)
+    // are retried per item. The registerTool() wrapper's retry only fires when execute()
+    // throws, which never happens now that we settle each task — and the SDK transport
+    // only retries network/timeout errors, not 5xx responses.
+
     // If no move parameters are provided, use updateTask without moveTask
     if (!resolvedProjectId && !sectionId && !parentId) {
-        return await client.updateTask(id, updateArgs)
+        return await executeWithRetry(() => client.updateTask(id, updateArgs))
     }
 
     const moveArgs = createMoveTaskArgs(id, resolvedProjectId, sectionId, parentId)
-    const movedTask = await client.moveTask(id, moveArgs)
+    const movedTask = await executeWithRetry(() => client.moveTask(id, moveArgs))
 
     if (Object.keys(updateArgs).length > 0) {
-        return await client.updateTask(id, updateArgs)
+        return await executeWithRetry(() => client.updateTask(id, updateArgs))
     }
 
     return movedTask

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -136,25 +136,17 @@ const updateTasks = {
         let skippedCount = 0
 
         settled.forEach((result, index) => {
-            const item = tasks[index]?.id ?? `Task ${index + 1}`
-
             if (result.status === 'fulfilled') {
-                const outcome = result.value
-                if (outcome.kind === 'skipped') {
+                if (result.value === undefined) {
                     skippedCount++
-                    return
-                }
-                // Both 'applied' and 'partial' changed the task, so it's part of the
-                // results; a partial additionally records what still needs retrying.
-                updatedTasks.push(outcome.task)
-                if (outcome.kind === 'partial') {
-                    failures.push({ item, error: outcome.error })
+                } else {
+                    updatedTasks.push(result.value)
                 }
                 return
             }
 
             failures.push({
-                item,
+                item: tasks[index]?.id ?? `Task ${index + 1}`,
                 error:
                     result.reason instanceof Error ? result.reason.message : String(result.reason),
             })
@@ -190,26 +182,14 @@ const updateTasks = {
 } satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
 
 /**
- * Outcome of applying a single task's changes:
- * - `skipped`: the task carried no changes to make.
- * - `applied`: every requested change succeeded; `task` is the final state.
- * - `partial`: the move succeeded but the follow-up field update failed. `task` is the
- *   moved task (so the completed move isn't discarded) and `error` explains what still
- *   needs retrying. Anything else throws, so a pure failure is recorded by the caller.
+ * Applies a single task's update and/or move. Returns the resulting task, or `undefined`
+ * when the task carries no changes to make (skipped). Throws on any API or validation
+ * error, so the caller records the whole task as a per-task failure without aborting the
+ * rest of the batch.
  */
-type TaskOutcome =
-    | { kind: 'skipped' }
-    | { kind: 'applied'; task: Task }
-    | { kind: 'partial'; task: Task; error: string }
-
-/**
- * Applies a single task's update and/or move. Throws on API or validation errors that
- * left nothing applied, so the caller can record a per-task failure without aborting the
- * rest of the batch. See {@link TaskOutcome} for the success/skip/partial cases.
- */
-async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<TaskOutcome> {
+async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<Task | undefined> {
     if (!hasUpdatesToMake(task)) {
-        return { kind: 'skipped' }
+        return undefined
     }
 
     const {
@@ -301,31 +281,17 @@ async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<
 
     // If no move parameters are provided, use updateTask without moveTask
     if (!resolvedProjectId && !sectionId && !parentId) {
-        return { kind: 'applied', task: await client.updateTask(id, updateArgs) }
+        return await client.updateTask(id, updateArgs)
     }
 
-    // Move first: a forbidden move (e.g. out of a workspace) fails here before any field
-    // update runs, keeping that common case a clean "nothing applied" failure.
     const moveArgs = createMoveTaskArgs(id, resolvedProjectId, sectionId, parentId)
     const movedTask = await client.moveTask(id, moveArgs)
 
-    if (Object.keys(updateArgs).length === 0) {
-        return { kind: 'applied', task: movedTask }
+    if (Object.keys(updateArgs).length > 0) {
+        return await client.updateTask(id, updateArgs)
     }
 
-    // The move is now applied server-side. If the follow-up field update fails, report a
-    // partial success rather than a pure failure — otherwise the completed move would be
-    // discarded and the caller told to replay the whole item (re-doing the move).
-    try {
-        return { kind: 'applied', task: await client.updateTask(id, updateArgs) }
-    } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        return {
-            kind: 'partial',
-            task: movedTask,
-            error: `Move applied, but updating the other fields failed: ${message}. The move is already done; only the field changes did not apply.`,
-        }
-    }
+    return movedTask
 }
 
 function generateTextContent({

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -4,7 +4,7 @@ import type { TodoistTool } from '../todoist-tool.js'
 import { formatBatchItemError } from '../tool-execution-error.js'
 import { createMoveTaskArgs, mapTask, resolveInboxProjectId } from '../tool-helpers.js'
 import { assignmentValidator } from '../utils/assignment-validator.js'
-import { DisplayLimits } from '../utils/constants.js'
+import { BatchLimits, DisplayLimits } from '../utils/constants.js'
 import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
 import { FailureSchema, TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
 import {
@@ -69,7 +69,11 @@ const TasksUpdateSchema = z.object({
             'The duration of the task. Use format: "2h" (hours), "90m" (minutes), "2h30m" (combined), or "1.5h" (decimal hours). Max 24h.',
         ),
     responsibleUser: z
-        .string()
+        .preprocess(
+            // Keep accepting legacy null while exposing a Gemini-compatible string schema.
+            (value) => (value === null ? 'unassign' : value),
+            z.string(),
+        )
         .optional()
         .describe(
             'Change task assignment. Use "unassign" to remove assignment. Can be "me" (assigns to current user), a user ID, name, or email. User must be a project collaborator.',
@@ -99,7 +103,7 @@ const DUE_DATE_REMOVAL_VALUE = 'no date' as const
 
 // Cap the batch size (matching add-tasks) so a single call can't fan out an unbounded
 // number of concurrent SDK requests or buffer an unbounded failures response.
-const MAX_TASKS_PER_OPERATION = 25
+const MAX_TASKS_PER_OPERATION = BatchLimits.TASKS_PER_OPERATION
 
 const ArgsSchema = {
     tasks: z
@@ -134,7 +138,9 @@ const updateTasks = {
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
     async execute(args, client) {
-        const { tasks } = args
+        // Direct callers bypass the MCP schema parser, so parse here as well to enforce
+        // transforms and the batch cap before starting concurrent work.
+        const { tasks } = z.object(ArgsSchema).parse(args)
 
         // Each task is updated independently. A failure on one task (for example, the
         // API rejecting a move with "Not allowed to move objects out of a workspace")
@@ -147,7 +153,7 @@ const updateTasks = {
         )
 
         const updatedTasks: Task[] = []
-        const failures: Array<{ item: string; error: string }> = []
+        const failures: Array<{ item: string; error: string; code?: string }> = []
         let skippedCount = 0
 
         for (const [index, result] of settled.entries()) {
@@ -162,6 +168,7 @@ const updateTasks = {
                     failures.push({
                         item: tasks[index]?.id ?? `Task ${index + 1}`,
                         error: result.value.error,
+                        code: 'PARTIAL_MOVE_APPLIED',
                     })
                 }
                 continue
@@ -228,10 +235,9 @@ async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<
     } = task
 
     // Resolve "inbox" to actual inbox project ID if needed
-    const resolvedProjectId = await resolveInboxProjectId({
-        projectId,
-        client,
-    })
+    const resolvedProjectId = await executeWithRetry(() =>
+        resolveInboxProjectId({ projectId, client }),
+    )
 
     let updateArgs: UpdateTaskArgs = {
         ...otherUpdateArgs,
@@ -353,7 +359,7 @@ function generateTextContent({
     skippedCount,
 }: {
     tasks: ReturnType<typeof mapTask>[]
-    failures: Array<{ item: string; error: string }>
+    failures: Array<{ item: string; error: string; code?: string }>
     skippedCount: number
 }) {
     const contextParts: string[] = []

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -1,6 +1,7 @@
 import type { Task, TodoistApi, UpdateTaskArgs } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
+import { formatBatchItemError } from '../tool-execution-error.js'
 import { createMoveTaskArgs, mapTask, resolveInboxProjectId } from '../tool-helpers.js'
 import { assignmentValidator } from '../utils/assignment-validator.js'
 import { DisplayLimits } from '../utils/constants.js'
@@ -87,6 +88,11 @@ const TasksUpdateSchema = z.object({
 
 type TaskUpdate = z.infer<typeof TasksUpdateSchema>
 
+type TaskUpdateOutcome =
+    | { kind: 'skipped' }
+    | { kind: 'updated'; task: Task }
+    | { kind: 'partial'; task: Task; error: string }
+
 const DUE_DATE_REMOVAL_ALIASES = ['remove', 'no date'] as const
 const DEADLINE_REMOVAL_ALIASES = ['remove', 'no date', 'no deadline'] as const
 const DUE_DATE_REMOVAL_VALUE = 'no date' as const
@@ -146,18 +152,24 @@ const updateTasks = {
 
         for (const [index, result] of settled.entries()) {
             if (result.status === 'fulfilled') {
-                if (result.value === undefined) {
+                if (result.value.kind === 'skipped') {
                     skippedCount++
-                } else {
-                    updatedTasks.push(result.value)
+                    continue
+                }
+
+                updatedTasks.push(result.value.task)
+                if (result.value.kind === 'partial') {
+                    failures.push({
+                        item: tasks[index]?.id ?? `Task ${index + 1}`,
+                        error: result.value.error,
+                    })
                 }
                 continue
             }
 
             failures.push({
                 item: tasks[index]?.id ?? `Task ${index + 1}`,
-                error:
-                    result.reason instanceof Error ? result.reason.message : String(result.reason),
+                error: formatBatchItemError(result.reason),
             })
         }
 
@@ -191,14 +203,14 @@ const updateTasks = {
 } satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
 
 /**
- * Applies a single task's update and/or move. Returns the resulting task, or `undefined`
- * when the task carries no changes to make (skipped). Throws on any API or validation
- * error, so the caller records the whole task as a per-task failure without aborting the
- * rest of the batch.
+ * Applies a single task's update and/or move. A move followed by a failed field update is
+ * returned as a partial outcome because the move already changed server state. Other API
+ * and validation errors throw so the caller records the task as a failure without aborting
+ * the rest of the batch.
  */
-async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<Task | undefined> {
+async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<TaskUpdateOutcome> {
     if (!hasUpdatesToMake(task)) {
-        return undefined
+        return { kind: 'skipped' }
     }
 
     const {
@@ -279,17 +291,31 @@ async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<
 
     // If no move parameters are provided, use updateTask without moveTask
     if (!resolvedProjectId && !sectionId && !parentId) {
-        return await executeWithRetry(() => client.updateTask(id, updateArgs))
+        return {
+            kind: 'updated',
+            task: await executeWithRetry(() => client.updateTask(id, updateArgs)),
+        }
     }
 
     const moveArgs = createMoveTaskArgs(id, resolvedProjectId, sectionId, parentId)
     const movedTask = await executeWithRetry(() => client.moveTask(id, moveArgs))
 
     if (Object.keys(updateArgs).length > 0) {
-        return await executeWithRetry(() => client.updateTask(id, updateArgs))
+        try {
+            return {
+                kind: 'updated',
+                task: await executeWithRetry(() => client.updateTask(id, updateArgs)),
+            }
+        } catch (error) {
+            return {
+                kind: 'partial',
+                task: movedTask,
+                error: `Move applied; field update failed: ${formatBatchItemError(error)}`,
+            }
+        }
     }
 
-    return movedTask
+    return { kind: 'updated', task: movedTask }
 }
 
 /**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -51,6 +51,12 @@ export const DisplayLimits = {
     BATCH_OPERATION_THRESHOLD: 10,
 } as const
 
+// Batch Operation Limits
+export const BatchLimits = {
+    /** Maximum tasks accepted by one task create or update operation */
+    TASKS_PER_OPERATION: 25,
+} as const
+
 // Response Builder Configuration
 export const ResponseConfig = {
     /** Maximum characters per line in text responses */


### PR DESCRIPTION
# Overview

`update-tasks` previously used `Promise.all`, so one rejected item discarded every successful result and surfaced an opaque tool failure. This refresh settles items independently and returns structured per-task `failures`, including when every item fails.

The batch is capped at 25 items and transient 502/503/504 responses are retried per item. API failure details retain the specific Todoist error rather than only the SDK’s generic HTTP status.

A move followed by a failed field update is reported as a partial outcome: the moved task remains in `tasks`/`updatedTaskIds`, while `failures` says that the move was applied and the field update failed. This prevents callers from treating an already-applied move as an untouched item.

## Reference

- Helps with https://github.com/Doist/Issues/issues/20441
- Aligns with https://github.com/Doist/todoist-mcp/issues/505

## Verification

- `npm test`
- `npm run type-check`
- `npm run format:check`
- `npm run build`