### PR TITLE
fix(projects,sections): Report per-item failures instead of failing the whole batch

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -136,7 +136,7 @@ New tool? Full checklist in `AGENTS.md`. Short version: copy `add-tasks.ts`; imp
 - `reminder-schemas.ts` — reminder-specific shapes
 - `assignment-validator.ts` — validate collaborator assignments
 - `user-resolver.ts` / `workspace-resolver.ts` — resolve user/workspace refs
-- `response-builders.ts` — `summarizeTaskOperation`, `summarizeBatch`, `previewTasks` (keep output messages consistent)
+- `response-builders.ts` — `summarizeTaskOperation`, `summarizeBatch`, `appendFailureSummary`, `previewTasks` (keep output messages consistent)
 - `retry.ts` — `executeWithRetry()` used inside `registerTool`
 - `sanitize-data.ts` — HTML sanitization (dompurify) for comment content
 - `validate-todoist-token.ts` — token validation for HTTP middleware

--- a/src/tools/add-projects.test.ts
+++ b/src/tools/add-projects.test.ts
@@ -529,43 +529,81 @@ describe(`${ADD_PROJECTS} tool`, () => {
             expect(mockTodoistApi.getWorkspaces).toHaveBeenCalledTimes(1)
         })
 
-        it('should throw when workspace name is ambiguous', async () => {
+        it('reports an ambiguous workspace reference as a per-project failure', async () => {
             const mockWorkspaces = [
                 createMockWorkspace({ id: '555', name: 'Engineering Team' }),
                 createMockWorkspace({ id: '666', name: 'Marketing Team' }),
             ]
             mockTodoistApi.getWorkspaces.mockResolvedValue(mockWorkspaces)
 
-            await expect(
-                addProjects.execute(
-                    { projects: [{ name: 'Project', workspace: 'Team' }] },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow(/Ambiguous workspace reference/)
+            const result = await addProjects.execute(
+                { projects: [{ name: 'Project', workspace: 'Team' }] },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.projects).toHaveLength(0)
+            expect(result.structuredContent.failures).toEqual([
+                expect.objectContaining({
+                    item: 'Project',
+                    error: expect.stringMatching(/Ambiguous workspace reference/),
+                }),
+            ])
         })
 
-        it('should throw when workspace name is not found', async () => {
+        it('reports a missing workspace as a per-project failure', async () => {
             mockTodoistApi.getWorkspaces.mockResolvedValue([
                 createMockWorkspace({ id: '777', name: 'Engineering' }),
             ])
 
-            await expect(
-                addProjects.execute(
-                    { projects: [{ name: 'Project', workspace: 'Nonexistent' }] },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow(/Workspace "Nonexistent" not found/)
+            const result = await addProjects.execute(
+                { projects: [{ name: 'Project', workspace: 'Nonexistent' }] },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.failures).toEqual([
+                expect.objectContaining({
+                    item: 'Project',
+                    error: expect.stringMatching(/Workspace "Nonexistent" not found/),
+                }),
+            ])
+        })
+
+        it('keeps personal-project successes when another project has an invalid workspace', async () => {
+            mockTodoistApi.getWorkspaces.mockResolvedValue([
+                createMockWorkspace({ id: '777', name: 'Engineering' }),
+            ])
+            mockTodoistApi.addProject.mockResolvedValue(
+                createMockProject({ id: 'personal-project', name: 'Personal project' }),
+            )
+
+            const result = await addProjects.execute(
+                {
+                    projects: [
+                        { name: 'Workspace project', workspace: 'Nonexistent' },
+                        { name: 'Personal project' },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.projects).toHaveLength(1)
+            expect(result.structuredContent.projects[0]?.id).toBe('personal-project')
+            expect(result.structuredContent.failures).toEqual([
+                expect.objectContaining({ item: 'Workspace project' }),
+            ])
         })
     })
 
     describe('error handling', () => {
-        it('should propagate API errors', async () => {
+        it('reports API errors as structured failures', async () => {
             const apiError = new Error('API Error: Project name is required')
             mockTodoistApi.addProject.mockRejectedValue(apiError)
 
-            await expect(
-                addProjects.execute({ projects: [{ name: '' }] }, mockTodoistApi),
-            ).rejects.toThrow('API Error: Project name is required')
+            const result = await addProjects.execute({ projects: [{ name: '' }] }, mockTodoistApi)
+
+            expect(result.structuredContent.failures).toEqual([
+                expect.objectContaining({ item: '', error: 'API Error: Project name is required' }),
+            ])
         })
 
         it('retries a transient 5xx failure on a per-item call via the retry helper', async () => {
@@ -631,22 +669,28 @@ describe(`${ADD_PROJECTS} tool`, () => {
 
             expect(result.textContent).toContain('Added 1 project:')
             expect(result.textContent).toContain('Failed (1)')
-            expect(result.textContent).toContain('not retried automatically')
+            expect(result.textContent).toContain('address or drop these items')
         })
 
-        it('should throw when every project in the batch fails', async () => {
+        it('returns structured failures when every project in the batch fails', async () => {
             mockTodoistApi.addProject
                 .mockRejectedValueOnce(new Error('API Error: Invalid project name'))
                 .mockRejectedValueOnce(new Error('API Error: Invalid project name'))
 
-            await expect(
-                addProjects.execute(
-                    {
-                        projects: [{ name: 'Invalid 1' }, { name: 'Invalid 2' }],
-                    },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow('All 2 project(s) failed to create')
+            const result = await addProjects.execute(
+                {
+                    projects: [{ name: 'Invalid 1' }, { name: 'Invalid 2' }],
+                },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.projects).toEqual([])
+            expect(result.structuredContent.successCount).toBe(0)
+            expect(result.structuredContent.failureCount).toBe(2)
+            expect(result.structuredContent.failures.map((failure) => failure.item)).toEqual([
+                'Invalid 1',
+                'Invalid 2',
+            ])
         })
     })
 })

--- a/src/tools/add-projects.test.ts
+++ b/src/tools/add-projects.test.ts
@@ -568,6 +568,35 @@ describe(`${ADD_PROJECTS} tool`, () => {
             ).rejects.toThrow('API Error: Project name is required')
         })
 
+        it('retries a transient 5xx failure on a per-item call via the retry helper', async () => {
+            // A per-item transient error must still get backoff+retry (it used to bubble
+            // up to the registerTool wrapper before the batch was settled per item). The
+            // first attempt fails with 503, the retry succeeds, so the item is reported as
+            // a success rather than a permanent failure.
+            vi.useFakeTimers()
+            try {
+                const okProject = createMockProject({ id: 'p-retry', name: 'Eventually OK' })
+                mockTodoistApi.addProject
+                    .mockRejectedValueOnce(
+                        Object.assign(new Error('Service Unavailable'), { httpStatusCode: 503 }),
+                    )
+                    .mockResolvedValueOnce(okProject)
+
+                const promise = addProjects.execute(
+                    { projects: [{ name: 'Eventually OK' }] },
+                    mockTodoistApi,
+                )
+                await vi.runAllTimersAsync()
+                const result = await promise
+
+                expect(mockTodoistApi.addProject).toHaveBeenCalledTimes(2)
+                expect(result.structuredContent.projects).toHaveLength(1)
+                expect(result.structuredContent.failureCount).toBe(0)
+            } finally {
+                vi.useRealTimers()
+            }
+        })
+
         it('should keep successful projects when one in the batch fails', async () => {
             const mockProject = createMockProject({
                 id: 'project-1',

--- a/src/tools/add-projects.test.ts
+++ b/src/tools/add-projects.test.ts
@@ -568,7 +568,7 @@ describe(`${ADD_PROJECTS} tool`, () => {
             ).rejects.toThrow('API Error: Project name is required')
         })
 
-        it('should handle partial failures in multiple projects', async () => {
+        it('should keep successful projects when one in the batch fails', async () => {
             const mockProject = createMockProject({
                 id: 'project-1',
                 name: 'First Project',
@@ -578,14 +578,46 @@ describe(`${ADD_PROJECTS} tool`, () => {
                 .mockResolvedValueOnce(mockProject)
                 .mockRejectedValueOnce(new Error('API Error: Invalid project name'))
 
+            const result = await addProjects.execute(
+                {
+                    projects: [{ name: 'First Project' }, { name: 'Invalid' }],
+                },
+                mockTodoistApi,
+            )
+
+            // The successful project is preserved instead of being discarded by the failure.
+            const { structuredContent } = result
+            expect(structuredContent.projects).toHaveLength(1)
+            expect(structuredContent.totalCount).toBe(1)
+            expect(structuredContent.successCount).toBe(1)
+            expect(structuredContent.totalRequested).toBe(2)
+
+            // The failure is reported per-item with the offending project identified by name.
+            expect(structuredContent.failureCount).toBe(1)
+            expect(structuredContent.failures).toHaveLength(1)
+            expect(structuredContent.failures[0]?.item).toBe('Invalid')
+            expect(structuredContent.failures[0]?.error).toContain(
+                'API Error: Invalid project name',
+            )
+
+            expect(result.textContent).toContain('Added 1 project:')
+            expect(result.textContent).toContain('Failed (1)')
+            expect(result.textContent).toContain('not retried automatically')
+        })
+
+        it('should throw when every project in the batch fails', async () => {
+            mockTodoistApi.addProject
+                .mockRejectedValueOnce(new Error('API Error: Invalid project name'))
+                .mockRejectedValueOnce(new Error('API Error: Invalid project name'))
+
             await expect(
                 addProjects.execute(
                     {
-                        projects: [{ name: 'First Project' }, { name: 'Invalid' }],
+                        projects: [{ name: 'Invalid 1' }, { name: 'Invalid 2' }],
                     },
                     mockTodoistApi,
                 ),
-            ).rejects.toThrow('API Error: Invalid project name')
+            ).rejects.toThrow('All 2 project(s) failed to create')
         })
     })
 })

--- a/src/tools/add-projects.ts
+++ b/src/tools/add-projects.ts
@@ -137,7 +137,10 @@ function generateTextContent({
     const count = projects.length
     const projectList = projects.map((project) => `• ${project.name} (id=${project.id})`).join('\n')
 
-    const summary = `Added ${count} project${count === 1 ? '' : 's'}:\n${projectList}`
+    const summary =
+        count > 0
+            ? `Added ${count} project${count === 1 ? '' : 's'}:\n${projectList}`
+            : 'Added 0 projects'
 
     return appendFailureSummary(summary, failures)
 }

--- a/src/tools/add-projects.ts
+++ b/src/tools/add-projects.ts
@@ -1,7 +1,7 @@
 import type { PersonalProject, WorkspaceProject } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
-import { formatToolExecutionError } from '../tool-execution-error.js'
+import { formatBatchItemError } from '../tool-execution-error.js'
 import { mapProject } from '../tool-helpers.js'
 import { ColorSchema } from '../utils/colors.js'
 import { FailureSchema, ProjectSchema as ProjectOutputSchema } from '../utils/output-schemas.js'
@@ -64,17 +64,22 @@ const addProjects = {
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     async execute({ projects }, client) {
-        // Collect unique workspace references and resolve each once. Resolution failures
-        // (ambiguous/unknown workspace) are validation errors that should fail loudly,
-        // so they stay outside the per-project settle below.
-        const uniqueWorkspaceRefs = [
-            ...new Set(projects.map((p) => p.workspace).filter(Boolean)),
-        ] as string[]
+        const workspaceResolutions = new Map<string, Promise<string>>()
 
-        const resolvedWorkspaces = new Map<string, string>()
-        for (const ref of uniqueWorkspaceRefs) {
-            const resolved = await workspaceResolver.resolveWorkspace(client, ref)
-            resolvedWorkspaces.set(ref, resolved.workspaceId)
+        const resolveWorkspaceId = (workspace: string | undefined) => {
+            if (!workspace) {
+                return Promise.resolve(undefined)
+            }
+
+            let resolution = workspaceResolutions.get(workspace)
+            if (!resolution) {
+                resolution = executeWithRetry(() =>
+                    workspaceResolver.resolveWorkspace(client, workspace),
+                ).then(({ workspaceId }) => workspaceId)
+                workspaceResolutions.set(workspace, resolution)
+            }
+
+            return resolution
         }
 
         // Each project is created independently: a failure on one (for example, the API
@@ -83,9 +88,9 @@ const addProjects = {
         // Per-item calls go through executeWithRetry so transient 5xx failures still get
         // the same backoff the registerTool() wrapper applies to single-call tools.
         const settled = await Promise.allSettled(
-            projects.map(({ workspace, ...rest }) => {
-                const workspaceId = workspace ? resolvedWorkspaces.get(workspace) : undefined
-                return executeWithRetry(() =>
+            projects.map(async ({ workspace, ...rest }) => {
+                const workspaceId = await resolveWorkspaceId(workspace)
+                return await executeWithRetry(() =>
                     client.addProject({ ...rest, ...(workspaceId ? { workspaceId } : {}) }),
                 )
             }),
@@ -100,16 +105,10 @@ const addProjects = {
             } else {
                 failures.push({
                     item: projects[index]?.name ?? `Project ${index + 1}`,
-                    error: formatToolExecutionError(result.reason),
+                    error: formatBatchItemError(result.reason),
                 })
             }
         })
-
-        // If every project failed, surface a hard error instead of a misleading success.
-        if (newProjects.length === 0 && failures.length > 0) {
-            const details = failures.map((f) => `"${f.item}": ${f.error}`).join('; ')
-            throw new Error(`All ${failures.length} project(s) failed to create: ${details}`)
-        }
 
         const mappedProjects = newProjects.map(mapProject)
         const textContent = generateTextContent({ projects: newProjects, failures })

--- a/src/tools/add-projects.ts
+++ b/src/tools/add-projects.ts
@@ -4,8 +4,9 @@ import type { TodoistTool } from '../todoist-tool.js'
 import { formatToolExecutionError } from '../tool-execution-error.js'
 import { mapProject } from '../tool-helpers.js'
 import { ColorSchema } from '../utils/colors.js'
-import { DisplayLimits } from '../utils/constants.js'
 import { FailureSchema, ProjectSchema as ProjectOutputSchema } from '../utils/output-schemas.js'
+import { appendFailureSummary } from '../utils/response-builders.js'
+import { executeWithRetry } from '../utils/retry.js'
 import { ToolNames } from '../utils/tool-names.js'
 import { workspaceResolver } from '../utils/workspace-resolver.js'
 
@@ -79,10 +80,14 @@ const addProjects = {
         // Each project is created independently: a failure on one (for example, the API
         // rejecting it with a 403 permission error) must not discard the projects that
         // succeeded nor collapse into one opaque batch error that invites a full retry.
+        // Per-item calls go through executeWithRetry so transient 5xx failures still get
+        // the same backoff the registerTool() wrapper applies to single-call tools.
         const settled = await Promise.allSettled(
             projects.map(({ workspace, ...rest }) => {
                 const workspaceId = workspace ? resolvedWorkspaces.get(workspace) : undefined
-                return client.addProject({ ...rest, ...(workspaceId ? { workspaceId } : {}) })
+                return executeWithRetry(() =>
+                    client.addProject({ ...rest, ...(workspaceId ? { workspaceId } : {}) }),
+                )
             }),
         )
 
@@ -135,16 +140,7 @@ function generateTextContent({
 
     const summary = `Added ${count} project${count === 1 ? '' : 's'}:\n${projectList}`
 
-    if (failures.length === 0) {
-        return summary
-    }
-
-    const shown = failures.slice(0, DisplayLimits.MAX_FAILURES_SHOWN)
-    const remaining = failures.length - shown.length
-    const failureLines = shown.map((f) => `    ${f.item}: ${f.error}`).join('\n')
-    const moreInfo = remaining > 0 ? `\n    +${remaining} more` : ''
-
-    return `${summary}\nFailed (${failures.length}) - not retried automatically; address or drop these items:\n${failureLines}${moreInfo}`
+    return appendFailureSummary(summary, failures)
 }
 
 export { addProjects }

--- a/src/tools/add-projects.ts
+++ b/src/tools/add-projects.ts
@@ -1,9 +1,11 @@
 import type { PersonalProject, WorkspaceProject } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
+import { formatToolExecutionError } from '../tool-execution-error.js'
 import { mapProject } from '../tool-helpers.js'
 import { ColorSchema } from '../utils/colors.js'
-import { ProjectSchema as ProjectOutputSchema } from '../utils/output-schemas.js'
+import { DisplayLimits } from '../utils/constants.js'
+import { FailureSchema, ProjectSchema as ProjectOutputSchema } from '../utils/output-schemas.js'
 import { ToolNames } from '../utils/tool-names.js'
 import { workspaceResolver } from '../utils/workspace-resolver.js'
 
@@ -44,6 +46,14 @@ const ArgsSchema = {
 const OutputSchema = {
     projects: z.array(ProjectOutputSchema).describe('The created projects.'),
     totalCount: z.number().describe('The total number of projects created.'),
+    failures: z
+        .array(FailureSchema)
+        .describe(
+            'Projects that could not be created, with the reason for each. A failure here does not affect the other projects in the batch — do not retry the whole batch; address or drop the failed items.',
+        ),
+    totalRequested: z.number().describe('The total number of projects requested.'),
+    successCount: z.number().describe('The number of successfully created projects.'),
+    failureCount: z.number().describe('The number of failed project creations.'),
 }
 
 const addProjects = {
@@ -53,7 +63,9 @@ const addProjects = {
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     async execute({ projects }, client) {
-        // Collect unique workspace references and resolve each once
+        // Collect unique workspace references and resolve each once. Resolution failures
+        // (ambiguous/unknown workspace) are validation errors that should fail loudly,
+        // so they stay outside the per-project settle below.
         const uniqueWorkspaceRefs = [
             ...new Set(projects.map((p) => p.workspace).filter(Boolean)),
         ] as string[]
@@ -64,32 +76,75 @@ const addProjects = {
             resolvedWorkspaces.set(ref, resolved.workspaceId)
         }
 
-        const newProjects = await Promise.all(
+        // Each project is created independently: a failure on one (for example, the API
+        // rejecting it with a 403 permission error) must not discard the projects that
+        // succeeded nor collapse into one opaque batch error that invites a full retry.
+        const settled = await Promise.allSettled(
             projects.map(({ workspace, ...rest }) => {
                 const workspaceId = workspace ? resolvedWorkspaces.get(workspace) : undefined
                 return client.addProject({ ...rest, ...(workspaceId ? { workspaceId } : {}) })
             }),
         )
-        const textContent = generateTextContent({ projects: newProjects })
+
+        const newProjects: (PersonalProject | WorkspaceProject)[] = []
+        const failures: Array<{ item: string; error: string }> = []
+
+        settled.forEach((result, index) => {
+            if (result.status === 'fulfilled') {
+                newProjects.push(result.value)
+            } else {
+                failures.push({
+                    item: projects[index]?.name ?? `Project ${index + 1}`,
+                    error: formatToolExecutionError(result.reason),
+                })
+            }
+        })
+
+        // If every project failed, surface a hard error instead of a misleading success.
+        if (newProjects.length === 0 && failures.length > 0) {
+            const details = failures.map((f) => `"${f.item}": ${f.error}`).join('; ')
+            throw new Error(`All ${failures.length} project(s) failed to create: ${details}`)
+        }
+
         const mappedProjects = newProjects.map(mapProject)
+        const textContent = generateTextContent({ projects: newProjects, failures })
 
         return {
             textContent,
             structuredContent: {
                 projects: mappedProjects,
                 totalCount: mappedProjects.length,
+                failures,
+                totalRequested: projects.length,
+                successCount: mappedProjects.length,
+                failureCount: failures.length,
             },
         }
     },
 } satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
 
-function generateTextContent({ projects }: { projects: (PersonalProject | WorkspaceProject)[] }) {
+function generateTextContent({
+    projects,
+    failures,
+}: {
+    projects: (PersonalProject | WorkspaceProject)[]
+    failures: Array<{ item: string; error: string }>
+}) {
     const count = projects.length
     const projectList = projects.map((project) => `• ${project.name} (id=${project.id})`).join('\n')
 
     const summary = `Added ${count} project${count === 1 ? '' : 's'}:\n${projectList}`
 
-    return summary
+    if (failures.length === 0) {
+        return summary
+    }
+
+    const shown = failures.slice(0, DisplayLimits.MAX_FAILURES_SHOWN)
+    const remaining = failures.length - shown.length
+    const failureLines = shown.map((f) => `    ${f.item}: ${f.error}`).join('\n')
+    const moreInfo = remaining > 0 ? `\n    +${remaining} more` : ''
+
+    return `${summary}\nFailed (${failures.length}) - not retried automatically; address or drop these items:\n${failureLines}${moreInfo}`
 }
 
 export { addProjects }

--- a/src/tools/add-sections.test.ts
+++ b/src/tools/add-sections.test.ts
@@ -247,7 +247,7 @@ describe(`${ADD_SECTIONS} tool`, () => {
             ).rejects.toThrow('API Error: Section name is required')
         })
 
-        it('should handle partial failures in multiple sections', async () => {
+        it('should keep successful sections when one in the batch fails', async () => {
             const mockSection = createMockSection({
                 id: 'section-1',
                 projectId: TEST_IDS.PROJECT_TEST,
@@ -258,17 +258,50 @@ describe(`${ADD_SECTIONS} tool`, () => {
                 .mockResolvedValueOnce(mockSection)
                 .mockRejectedValueOnce(new Error('API Error: Invalid project ID'))
 
+            const result = await addSections.execute(
+                {
+                    sections: [
+                        { name: 'First Section', projectId: TEST_IDS.PROJECT_TEST },
+                        { name: 'Second Section', projectId: 'invalid-project' },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            // The successful section is preserved instead of being discarded by the failure.
+            const { structuredContent } = result
+            expect(structuredContent.sections).toHaveLength(1)
+            expect(structuredContent.totalCount).toBe(1)
+            expect(structuredContent.successCount).toBe(1)
+            expect(structuredContent.totalRequested).toBe(2)
+
+            // The failure is reported per-item with the offending section identified by name.
+            expect(structuredContent.failureCount).toBe(1)
+            expect(structuredContent.failures).toHaveLength(1)
+            expect(structuredContent.failures[0]?.item).toBe('Second Section')
+            expect(structuredContent.failures[0]?.error).toContain('API Error: Invalid project ID')
+
+            expect(result.textContent).toContain('Added 1 section:')
+            expect(result.textContent).toContain('Failed (1)')
+            expect(result.textContent).toContain('not retried automatically')
+        })
+
+        it('should throw when every section in the batch fails', async () => {
+            mockTodoistApi.addSection
+                .mockRejectedValueOnce(new Error('API Error: Invalid project ID'))
+                .mockRejectedValueOnce(new Error('API Error: Invalid project ID'))
+
             await expect(
                 addSections.execute(
                     {
                         sections: [
-                            { name: 'First Section', projectId: TEST_IDS.PROJECT_TEST },
-                            { name: 'Second Section', projectId: 'invalid-project' },
+                            { name: 'First Section', projectId: 'invalid-1' },
+                            { name: 'Second Section', projectId: 'invalid-2' },
                         ],
                     },
                     mockTodoistApi,
                 ),
-            ).rejects.toThrow('API Error: Invalid project ID')
+            ).rejects.toThrow('All 2 section(s) failed to create')
         })
     })
 })

--- a/src/tools/add-sections.test.ts
+++ b/src/tools/add-sections.test.ts
@@ -306,6 +306,10 @@ describe(`${ADD_SECTIONS} tool`, () => {
             expect(result.structuredContent.sections).toEqual([])
             expect(result.structuredContent.successCount).toBe(0)
             expect(result.structuredContent.failureCount).toBe(2)
+            expect(result.structuredContent.failures.map((failure) => failure.item)).toEqual([
+                'First Section',
+                'Second Section',
+            ])
         })
 
         it('keeps non-inbox successes when inbox resolution fails', async () => {

--- a/src/tools/add-sections.test.ts
+++ b/src/tools/add-sections.test.ts
@@ -235,16 +235,18 @@ describe(`${ADD_SECTIONS} tool`, () => {
     })
 
     describe('error handling', () => {
-        it('should propagate API errors', async () => {
+        it('reports API errors as structured failures', async () => {
             const apiError = new Error('API Error: Section name is required')
             mockTodoistApi.addSection.mockRejectedValue(apiError)
 
-            await expect(
-                addSections.execute(
-                    { sections: [{ name: '', projectId: TEST_IDS.PROJECT_TEST }] },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow('API Error: Section name is required')
+            const result = await addSections.execute(
+                { sections: [{ name: '', projectId: TEST_IDS.PROJECT_TEST }] },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.failures).toEqual([
+                expect.objectContaining({ item: '', error: 'API Error: Section name is required' }),
+            ])
         })
 
         it('should keep successful sections when one in the batch fails', async () => {
@@ -283,25 +285,57 @@ describe(`${ADD_SECTIONS} tool`, () => {
 
             expect(result.textContent).toContain('Added 1 section:')
             expect(result.textContent).toContain('Failed (1)')
-            expect(result.textContent).toContain('not retried automatically')
+            expect(result.textContent).toContain('address or drop these items')
         })
 
-        it('should throw when every section in the batch fails', async () => {
+        it('returns structured failures when every section in the batch fails', async () => {
             mockTodoistApi.addSection
                 .mockRejectedValueOnce(new Error('API Error: Invalid project ID'))
                 .mockRejectedValueOnce(new Error('API Error: Invalid project ID'))
 
-            await expect(
-                addSections.execute(
-                    {
-                        sections: [
-                            { name: 'First Section', projectId: 'invalid-1' },
-                            { name: 'Second Section', projectId: 'invalid-2' },
-                        ],
-                    },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow('All 2 section(s) failed to create')
+            const result = await addSections.execute(
+                {
+                    sections: [
+                        { name: 'First Section', projectId: 'invalid-1' },
+                        { name: 'Second Section', projectId: 'invalid-2' },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.sections).toEqual([])
+            expect(result.structuredContent.successCount).toBe(0)
+            expect(result.structuredContent.failureCount).toBe(2)
+        })
+
+        it('keeps non-inbox successes when inbox resolution fails', async () => {
+            mockTodoistApi.getUser.mockRejectedValue(new Error('API Error: Cannot resolve inbox'))
+            mockTodoistApi.addSection.mockResolvedValue(
+                createMockSection({
+                    id: 'regular-section',
+                    name: 'Regular section',
+                    projectId: TEST_IDS.PROJECT_TEST,
+                }),
+            )
+
+            const result = await addSections.execute(
+                {
+                    sections: [
+                        { name: 'Inbox section', projectId: 'inbox' },
+                        { name: 'Regular section', projectId: TEST_IDS.PROJECT_TEST },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.sections).toHaveLength(1)
+            expect(result.structuredContent.sections[0]?.id).toBe('regular-section')
+            expect(result.structuredContent.failures).toEqual([
+                expect.objectContaining({
+                    item: 'Inbox section',
+                    error: 'API Error: Cannot resolve inbox',
+                }),
+            ])
         })
     })
 })

--- a/src/tools/add-sections.ts
+++ b/src/tools/add-sections.ts
@@ -3,12 +3,13 @@ import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
 import { formatToolExecutionError } from '../tool-execution-error.js'
 import { isInboxProjectId, resolveInboxProjectId } from '../tool-helpers.js'
-import { DisplayLimits } from '../utils/constants.js'
 import {
     FailureSchema,
     SectionSchema as SectionOutputSchema,
     toSectionSummary,
 } from '../utils/output-schemas.js'
+import { appendFailureSummary } from '../utils/response-builders.js'
+import { executeWithRetry } from '../utils/retry.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 const SectionSchema = z.object({
@@ -56,6 +57,8 @@ const addSections = {
         // Each section is created independently: a failure on one (for example, the API
         // rejecting it with a 403 permission error) must not discard the sections that
         // succeeded nor collapse into one opaque batch error that invites a full retry.
+        // Per-item calls go through executeWithRetry so transient 5xx failures still get
+        // the same backoff the registerTool() wrapper applies to single-call tools.
         const settled = await Promise.allSettled(
             sections.map(async (section) => {
                 const projectId =
@@ -64,7 +67,7 @@ const addSections = {
                         user: todoistUser,
                         client: todoistUser ? undefined : client,
                     })) ?? section.projectId
-                return client.addSection({ ...section, projectId })
+                return executeWithRetry(() => client.addSection({ ...section, projectId }))
             }),
         )
 
@@ -118,23 +121,7 @@ function generateTextContent({
 
     const summary = `Added ${count} section${count === 1 ? '' : 's'}:\n${sectionList}`
 
-    return failures.length === 0 ? summary : appendFailureSummary(summary, failures)
-}
-
-/**
- * Appends a per-item failure block to a success summary, telling the caller these
- * items were not retried automatically so it does not blindly resend the whole batch.
- */
-function appendFailureSummary(
-    summary: string,
-    failures: Array<{ item: string; error: string }>,
-): string {
-    const shown = failures.slice(0, DisplayLimits.MAX_FAILURES_SHOWN)
-    const remaining = failures.length - shown.length
-    const failureLines = shown.map((f) => `    ${f.item}: ${f.error}`).join('\n')
-    const moreInfo = remaining > 0 ? `\n    +${remaining} more` : ''
-
-    return `${summary}\nFailed (${failures.length}) - not retried automatically; address or drop these items:\n${failureLines}${moreInfo}`
+    return appendFailureSummary(summary, failures)
 }
 
 export { addSections }

--- a/src/tools/add-sections.ts
+++ b/src/tools/add-sections.ts
@@ -116,7 +116,10 @@ function generateTextContent({
         .map((section) => `• ${section.name} (id=${section.id}, projectId=${section.projectId})`)
         .join('\n')
 
-    const summary = `Added ${count} section${count === 1 ? '' : 's'}:\n${sectionList}`
+    const summary =
+        count > 0
+            ? `Added ${count} section${count === 1 ? '' : 's'}:\n${sectionList}`
+            : 'Added 0 sections'
 
     return appendFailureSummary(summary, failures)
 }

--- a/src/tools/add-sections.ts
+++ b/src/tools/add-sections.ts
@@ -1,8 +1,14 @@
 import type { Section } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
+import { formatToolExecutionError } from '../tool-execution-error.js'
 import { isInboxProjectId, resolveInboxProjectId } from '../tool-helpers.js'
-import { SectionSchema as SectionOutputSchema, toSectionSummary } from '../utils/output-schemas.js'
+import { DisplayLimits } from '../utils/constants.js'
+import {
+    FailureSchema,
+    SectionSchema as SectionOutputSchema,
+    toSectionSummary,
+} from '../utils/output-schemas.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 const SectionSchema = z.object({
@@ -26,6 +32,14 @@ const ArgsSchema = {
 const OutputSchema = {
     sections: z.array(SectionOutputSchema).describe('The created sections.'),
     totalCount: z.number().describe('The total number of sections created.'),
+    failures: z
+        .array(FailureSchema)
+        .describe(
+            'Sections that could not be created, with the reason for each. A failure here does not affect the other sections in the batch — do not retry the whole batch; address or drop the failed items.',
+        ),
+    totalRequested: z.number().describe('The total number of sections requested.'),
+    successCount: z.number().describe('The number of successfully created sections.'),
+    failureCount: z.number().describe('The number of failed section creations.'),
 }
 
 const addSections = {
@@ -39,35 +53,64 @@ const addSections = {
         const needsInboxResolution = sections.some((section) => isInboxProjectId(section.projectId))
         const todoistUser = needsInboxResolution ? await client.getUser() : undefined
 
-        // Resolve inbox project IDs
-        const sectionsWithResolvedProjectIds = await Promise.all(
-            sections.map(async (section) => ({
-                ...section,
-                projectId:
+        // Each section is created independently: a failure on one (for example, the API
+        // rejecting it with a 403 permission error) must not discard the sections that
+        // succeeded nor collapse into one opaque batch error that invites a full retry.
+        const settled = await Promise.allSettled(
+            sections.map(async (section) => {
+                const projectId =
                     (await resolveInboxProjectId({
                         projectId: section.projectId,
                         user: todoistUser,
                         client: todoistUser ? undefined : client,
-                    })) ?? section.projectId,
-            })),
+                    })) ?? section.projectId
+                return client.addSection({ ...section, projectId })
+            }),
         )
 
-        const newSections = await Promise.all(
-            sectionsWithResolvedProjectIds.map((section) => client.addSection(section)),
-        )
-        const textContent = generateTextContent({ sections: newSections })
+        const newSections: Section[] = []
+        const failures: Array<{ item: string; error: string }> = []
+
+        settled.forEach((result, index) => {
+            if (result.status === 'fulfilled') {
+                newSections.push(result.value)
+            } else {
+                failures.push({
+                    item: sections[index]?.name ?? `Section ${index + 1}`,
+                    error: formatToolExecutionError(result.reason),
+                })
+            }
+        })
+
+        // If every section failed, surface a hard error instead of a misleading success.
+        if (newSections.length === 0 && failures.length > 0) {
+            const details = failures.map((f) => `"${f.item}": ${f.error}`).join('; ')
+            throw new Error(`All ${failures.length} section(s) failed to create: ${details}`)
+        }
+
+        const textContent = generateTextContent({ sections: newSections, failures })
 
         return {
             textContent,
             structuredContent: {
                 sections: newSections.map(toSectionSummary),
                 totalCount: newSections.length,
+                failures,
+                totalRequested: sections.length,
+                successCount: newSections.length,
+                failureCount: failures.length,
             },
         }
     },
 } satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
 
-function generateTextContent({ sections }: { sections: Section[] }) {
+function generateTextContent({
+    sections,
+    failures,
+}: {
+    sections: Section[]
+    failures: Array<{ item: string; error: string }>
+}) {
     const count = sections.length
     const sectionList = sections
         .map((section) => `• ${section.name} (id=${section.id}, projectId=${section.projectId})`)
@@ -75,7 +118,23 @@ function generateTextContent({ sections }: { sections: Section[] }) {
 
     const summary = `Added ${count} section${count === 1 ? '' : 's'}:\n${sectionList}`
 
-    return summary
+    return failures.length === 0 ? summary : appendFailureSummary(summary, failures)
+}
+
+/**
+ * Appends a per-item failure block to a success summary, telling the caller these
+ * items were not retried automatically so it does not blindly resend the whole batch.
+ */
+function appendFailureSummary(
+    summary: string,
+    failures: Array<{ item: string; error: string }>,
+): string {
+    const shown = failures.slice(0, DisplayLimits.MAX_FAILURES_SHOWN)
+    const remaining = failures.length - shown.length
+    const failureLines = shown.map((f) => `    ${f.item}: ${f.error}`).join('\n')
+    const moreInfo = remaining > 0 ? `\n    +${remaining} more` : ''
+
+    return `${summary}\nFailed (${failures.length}) - not retried automatically; address or drop these items:\n${failureLines}${moreInfo}`
 }
 
 export { addSections }

--- a/src/tools/add-sections.ts
+++ b/src/tools/add-sections.ts
@@ -1,7 +1,7 @@
 import type { Section } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
-import { formatToolExecutionError } from '../tool-execution-error.js'
+import { formatBatchItemError } from '../tool-execution-error.js'
 import { isInboxProjectId, resolveInboxProjectId } from '../tool-helpers.js'
 import {
     FailureSchema,
@@ -50,9 +50,9 @@ const addSections = {
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     async execute({ sections }, client) {
-        // Check if any section needs inbox resolution
-        const needsInboxResolution = sections.some((section) => isInboxProjectId(section.projectId))
-        const todoistUser = needsInboxResolution ? await client.getUser() : undefined
+        const todoistUserPromise = sections.some((section) => isInboxProjectId(section.projectId))
+            ? executeWithRetry(() => client.getUser())
+            : undefined
 
         // Each section is created independently: a failure on one (for example, the API
         // rejecting it with a 403 permission error) must not discard the sections that
@@ -61,11 +61,14 @@ const addSections = {
         // the same backoff the registerTool() wrapper applies to single-call tools.
         const settled = await Promise.allSettled(
             sections.map(async (section) => {
+                const todoistUser = isInboxProjectId(section.projectId)
+                    ? await todoistUserPromise
+                    : undefined
                 const projectId =
                     (await resolveInboxProjectId({
                         projectId: section.projectId,
                         user: todoistUser,
-                        client: todoistUser ? undefined : client,
+                        client: undefined,
                     })) ?? section.projectId
                 return executeWithRetry(() => client.addSection({ ...section, projectId }))
             }),
@@ -80,16 +83,10 @@ const addSections = {
             } else {
                 failures.push({
                     item: sections[index]?.name ?? `Section ${index + 1}`,
-                    error: formatToolExecutionError(result.reason),
+                    error: formatBatchItemError(result.reason),
                 })
             }
         })
-
-        // If every section failed, surface a hard error instead of a misleading success.
-        if (newSections.length === 0 && failures.length > 0) {
-            const details = failures.map((f) => `"${f.item}": ${f.error}`).join('; ')
-            throw new Error(`All ${failures.length} section(s) failed to create: ${details}`)
-        }
 
         const textContent = generateTextContent({ sections: newSections, failures })
 

--- a/src/tools/update-projects.test.ts
+++ b/src/tools/update-projects.test.ts
@@ -591,5 +591,35 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
                 ),
             ).rejects.toThrow('All 2 project update(s) failed')
         })
+
+        it('does not throw when the batch is only skipped and failed projects', async () => {
+            // No project is actually updated: one is a no-op skip, the other fails. A skip
+            // is a successful no-op, so this is NOT a total failure and must return normally
+            // with the failure listed — rather than throwing a batch-wide error.
+            mockTodoistApi.updateProject.mockRejectedValueOnce(
+                new Error('API Error: Project not found'),
+            )
+
+            const result = await updateProjects.execute(
+                {
+                    projects: [
+                        { id: 'noop-project' }, // no fields -> skipped
+                        { id: 'nonexistent', name: 'New Name' }, // update -> fails
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            const { structuredContent } = result
+            expect(structuredContent.projects).toHaveLength(0)
+            expect(structuredContent.totalCount).toBe(0)
+            expect(structuredContent.failures).toHaveLength(1)
+            expect(structuredContent.failures[0]?.item).toBe('nonexistent')
+            expect(structuredContent.appliedOperations).toEqual({
+                updateCount: 0,
+                skippedCount: 1,
+                failureCount: 1,
+            })
+        })
     })
 })

--- a/src/tools/update-projects.test.ts
+++ b/src/tools/update-projects.test.ts
@@ -521,16 +521,21 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
     })
 
     describe('error handling', () => {
-        it('should propagate API errors', async () => {
+        it('reports API errors as structured failures', async () => {
             const apiError = new Error('API Error: Project not found')
             mockTodoistApi.updateProject.mockRejectedValue(apiError)
 
-            await expect(
-                updateProjects.execute(
-                    { projects: [{ id: 'nonexistent', name: 'New Name' }] },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow('API Error: Project not found')
+            const result = await updateProjects.execute(
+                { projects: [{ id: 'nonexistent', name: 'New Name' }] },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.failures).toEqual([
+                expect.objectContaining({
+                    item: 'nonexistent',
+                    error: 'API Error: Project not found',
+                }),
+            ])
         })
 
         it('should keep successful updates when one in the batch fails', async () => {
@@ -571,25 +576,31 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
 
             expect(result.textContent).toContain('Updated 1 project')
             expect(result.textContent).toContain('Failed (1)')
-            expect(result.textContent).toContain('not retried automatically')
+            expect(result.textContent).toContain('address or drop these items')
         })
 
-        it('should throw when every project in the batch fails', async () => {
+        it('returns structured failures when every project in the batch fails', async () => {
             mockTodoistApi.updateProject
                 .mockRejectedValueOnce(new Error('API Error: Project not found'))
                 .mockRejectedValueOnce(new Error('API Error: Project not found'))
 
-            await expect(
-                updateProjects.execute(
-                    {
-                        projects: [
-                            { id: 'nonexistent-1', name: 'New Name' },
-                            { id: 'nonexistent-2', name: 'New Name' },
-                        ],
-                    },
-                    mockTodoistApi,
-                ),
-            ).rejects.toThrow('All 2 project update(s) failed')
+            const result = await updateProjects.execute(
+                {
+                    projects: [
+                        { id: 'nonexistent-1', name: 'New Name' },
+                        { id: 'nonexistent-2', name: 'New Name' },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.projects).toEqual([])
+            expect(result.structuredContent.updatedProjectIds).toEqual([])
+            expect(result.structuredContent.appliedOperations).toEqual({
+                updateCount: 0,
+                skippedCount: 0,
+                failureCount: 2,
+            })
         })
 
         it('does not throw when the batch is only skipped and failed projects', async () => {

--- a/src/tools/update-projects.test.ts
+++ b/src/tools/update-projects.test.ts
@@ -73,6 +73,7 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
                     appliedOperations: {
                         updateCount: 1,
                         skippedCount: 0,
+                        failureCount: 0,
                     },
                 }),
             )
@@ -251,6 +252,7 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
             expect(result.structuredContent.appliedOperations).toEqual({
                 updateCount: 0,
                 skippedCount: 1,
+                failureCount: 0,
             })
         })
 
@@ -280,6 +282,7 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
             expect(result.structuredContent.appliedOperations).toEqual({
                 updateCount: 1,
                 skippedCount: 2,
+                failureCount: 0,
             })
         })
     })
@@ -346,6 +349,7 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
                     appliedOperations: {
                         updateCount: 3,
                         skippedCount: 0,
+                        failureCount: 0,
                     },
                 }),
             )
@@ -387,6 +391,7 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
                     appliedOperations: {
                         updateCount: 1,
                         skippedCount: 1,
+                        failureCount: 0,
                     },
                 }),
             )
@@ -528,7 +533,7 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
             ).rejects.toThrow('API Error: Project not found')
         })
 
-        it('should handle partial failures in multiple projects', async () => {
+        it('should keep successful updates when one in the batch fails', async () => {
             const mockProject = createMockProject({
                 id: 'project-1',
                 name: 'Updated Project',
@@ -538,17 +543,53 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
                 .mockResolvedValueOnce(mockProject)
                 .mockRejectedValueOnce(new Error('API Error: Project not found'))
 
+            const result = await updateProjects.execute(
+                {
+                    projects: [
+                        { id: 'project-1', name: 'Updated Project' },
+                        { id: 'nonexistent', name: 'New Name' },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            // The successful update is preserved instead of being discarded by the failure.
+            const { structuredContent } = result
+            expect(structuredContent.projects).toHaveLength(1)
+            expect(structuredContent.totalCount).toBe(1)
+            expect(structuredContent.updatedProjectIds).toEqual(['project-1'])
+
+            // The failure is reported per-item, identified by the project id.
+            expect(structuredContent.failures).toHaveLength(1)
+            expect(structuredContent.failures[0]?.item).toBe('nonexistent')
+            expect(structuredContent.failures[0]?.error).toContain('API Error: Project not found')
+            expect(structuredContent.appliedOperations).toEqual({
+                updateCount: 1,
+                skippedCount: 0,
+                failureCount: 1,
+            })
+
+            expect(result.textContent).toContain('Updated 1 project')
+            expect(result.textContent).toContain('Failed (1)')
+            expect(result.textContent).toContain('not retried automatically')
+        })
+
+        it('should throw when every project in the batch fails', async () => {
+            mockTodoistApi.updateProject
+                .mockRejectedValueOnce(new Error('API Error: Project not found'))
+                .mockRejectedValueOnce(new Error('API Error: Project not found'))
+
             await expect(
                 updateProjects.execute(
                     {
                         projects: [
-                            { id: 'project-1', name: 'Updated Project' },
-                            { id: 'nonexistent', name: 'New Name' },
+                            { id: 'nonexistent-1', name: 'New Name' },
+                            { id: 'nonexistent-2', name: 'New Name' },
                         ],
                     },
                     mockTodoistApi,
                 ),
-            ).rejects.toThrow('API Error: Project not found')
+            ).rejects.toThrow('All 2 project update(s) failed')
         })
     })
 })

--- a/src/tools/update-projects.ts
+++ b/src/tools/update-projects.ts
@@ -1,7 +1,7 @@
 import type { PersonalProject, WorkspaceProject } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
-import { formatToolExecutionError } from '../tool-execution-error.js'
+import { formatBatchItemError } from '../tool-execution-error.js'
 import { mapProject } from '../tool-helpers.js'
 import { ColorSchema } from '../utils/colors.js'
 import { FailureSchema, ProjectSchema as ProjectOutputSchema } from '../utils/output-schemas.js'
@@ -67,7 +67,6 @@ const updateProjects = {
         type Outcome =
             | { kind: 'updated'; project: PersonalProject | WorkspaceProject }
             | { kind: 'skipped'; reason: SkipReason }
-            | { kind: 'failed'; item: string; error: string }
 
         // Each project is updated independently: a failure on one (for example, the API
         // rejecting it with a 403 permission error) must not discard the projects that
@@ -87,42 +86,27 @@ const updateProjects = {
             }),
         )
 
-        const outcomes: Outcome[] = settled.map((result, index) => {
-            if (result.status === 'fulfilled') return result.value
-            return {
-                kind: 'failed',
-                item: projects[index]?.id ?? `Project ${index + 1}`,
-                error: formatToolExecutionError(result.reason),
+        const updatedProjects: ReturnType<typeof mapProject>[] = []
+        const failures: Array<{ item: string; error: string }> = []
+        let skippedNoFields = 0
+        let skippedNoValidValues = 0
+
+        for (const [index, result] of settled.entries()) {
+            if (result.status === 'rejected') {
+                failures.push({
+                    item: projects[index]?.id ?? `Project ${index + 1}`,
+                    error: formatBatchItemError(result.reason),
+                })
+                continue
             }
-        })
 
-        const updatedProjects = outcomes
-            .filter(
-                (o): o is { kind: 'updated'; project: PersonalProject | WorkspaceProject } =>
-                    o.kind === 'updated',
-            )
-            .map((o) => mapProject(o.project))
-
-        const failures = outcomes
-            .filter(
-                (o): o is { kind: 'failed'; item: string; error: string } => o.kind === 'failed',
-            )
-            .map(({ item, error }) => ({ item, error }))
-
-        const skippedNoFields = outcomes.filter(
-            (o) => o.kind === 'skipped' && o.reason === 'no-fields',
-        ).length
-
-        const skippedNoValidValues = outcomes.filter(
-            (o) => o.kind === 'skipped' && o.reason === 'no-valid-values',
-        ).length
-
-        // Only a total failure — every project in the batch failed — is a hard error.
-        // Skips are successful no-ops, so a batch with any success or skip returns
-        // normally with the failures listed rather than throwing.
-        if (failures.length > 0 && failures.length === projects.length) {
-            const details = failures.map((f) => `"${f.item}": ${f.error}`).join('; ')
-            throw new Error(`All ${failures.length} project update(s) failed: ${details}`)
+            if (result.value.kind === 'updated') {
+                updatedProjects.push(mapProject(result.value.project))
+            } else if (result.value.reason === 'no-fields') {
+                skippedNoFields++
+            } else {
+                skippedNoValidValues++
+            }
         }
 
         const textContent = generateTextContent({

--- a/src/tools/update-projects.ts
+++ b/src/tools/update-projects.ts
@@ -4,8 +4,9 @@ import type { TodoistTool } from '../todoist-tool.js'
 import { formatToolExecutionError } from '../tool-execution-error.js'
 import { mapProject } from '../tool-helpers.js'
 import { ColorSchema } from '../utils/colors.js'
-import { DisplayLimits } from '../utils/constants.js'
 import { FailureSchema, ProjectSchema as ProjectOutputSchema } from '../utils/output-schemas.js'
+import { appendFailureSummary } from '../utils/response-builders.js'
+import { executeWithRetry } from '../utils/retry.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 const ProjectUpdateSchema = z.object({
@@ -71,6 +72,8 @@ const updateProjects = {
         // Each project is updated independently: a failure on one (for example, the API
         // rejecting it with a 403 permission error) must not discard the projects that
         // succeeded nor collapse into one opaque batch error that invites a full retry.
+        // Per-item calls go through executeWithRetry so transient 5xx failures still get
+        // the same backoff the registerTool() wrapper applies to single-call tools.
         const settled = await Promise.allSettled(
             projects.map(async (project): Promise<Outcome> => {
                 const skipReason = getSkipReason(project)
@@ -79,7 +82,7 @@ const updateProjects = {
                 // An empty `description` clears it. That is already the project
                 // wire value (backend NULL_KEEPS_UNCHANGED), so forward as-is.
                 const { id, ...updateArgs } = project
-                const updated = await client.updateProject(id, updateArgs)
+                const updated = await executeWithRetry(() => client.updateProject(id, updateArgs))
                 return { kind: 'updated', project: updated }
             }),
         )
@@ -114,9 +117,10 @@ const updateProjects = {
             (o) => o.kind === 'skipped' && o.reason === 'no-valid-values',
         ).length
 
-        // If nothing was updated but real failures occurred, surface a hard error instead
-        // of a misleading success. (Skip-only batches still return normally.)
-        if (updatedProjects.length === 0 && failures.length > 0) {
+        // Only a total failure — every project in the batch failed — is a hard error.
+        // Skips are successful no-ops, so a batch with any success or skip returns
+        // normally with the failures listed rather than throwing.
+        if (failures.length > 0 && failures.length === projects.length) {
             const details = failures.map((f) => `"${f.item}": ${f.error}`).join('; ')
             throw new Error(`All ${failures.length} project update(s) failed: ${details}`)
         }
@@ -177,16 +181,7 @@ function generateTextContent({
         summary += `:\n${projectList}`
     }
 
-    if (failures.length === 0) {
-        return summary
-    }
-
-    const shown = failures.slice(0, DisplayLimits.MAX_FAILURES_SHOWN)
-    const remaining = failures.length - shown.length
-    const failureLines = shown.map((f) => `    ${f.item}: ${f.error}`).join('\n')
-    const moreInfo = remaining > 0 ? `\n    +${remaining} more` : ''
-
-    return `${summary}\nFailed (${failures.length}) - not retried automatically; address or drop these items:\n${failureLines}${moreInfo}`
+    return appendFailureSummary(summary, failures)
 }
 
 function getSkipReason({ id: _id, ...otherUpdateArgs }: ProjectUpdate): SkipReason | null {

--- a/src/tools/update-projects.ts
+++ b/src/tools/update-projects.ts
@@ -1,9 +1,11 @@
 import type { PersonalProject, WorkspaceProject } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
+import { formatToolExecutionError } from '../tool-execution-error.js'
 import { mapProject } from '../tool-helpers.js'
 import { ColorSchema } from '../utils/colors.js'
-import { ProjectSchema as ProjectOutputSchema } from '../utils/output-schemas.js'
+import { DisplayLimits } from '../utils/constants.js'
+import { FailureSchema, ProjectSchema as ProjectOutputSchema } from '../utils/output-schemas.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 const ProjectUpdateSchema = z.object({
@@ -38,10 +40,16 @@ const OutputSchema = {
     projects: z.array(ProjectOutputSchema).describe('The updated projects.'),
     totalCount: z.number().describe('The total number of projects updated.'),
     updatedProjectIds: z.array(z.string()).describe('The IDs of the updated projects.'),
+    failures: z
+        .array(FailureSchema)
+        .describe(
+            'Projects that could not be updated, with the reason for each. A failure here does not affect the other projects in the batch — do not retry the whole batch; address or drop the failed items.',
+        ),
     appliedOperations: z
         .object({
             updateCount: z.number().describe('The number of projects actually updated.'),
             skippedCount: z.number().describe('The number of projects skipped (no changes).'),
+            failureCount: z.number().describe('The number of projects that failed to update.'),
         })
         .describe('Summary of operations performed.'),
 }
@@ -55,12 +63,16 @@ const updateProjects = {
     async execute(args, client) {
         const { projects } = args
 
-        type Result =
+        type Outcome =
             | { kind: 'updated'; project: PersonalProject | WorkspaceProject }
             | { kind: 'skipped'; reason: SkipReason }
+            | { kind: 'failed'; item: string; error: string }
 
-        const results: Result[] = await Promise.all(
-            projects.map(async (project): Promise<Result> => {
+        // Each project is updated independently: a failure on one (for example, the API
+        // rejecting it with a 403 permission error) must not discard the projects that
+        // succeeded nor collapse into one opaque batch error that invites a full retry.
+        const settled = await Promise.allSettled(
+            projects.map(async (project): Promise<Outcome> => {
                 const skipReason = getSkipReason(project)
                 if (skipReason !== null) return { kind: 'skipped', reason: skipReason }
 
@@ -72,27 +84,48 @@ const updateProjects = {
             }),
         )
 
-        const updatedProjects = results
+        const outcomes: Outcome[] = settled.map((result, index) => {
+            if (result.status === 'fulfilled') return result.value
+            return {
+                kind: 'failed',
+                item: projects[index]?.id ?? `Project ${index + 1}`,
+                error: formatToolExecutionError(result.reason),
+            }
+        })
+
+        const updatedProjects = outcomes
             .filter(
-                (r): r is { kind: 'updated'; project: PersonalProject | WorkspaceProject } =>
-                    r.kind === 'updated',
+                (o): o is { kind: 'updated'; project: PersonalProject | WorkspaceProject } =>
+                    o.kind === 'updated',
             )
-            .map((r) => mapProject(r.project))
+            .map((o) => mapProject(o.project))
 
-        const skippedNoFields = results.filter(
-            (r): r is { kind: 'skipped'; reason: SkipReason } =>
-                r.kind === 'skipped' && r.reason === 'no-fields',
+        const failures = outcomes
+            .filter(
+                (o): o is { kind: 'failed'; item: string; error: string } => o.kind === 'failed',
+            )
+            .map(({ item, error }) => ({ item, error }))
+
+        const skippedNoFields = outcomes.filter(
+            (o) => o.kind === 'skipped' && o.reason === 'no-fields',
         ).length
 
-        const skippedNoValidValues = results.filter(
-            (r): r is { kind: 'skipped'; reason: SkipReason } =>
-                r.kind === 'skipped' && r.reason === 'no-valid-values',
+        const skippedNoValidValues = outcomes.filter(
+            (o) => o.kind === 'skipped' && o.reason === 'no-valid-values',
         ).length
+
+        // If nothing was updated but real failures occurred, surface a hard error instead
+        // of a misleading success. (Skip-only batches still return normally.)
+        if (updatedProjects.length === 0 && failures.length > 0) {
+            const details = failures.map((f) => `"${f.item}": ${f.error}`).join('; ')
+            throw new Error(`All ${failures.length} project update(s) failed: ${details}`)
+        }
 
         const textContent = generateTextContent({
             projects: updatedProjects,
             skippedNoFields,
             skippedNoValidValues,
+            failures,
         })
 
         return {
@@ -101,9 +134,11 @@ const updateProjects = {
                 projects: updatedProjects,
                 totalCount: updatedProjects.length,
                 updatedProjectIds: updatedProjects.map((project) => project.id),
+                failures,
                 appliedOperations: {
                     updateCount: updatedProjects.length,
                     skippedCount: skippedNoFields + skippedNoValidValues,
+                    failureCount: failures.length,
                 },
             },
         }
@@ -114,10 +149,12 @@ function generateTextContent({
     projects,
     skippedNoFields,
     skippedNoValidValues,
+    failures,
 }: {
     projects: Array<{ id: string; name: string }>
     skippedNoFields: number
     skippedNoValidValues: number
+    failures: Array<{ item: string; error: string }>
 }) {
     const count = projects.length
     const projectList = projects.map((project) => `• ${project.name} (id=${project.id})`).join('\n')
@@ -140,7 +177,16 @@ function generateTextContent({
         summary += `:\n${projectList}`
     }
 
-    return summary
+    if (failures.length === 0) {
+        return summary
+    }
+
+    const shown = failures.slice(0, DisplayLimits.MAX_FAILURES_SHOWN)
+    const remaining = failures.length - shown.length
+    const failureLines = shown.map((f) => `    ${f.item}: ${f.error}`).join('\n')
+    const moreInfo = remaining > 0 ? `\n    +${remaining} more` : ''
+
+    return `${summary}\nFailed (${failures.length}) - not retried automatically; address or drop these items:\n${failureLines}${moreInfo}`
 }
 
 function getSkipReason({ id: _id, ...otherUpdateArgs }: ProjectUpdate): SkipReason | null {

--- a/src/utils/response-builders.ts
+++ b/src/utils/response-builders.ts
@@ -116,6 +116,27 @@ export function summarizeBatch(params: BatchOperationParams): string {
 }
 
 /**
+ * Appends a per-item failure block to a success summary, signalling that the listed
+ * items were not retried automatically so the caller does not blindly resend the whole
+ * batch. Returns the summary unchanged when there are no failures.
+ */
+export function appendFailureSummary(
+    summary: string,
+    failures: Array<{ item: string; error: string }>,
+): string {
+    if (failures.length === 0) {
+        return summary
+    }
+
+    const shown = failures.slice(0, DisplayLimits.MAX_FAILURES_SHOWN)
+    const remaining = failures.length - shown.length
+    const failureLines = shown.map((f) => `    ${f.item}: ${f.error}`).join('\n')
+    const moreInfo = remaining > 0 ? `\n    +${remaining} more` : ''
+
+    return `${summary}\nFailed (${failures.length}) - not retried automatically; address or drop these items:\n${failureLines}${moreInfo}`
+}
+
+/**
  * Formats a single task-like object into a readable preview line
  */
 function formatTaskPreview(task: TaskLike): string {

--- a/src/utils/response-builders.ts
+++ b/src/utils/response-builders.ts
@@ -116,9 +116,8 @@ export function summarizeBatch(params: BatchOperationParams): string {
 }
 
 /**
- * Appends a per-item failure block to a success summary, signalling that the listed
- * items were not retried automatically so the caller does not blindly resend the whole
- * batch. Returns the summary unchanged when there are no failures.
+ * Appends a per-item failure block to a success summary. Returns the summary unchanged
+ * when there are no failures.
  */
 export function appendFailureSummary(
     summary: string,
@@ -133,7 +132,7 @@ export function appendFailureSummary(
     const failureLines = shown.map((f) => `    ${f.item}: ${f.error}`).join('\n')
     const moreInfo = remaining > 0 ? `\n    +${remaining} more` : ''
 
-    return `${summary}\nFailed (${failures.length}) - not retried automatically; address or drop these items:\n${failureLines}${moreInfo}`
+    return `${summary}\nFailed (${failures.length}) - address or drop these items:\n${failureLines}${moreInfo}`
 }
 
 /**

--- a/src/utils/workspace-resolver.test.ts
+++ b/src/utils/workspace-resolver.test.ts
@@ -134,6 +134,34 @@ describe('WorkspaceResolver', () => {
     })
 
     describe('caching', () => {
+        it('shares an in-flight workspace request across concurrent resolutions', async () => {
+            const workspaces = [
+                createMockWorkspace({ id: '111', name: 'Engineering' }),
+                createMockWorkspace({ id: '222', name: 'Marketing' }),
+            ]
+            let resolveWorkspaces: (value: Workspace[]) => void = () => undefined
+            mockTodoistApi.getWorkspaces.mockReturnValue(
+                new Promise<Workspace[]>((resolve) => {
+                    resolveWorkspaces = resolve
+                }),
+            )
+
+            const engineering = resolver.resolveWorkspace(mockTodoistApi, 'Engineering')
+            const marketing = resolver.resolveWorkspace(mockTodoistApi, 'Marketing')
+
+            expect(mockTodoistApi.getWorkspaces).toHaveBeenCalledTimes(1)
+
+            resolveWorkspaces(workspaces)
+            await expect(engineering).resolves.toEqual({
+                workspaceId: '111',
+                workspaceName: 'Engineering',
+            })
+            await expect(marketing).resolves.toEqual({
+                workspaceId: '222',
+                workspaceName: 'Marketing',
+            })
+        })
+
         it('should not re-fetch workspaces on second call', async () => {
             const workspaces = [createMockWorkspace({ id: '111', name: 'Engineering' })]
             mockTodoistApi.getWorkspaces.mockResolvedValue(workspaces)

--- a/src/utils/workspace-resolver.ts
+++ b/src/utils/workspace-resolver.ts
@@ -16,15 +16,30 @@ export function looksLikeWorkspaceId(ref: string): boolean {
 
 export class WorkspaceResolver {
     private cache: { workspaces: Workspace[]; timestamp: number } | null = null
+    private inFlightWorkspaces: Promise<Workspace[]> | null = null
 
     private async getWorkspaces(client: TodoistApi): Promise<Workspace[]> {
         if (this.cache && Date.now() - this.cache.timestamp < CACHE_TTL) {
             return this.cache.workspaces
         }
 
-        const workspaces = await client.getWorkspaces()
-        this.cache = { workspaces, timestamp: Date.now() }
-        return workspaces
+        if (this.inFlightWorkspaces) {
+            return this.inFlightWorkspaces
+        }
+
+        const request = client
+            .getWorkspaces()
+            .then((workspaces) => {
+                this.cache = { workspaces, timestamp: Date.now() }
+                return workspaces
+            })
+            .finally(() => {
+                if (this.inFlightWorkspaces === request) {
+                    this.inFlightWorkspaces = null
+                }
+            })
+        this.inFlightWorkspaces = request
+        return request
     }
 
     /**


### PR DESCRIPTION
# Overview

`add-projects`, `add-sections`, and `update-projects` previously allowed one rejected item to discard the rest of a batch behind an opaque error. This refresh settles each item independently and returns structured per-item `failures`, including when every item fails. Successful items and no-op skips remain visible to callers.

Each per-item API call retries transient 502/503/504 responses. Workspace and inbox resolution failures are also isolated to the affected items, so they do not block unrelated project or section writes. Batch error rows use the compact API formatter, and all three tools share one failure-summary renderer.

## Reference

- Relates to https://github.com/Doist/Issues/issues/20441
- Implements the contract agreed in https://github.com/Doist/todoist-mcp/issues/505

## Verification

- `npm test`
- `npm run type-check`
- `npm run format:check`
- `npm run build`