### PR TITLE
fix: bind standalone HTTP server to localhost by default

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -129,12 +129,12 @@ TODOIST_API_KEY=your-key node dist/main-http.js
 
 ### Environment Variables
 
-| Variable           | Default     | Description                                                              |
-| ------------------ | ----------- | ------------------------------------------------------------------------ |
-| `TODOIST_API_KEY`  | (required)  | Your Todoist API key. MCP tool calls run as this Todoist user.           |
-| `HOST`             | `127.0.0.1` | HTTP bind host. Use `0.0.0.0` only behind trusted network/auth controls. |
-| `PORT`             | `3000`      | HTTP server port                                                         |
-| `TODOIST_BASE_URL` | (optional)  | Custom Todoist API base URL                                              |
+| Variable           | Default     | Description                                                                       |
+| ------------------ | ----------- | --------------------------------------------------------------------------------- |
+| `TODOIST_API_KEY`  | (required)  | Your Todoist API key. MCP tool calls run as this Todoist user.                    |
+| `HOST`             | `127.0.0.1` | HTTP bind host. Use non-loopback hosts only behind trusted network/auth controls. |
+| `PORT`             | `3000`      | HTTP server port                                                                  |
+| `TODOIST_BASE_URL` | (optional)  | Custom Todoist API base URL                                                       |
 
 ### Local Development
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -95,19 +95,21 @@ Update the configuration above as follows
 
 ## Using Streamable HTTP Server Transport
 
-You can run the MCP server as an HTTP service with configurable session timeouts. This is useful as an alternative to the hosted service at `ai.todoist.net/mcp`, especially if you experience frequent session disconnections ([#239](https://github.com/Doist/todoist-mcp/issues/239)).
+You can run the MCP server as a local HTTP service. This is useful as an alternative to the hosted service at `ai.todoist.net/mcp`, especially if you experience frequent session disconnections ([#239](https://github.com/Doist/todoist-mcp/issues/239)).
+
+> [!IMPORTANT]
+> The standalone HTTP server runs every MCP tool with the `TODOIST_API_KEY` supplied by the operator. It binds to `127.0.0.1` by default and is intended for local MCP clients. Do not expose it to a LAN or the public internet unless you add your own trusted network and authentication controls.
 
 ### Quick Start with npx
 
 ```bash
-# Default: 30 minute session timeout
 TODOIST_API_KEY=your-key npx -p @doist/todoist-mcp todoist-mcp-http
-
-# Custom timeout: 1 hour (3600000ms)
-TODOIST_API_KEY=your-key SESSION_TIMEOUT_MS=3600000 npx -p @doist/todoist-mcp todoist-mcp-http
 
 # Custom port
 TODOIST_API_KEY=your-key PORT=8080 npx -p @doist/todoist-mcp todoist-mcp-http
+
+# Explicitly expose on all interfaces. Only do this behind trusted network/auth controls.
+TODOIST_API_KEY=your-key HOST=0.0.0.0 npx -p @doist/todoist-mcp todoist-mcp-http
 ```
 
 ### Running from Source
@@ -127,12 +129,12 @@ TODOIST_API_KEY=your-key node dist/main-http.js
 
 ### Environment Variables
 
-| Variable             | Default    | Description                                      |
-| -------------------- | ---------- | ------------------------------------------------ |
-| `TODOIST_API_KEY`    | (required) | Your Todoist API key                             |
-| `PORT`               | `3000`     | HTTP server port                                 |
-| `SESSION_TIMEOUT_MS` | `1800000`  | Session timeout in milliseconds (30 min default) |
-| `TODOIST_BASE_URL`   | (optional) | Custom Todoist API base URL                      |
+| Variable           | Default     | Description                                                              |
+| ------------------ | ----------- | ------------------------------------------------------------------------ |
+| `TODOIST_API_KEY`  | (required)  | Your Todoist API key. MCP tool calls run as this Todoist user.           |
+| `HOST`             | `127.0.0.1` | HTTP bind host. Use `0.0.0.0` only behind trusted network/auth controls. |
+| `PORT`             | `3000`      | HTTP server port                                                         |
+| `TODOIST_BASE_URL` | (optional)  | Custom Todoist API base URL                                              |
 
 ### Local Development
 
@@ -140,7 +142,7 @@ TODOIST_API_KEY=your-key node dist/main-http.js
 PORT=8080 npm run dev:http
 ```
 
-This will expose the service at `http://localhost:8080/mcp` with hot-reload.
+This will expose the service at `http://127.0.0.1:8080/mcp` with hot-reload.
 
 ### Connecting MCP Clients
 
@@ -163,8 +165,6 @@ MCP host applications can connect via the `mcp-remote` bridge:
 The HTTP server exposes a health check endpoint at `/health` that returns:
 
 - Server status
-- Number of active sessions
-- Configured session timeout
 
 ```bash
 curl http://localhost:3000/health

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -154,7 +154,7 @@ MCP host applications can connect via the `mcp-remote` bridge:
         "todoist-mcp-http": {
             "type": "stdio",
             "command": "npx",
-            "args": ["mcp-remote", "http://localhost:3000/mcp"]
+            "args": ["mcp-remote", "http://127.0.0.1:3000/mcp"]
         }
     }
 }
@@ -167,7 +167,7 @@ The HTTP server exposes a health check endpoint at `/health` that returns:
 - Server status
 
 ```bash
-curl http://localhost:3000/health
+curl http://127.0.0.1:3000/health
 ```
 
 > [!NOTE]

--- a/src/main-http.ts
+++ b/src/main-http.ts
@@ -10,6 +10,8 @@
  * - TODOIST_API_KEY: Required. Your Todoist API key.
  * - TODOIST_BASE_URL: Optional. Custom Todoist API base URL.
  * - PORT: Optional. Server port (default: 3000).
+ * - HOST: Optional. Bind host (default: 127.0.0.1). Use 0.0.0.0 only behind
+ *   trusted network/auth controls because requests run with TODOIST_API_KEY.
  *
  * @see https://github.com/Doist/todoist-mcp/issues/239
  */
@@ -22,6 +24,7 @@ import { requireValidTodoistToken } from './middleware/require-valid-todoist-tok
 dotenv.config({ quiet: true })
 
 const PORT = Number.parseInt(process.env.PORT || '3000', 10)
+const HOST = process.env.HOST || '127.0.0.1'
 
 function main() {
     const baseUrl = process.env.TODOIST_BASE_URL
@@ -75,10 +78,17 @@ function main() {
         res.status(405).set('Allow', 'POST').send('Method Not Allowed')
     })
 
-    app.listen(PORT, () => {
-        console.error(`Todoist MCP HTTP Server started on port ${PORT}`)
-        console.error(`MCP endpoint: http://localhost:${PORT}/mcp`)
-        console.error(`Health check: http://localhost:${PORT}/health`)
+    app.listen(PORT, HOST, () => {
+        const displayHost = HOST === '0.0.0.0' ? 'localhost' : HOST
+        console.error(`Todoist MCP HTTP Server started on ${HOST}:${PORT}`)
+        console.error(`MCP endpoint: http://${displayHost}:${PORT}/mcp`)
+        console.error(`Health check: http://${displayHost}:${PORT}/health`)
+        if (HOST === '0.0.0.0' || HOST === '::') {
+            console.error(
+                'Warning: todoist-mcp-http is reachable from other hosts. ' +
+                    'Protect this service with trusted network/auth controls because requests run with TODOIST_API_KEY.',
+            )
+        }
     })
 }
 

--- a/src/main-http.ts
+++ b/src/main-http.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { isIP } from 'node:net'
 /**
  * HTTP Server for Todoist MCP in stateless mode.
  *
@@ -10,8 +11,9 @@
  * - TODOIST_API_KEY: Required. Your Todoist API key.
  * - TODOIST_BASE_URL: Optional. Custom Todoist API base URL.
  * - PORT: Optional. Server port (default: 3000).
- * - HOST: Optional. Bind host (default: 127.0.0.1). Use 0.0.0.0 only behind
- *   trusted network/auth controls because requests run with TODOIST_API_KEY.
+ * - HOST: Optional. Bind host (default: 127.0.0.1). Use non-loopback hosts
+ *   only behind trusted network/auth controls because requests run with
+ *   TODOIST_API_KEY.
  *
  * @see https://github.com/Doist/todoist-mcp/issues/239
  */
@@ -25,6 +27,22 @@ dotenv.config({ quiet: true })
 
 const PORT = Number.parseInt(process.env.PORT || '3000', 10)
 const HOST = process.env.HOST || '127.0.0.1'
+
+function isLoopbackHost(host: string): boolean {
+    if (host === 'localhost') {
+        return true
+    }
+    if (host.startsWith('[') && host.endsWith(']')) {
+        host = host.slice(1, -1)
+    }
+    if (host === '::1' || host === '0:0:0:0:0:0:0:1') {
+        return true
+    }
+    if (isIP(host) === 4) {
+        return host.split('.')[0] === '127'
+    }
+    return false
+}
 
 function main() {
     const baseUrl = process.env.TODOIST_BASE_URL
@@ -83,7 +101,7 @@ function main() {
         console.error(`Todoist MCP HTTP Server started on ${HOST}:${PORT}`)
         console.error(`MCP endpoint: http://${displayHost}:${PORT}/mcp`)
         console.error(`Health check: http://${displayHost}:${PORT}/health`)
-        if (HOST === '0.0.0.0' || HOST === '::') {
+        if (!isLoopbackHost(HOST)) {
             console.error(
                 'Warning: todoist-mcp-http is reachable from other hosts. ' +
                     'Protect this service with trusted network/auth controls because requests run with TODOIST_API_KEY.',

--- a/src/main-http.ts
+++ b/src/main-http.ts
@@ -27,13 +27,33 @@ dotenv.config({ quiet: true })
 
 const PORT = Number.parseInt(process.env.PORT || '3000', 10)
 const HOST = process.env.HOST || '127.0.0.1'
+const LISTEN_HOST = normalizeListenHost(HOST)
+
+function normalizeListenHost(host: string): string {
+    if (host.startsWith('[') && host.endsWith(']')) {
+        return host.slice(1, -1)
+    }
+    return host
+}
+
+function formatUrlHost(host: string): string {
+    if (host === '0.0.0.0' || host === '::') {
+        return 'localhost'
+    }
+    return formatListenHost(host)
+}
+
+function formatListenHost(host: string): string {
+    if (isIP(host) === 6) {
+        return `[${host}]`
+    }
+    return host
+}
 
 function isLoopbackHost(host: string): boolean {
+    host = normalizeListenHost(host)
     if (host === 'localhost') {
         return true
-    }
-    if (host.startsWith('[') && host.endsWith(']')) {
-        host = host.slice(1, -1)
     }
     if (host === '::1' || host === '0:0:0:0:0:0:0:1') {
         return true
@@ -96,12 +116,12 @@ function main() {
         res.status(405).set('Allow', 'POST').send('Method Not Allowed')
     })
 
-    app.listen(PORT, HOST, () => {
-        const displayHost = HOST === '0.0.0.0' ? 'localhost' : HOST
-        console.error(`Todoist MCP HTTP Server started on ${HOST}:${PORT}`)
+    app.listen(PORT, LISTEN_HOST, () => {
+        const displayHost = formatUrlHost(LISTEN_HOST)
+        console.error(`Todoist MCP HTTP Server started on ${formatListenHost(LISTEN_HOST)}:${PORT}`)
         console.error(`MCP endpoint: http://${displayHost}:${PORT}/mcp`)
         console.error(`Health check: http://${displayHost}:${PORT}/health`)
-        if (!isLoopbackHost(HOST)) {
+        if (!isLoopbackHost(LISTEN_HOST)) {
             console.error(
                 'Warning: todoist-mcp-http is reachable from other hosts. ' +
                     'Protect this service with trusted network/auth controls because requests run with TODOIST_API_KEY.',


### PR DESCRIPTION
## Summary

Bind the standalone `todoist-mcp-http` server to `127.0.0.1` by default instead of relying on Node's implicit all-interface listen behavior. Operators can still explicitly expose it with `HOST=0.0.0.0`, but the server now logs a warning and the docs clarify that this mode runs tool calls with the operator-provided `TODOIST_API_KEY` and should only be exposed behind trusted network/auth controls.

This keeps the local HTTP transport useful for development and local MCP clients while reducing the chance that a self-hosted instance accidentally exposes the operator's Todoist account to the network.
