### PR TITLE
fix(release): send client_payload as a JSON object in the integrations dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,14 +137,19 @@ jobs:
 
             - name: Trigger todoist-ai-integrations update
               if: ${{ steps.announcement.outputs.should_announce == 'true' }}
+              env:
+                  GH_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+                  VERSION: ${{ steps.announcement.outputs.package_version }}
               run: |
+                  # `client_payload` must be sent as nested fields so gh builds a
+                  # JSON object; passing a JSON string via a single `-f` is
+                  # rejected by the dispatches API with HTTP 422 ("not an object").
                   gh api \
                     --method POST \
                     -H "Accept: application/vnd.github+json" \
                     -H "X-GitHub-Api-Version: 2022-11-28" \
                     /repos/Doist/todoist-ai-integrations/dispatches \
                     -f event_type='todoist-ai-updated' \
-                    -f client_payload='{"version":"${{ steps.announcement.outputs.package_version }}","npm_tag":"latest"}'
-              env:
-                  GH_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+                    -f "client_payload[version]=${VERSION}" \
+                    -f "client_payload[npm_tag]=latest"
               continue-on-error: true


### PR DESCRIPTION
## Problem

The Release workflow's "Trigger todoist-ai-integrations update" step has never actually triggered the downstream update. The live run log shows:

```
-f client_payload='{"version":"10.3.0","npm_tag":"latest"}'
For 'properties/client_payload', "{\"version\":\"10.3.0\",\"npm_tag\":\"latest\"}" is not an object. (HTTP 422)
##[error]Process completed with exit code 1.
```

`gh api -f` sends every value as a **string**, but the `repository_dispatch` API requires `client_payload` to be a JSON **object**, so the call is rejected with HTTP 422 and the dispatch never fires. Because the step is `continue-on-error: true`, the release stays green and the failure has been silently swallowed every release.

This is **not** a token or event-type problem:
- The request reached the API and got a 422 (validation), not 401/403 — `DEPLOY_TOKEN` is valid and authorised.
- `event_type=todoist-ai-updated` is correctly registered in the receiver (`Doist/todoist-ai-integrations` `update-mcps.yml`: `types: [todoist-ai-updated, comms-mcp-updated]`).

## Fix

Build `client_payload` with `gh`'s nested-field syntax so it's sent as an object, matching the working `comms-mcp` release workflow:

```bash
-f "client_payload[version]=${VERSION}" \
-f "client_payload[npm_tag]=latest"
```

`continue-on-error: true` is intentionally **kept** (a dispatch hiccup shouldn't fail an otherwise-successful release).

## Verification
The receiver reads `github.event.client_payload.version`; with the payload now sent as an object, `client_payload.version` populates correctly. This mirrors the comms-mcp dispatch, which works today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)