### PR TITLE
fix: validate Host/Origin on HTTP transport to block DNS rebinding

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -36,7 +36,8 @@ TypeScript · ESM-only · Node 18+ · `zod` v4 for schemas · MCP SDK ≥1.25.
 ```
 src/
 ├─ main.ts                    # stdio entry: dotenv → getMcpServer() → StdioServerTransport
-├─ main-http.ts               # Express entry: same server behind HTTP
+├─ main-http.ts               # Express entry: thin bootstrap — reads env, builds the app, listen()
+├─ http-app.ts                # createHttpApp(): the Express app + middleware chain (Host/Origin guard scoped to /mcp). Pure/side-effect-free so it's testable
 ├─ index.ts                   # Public package exports — a curated subset of tools + helpers + types. NOT the full registry.
 ├─ mcp-server.ts              # getMcpServer() factory. **Authoritative tool registry** — imports every tool, calls registerTool() for each, registers productivity-analysis prompt, contains the giant `instructions` string shown to the LLM
 ├─ mcp-helpers.ts             # registerTool(), FEATURE_NAMES, output formatting, retry wrapping
@@ -46,7 +47,7 @@ src/
 ├─ filter-helpers.ts          # appendToQuery, buildResponsibleUserQueryFilter, resolveResponsibleUser
 ├─ tool-execution-error.ts    # ToolExecutionError: wraps SDK errors with user/system classification
 ├─ prompts/                   # MCP prompts (productivity-analysis)
-├─ middleware/                # require-valid-todoist-token (HTTP auth)
+├─ middleware/                # require-trusted-host (Host/Origin allowlist, DNS-rebinding protection), require-valid-todoist-token (HTTP auth)
 ├─ mcp-apps/                  # React UI widgets (task list). Built separately. Ignore unless task mentions widgets.
 ├─ tools/                     # 40+ tool definitions. One file = one tool. Each <tool>.test.ts sits alongside its tool; snapshots in tools/__snapshots__/. See catalog.
 └─ utils/                     # Reusable helpers. See catalog.
@@ -144,6 +145,7 @@ New tool? Full checklist in `AGENTS.md`. Short version: copy `add-tasks.ts`; imp
 
 - Client: `new TodoistApi(apiKey, baseUrl?)` — created once per server in `mcp-server.ts`, passed into every `execute()`.
 - Auth: `TODOIST_API_KEY` env var, validated at startup. Both stdio and HTTP use this; the HTTP server passes it through `requireValidTodoistToken({ type: 'static', apiKey })` middleware (`src/middleware/require-valid-todoist-token.ts`). The middleware _also_ supports a per-request bearer-token mode, but `main-http.ts` does not wire that up today.
+- HTTP request guard: `requireTrustedHost` (`src/middleware/require-trusted-host.ts`) is scoped to the `/mcp` routes, running ahead of `express.json()` and `requireValidTodoistToken`, validating the `Host` and `Origin` headers against a trusted-hostname allowlist (loopback defaults + `ALLOWED_HOSTS` + a concrete non-loopback `HOST`). This is DNS-rebinding protection: it blocks malicious websites from reaching the loopback server with the operator's token. `/health` is intentionally unguarded so deployment probes (which use the target's private IP in the Host header) stay reachable. The allowlist is built by `buildAllowedHosts(HOST, ALLOWED_HOSTS)` in the same module; shared host helpers live in `src/utils/host.ts`. The app is assembled by `createHttpApp()` in `src/http-app.ts` (a pure module, no side effects, so the middleware chain is testable); `src/main-http.ts` is a thin bootstrap that reads env and calls `listen()`.
 - Optional `TODOIST_BASE_URL` for staging/dev APIs.
 - Errors: wrap SDK throws in `ToolExecutionError` (classify user vs system) — `registerTool` handles this automatically.
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -98,7 +98,7 @@ Update the configuration above as follows
 You can run the MCP server as a local HTTP service. This is useful as an alternative to the hosted service at `ai.todoist.net/mcp`, especially if you experience frequent session disconnections ([#239](https://github.com/Doist/todoist-mcp/issues/239)).
 
 > [!IMPORTANT]
-> The standalone HTTP server runs every MCP tool with the `TODOIST_API_KEY` supplied by the operator. It binds to `127.0.0.1` by default and is intended for local MCP clients. Do not expose it to a LAN or the public internet unless you add your own trusted network and authentication controls.
+> The standalone HTTP server runs every MCP tool with the `TODOIST_API_KEY` supplied by the operator. It binds to `127.0.0.1` by default and is intended for local MCP clients. Requests to `/mcp` have their `Host` and `Origin` headers validated against a trusted-hostname allowlist (DNS-rebinding protection), so loopback clients work out of the box (`/health` is exempt so deployment health probes keep working). Do not expose it to a LAN or the public internet unless you add your own trusted network and authentication controls — and when you do, set `ALLOWED_HOSTS` to the hostnames your clients use.
 
 ### Quick Start with npx
 
@@ -109,7 +109,8 @@ TODOIST_API_KEY=your-key npx -p @doist/todoist-mcp todoist-mcp-http
 TODOIST_API_KEY=your-key PORT=8080 npx -p @doist/todoist-mcp todoist-mcp-http
 
 # Explicitly expose on all interfaces. Only do this behind trusted network/auth controls.
-TODOIST_API_KEY=your-key HOST=0.0.0.0 npx -p @doist/todoist-mcp todoist-mcp-http
+# Set ALLOWED_HOSTS to the hostnames clients use, otherwise their requests are rejected with 403.
+TODOIST_API_KEY=your-key HOST=0.0.0.0 ALLOWED_HOSTS=mcp.example.lan npx -p @doist/todoist-mcp todoist-mcp-http
 ```
 
 ### Running from Source
@@ -129,12 +130,13 @@ TODOIST_API_KEY=your-key node dist/main-http.js
 
 ### Environment Variables
 
-| Variable           | Default     | Description                                                                       |
-| ------------------ | ----------- | --------------------------------------------------------------------------------- |
-| `TODOIST_API_KEY`  | (required)  | Your Todoist API key. MCP tool calls run as this Todoist user.                    |
-| `HOST`             | `127.0.0.1` | HTTP bind host. Use non-loopback hosts only behind trusted network/auth controls. |
-| `PORT`             | `3000`      | HTTP server port                                                                  |
-| `TODOIST_BASE_URL` | (optional)  | Custom Todoist API base URL                                                       |
+| Variable           | Default     | Description                                                                                                                                                                                                                                                                                             |
+| ------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TODOIST_API_KEY`  | (required)  | Your Todoist API key. MCP tool calls run as this Todoist user.                                                                                                                                                                                                                                          |
+| `HOST`             | `127.0.0.1` | HTTP bind host. Use non-loopback hosts only behind trusted network/auth controls.                                                                                                                                                                                                                       |
+| `ALLOWED_HOSTS`    | (optional)  | Comma-separated extra hostnames trusted in the `Host`/`Origin` headers (DNS-rebinding protection), in addition to the loopback defaults (`localhost`, `127.0.0.1`, `[::1]`). Required when `HOST=0.0.0.0` so LAN clients' hostnames are accepted. IPv6 entries must be bracketed, e.g. `[2001:db8::1]`. |
+| `PORT`             | `3000`      | HTTP server port                                                                                                                                                                                                                                                                                        |
+| `TODOIST_BASE_URL` | (optional)  | Custom Todoist API base URL                                                                                                                                                                                                                                                                             |
 
 ### Local Development
 

--- a/src/http-app.test.ts
+++ b/src/http-app.test.ts
@@ -1,0 +1,137 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createHttpApp } from './http-app.js'
+import { DEFAULT_ALLOWED_HOSTS } from './middleware/require-trusted-host.js'
+import { clearTokenValidationCache } from './middleware/require-valid-todoist-token.js'
+
+vi.mock('./utils/validate-todoist-token.js', () => ({
+    validateTodoistToken: vi.fn(),
+}))
+
+import { validateTodoistToken } from './utils/validate-todoist-token.js'
+
+const mockValidate = validateTodoistToken as Mock
+
+type Server = ReturnType<typeof http.createServer>
+
+let server: Server
+
+function startApp(): Promise<number> {
+    const app = createHttpApp({ todoistApiKey: 'test-key', allowedHosts: DEFAULT_ALLOWED_HOSTS })
+    return new Promise((resolve) => {
+        server = app.listen(0, '127.0.0.1', () => {
+            resolve((server.address() as AddressInfo).port)
+        })
+    })
+}
+
+function request(
+    port: number,
+    options: { method: string; path: string; headers?: Record<string, string>; body?: string },
+): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+        const req = http.request(
+            {
+                host: '127.0.0.1',
+                port,
+                method: options.method,
+                path: options.path,
+                headers: options.headers,
+            },
+            (res) => {
+                let body = ''
+                res.on('data', (chunk) => {
+                    body += chunk
+                })
+                res.on('end', () => resolve({ status: res.statusCode ?? 0, body }))
+            },
+        )
+        req.on('error', reject)
+        if (options.body) {
+            req.write(options.body)
+        }
+        req.end()
+    })
+}
+
+const JSON_HEADERS = { 'content-type': 'application/json' }
+const INIT_BODY = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+
+describe('createHttpApp middleware chain', () => {
+    beforeEach(() => {
+        clearTokenValidationCache()
+        mockValidate.mockReset()
+        // Invalid token: a request that passes the Host/Origin guard reaches the
+        // token middleware and gets a 401, which lets us prove the guard ran first
+        // (a blocked request would be a 403 before token validation).
+        mockValidate.mockResolvedValue(false)
+    })
+
+    afterEach(() => {
+        server?.close()
+    })
+
+    it('rejects /mcp requests with an untrusted Host (DNS rebinding) with 403', async () => {
+        const port = await startApp()
+        const res = await request(port, {
+            method: 'POST',
+            path: '/mcp',
+            headers: { ...JSON_HEADERS, host: 'evil.com' },
+            body: INIT_BODY,
+        })
+
+        expect(res.status).toBe(403)
+        expect(mockValidate).not.toHaveBeenCalled()
+    })
+
+    it('rejects /mcp requests with an untrusted Origin with 403', async () => {
+        const port = await startApp()
+        const res = await request(port, {
+            method: 'POST',
+            path: '/mcp',
+            headers: { ...JSON_HEADERS, host: `127.0.0.1:${port}`, origin: 'http://evil.com' },
+            body: INIT_BODY,
+        })
+
+        expect(res.status).toBe(403)
+        expect(mockValidate).not.toHaveBeenCalled()
+    })
+
+    it('passes a trusted Host through the guard to token validation (401 on bad token)', async () => {
+        const port = await startApp()
+        const res = await request(port, {
+            method: 'POST',
+            path: '/mcp',
+            headers: { ...JSON_HEADERS, host: `127.0.0.1:${port}` },
+            body: INIT_BODY,
+        })
+
+        expect(res.status).toBe(401)
+        expect(mockValidate).toHaveBeenCalledOnce()
+    })
+
+    it('exempts /health from the Host guard so deployment probes work', async () => {
+        const port = await startApp()
+        const res = await request(port, {
+            method: 'GET',
+            path: '/health',
+            headers: { host: 'health-probe.internal' },
+        })
+
+        expect(res.status).toBe(200)
+        expect(JSON.parse(res.body)).toEqual({ status: 'ok' })
+    })
+
+    it('returns 405 for GET /mcp from a trusted Host', async () => {
+        const port = await startApp()
+        const res = await request(port, {
+            method: 'GET',
+            path: '/mcp',
+            headers: { host: `127.0.0.1:${port}` },
+        })
+
+        expect(res.status).toBe(405)
+    })
+})

--- a/src/http-app.ts
+++ b/src/http-app.ts
@@ -1,0 +1,73 @@
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import express, { type Express, type Request, type Response } from 'express'
+import { getMcpServer } from './mcp-server.js'
+import { requireTrustedHost } from './middleware/require-trusted-host.js'
+import { requireValidTodoistToken } from './middleware/require-valid-todoist-token.js'
+
+type CreateHttpAppOptions = {
+    todoistApiKey: string
+    baseUrl?: string
+    /** Hostnames trusted in the Host/Origin headers (DNS-rebinding protection). */
+    allowedHosts: string[]
+}
+
+/**
+ * Build the Express app for the MCP HTTP server.
+ *
+ * The DNS-rebinding guard (`requireTrustedHost`) is scoped to the sensitive
+ * `/mcp` routes and runs ahead of body parsing and token auth there. `/health`
+ * is intentionally unguarded so deployment health probes — which send the
+ * target's private IP in the Host header — keep working; it exposes no account
+ * data.
+ */
+function createHttpApp({ todoistApiKey, baseUrl, allowedHosts }: CreateHttpAppOptions): Express {
+    const app = express()
+    const trustedHost = requireTrustedHost({ allowedHosts })
+
+    // Health check endpoint (no host guard — see above).
+    app.get('/health', (_req: Request, res: Response) => {
+        res.json({ status: 'ok' })
+    })
+
+    // MCP endpoint - POST for requests.
+    // `trustedHost` rejects untrusted Host/Origin with a cheap 403 before the
+    // body is parsed. `requireValidTodoistToken` then validates the token so that
+    // invalid tokens produce an HTTP 401 (per MCP spec) instead of being
+    // swallowed into a 200 JSON-RPC response with isError: true.
+    app.post(
+        '/mcp',
+        trustedHost,
+        express.json(),
+        requireValidTodoistToken({ type: 'static', apiKey: todoistApiKey, baseUrl }),
+        async (req: Request, res: Response) => {
+            try {
+                const transport = new StreamableHTTPServerTransport({
+                    sessionIdGenerator: undefined,
+                })
+
+                const server = getMcpServer({ todoistApiKey, baseUrl })
+                await server.connect(transport)
+                await transport.handleRequest(req, res, req.body)
+            } catch (error) {
+                console.error('[Error] Request handling failed:', error)
+                res.status(500).json({
+                    jsonrpc: '2.0',
+                    error: {
+                        code: -32603,
+                        message: 'Internal server error',
+                    },
+                    id: null,
+                })
+            }
+        },
+    )
+
+    // MCP endpoint - GET returns 405 (needed for MCP client compatibility).
+    app.get('/mcp', trustedHost, (_req: Request, res: Response) => {
+        res.status(405).set('Allow', 'POST').send('Method Not Allowed')
+    })
+
+    return app
+}
+
+export { createHttpApp, type CreateHttpAppOptions }

--- a/src/main-http.ts
+++ b/src/main-http.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 import { isIP } from 'node:net'
 /**
- * HTTP Server for Todoist MCP in stateless mode.
+ * HTTP Server entrypoint for Todoist MCP in stateless mode.
  *
- * This server provides an alternative to the hosted service at ai.todoist.net/mcp.
- * Each request creates a fresh transport and MCP server instance — no session
- * tracking, timeouts, or cleanup required.
+ * Thin bootstrap: reads configuration from the environment, builds the Express
+ * app via createHttpApp(), and starts listening. The app itself (and its
+ * middleware chain) lives in ./http-app.ts so it can be tested without starting
+ * a server. Each request creates a fresh transport and MCP server instance — no
+ * session tracking, timeouts, or cleanup required.
  *
  * Environment variables:
  * - TODOIST_API_KEY: Required. Your Todoist API key.
@@ -14,27 +16,28 @@ import { isIP } from 'node:net'
  * - HOST: Optional. Bind host (default: 127.0.0.1). Use non-loopback hosts
  *   only behind trusted network/auth controls because requests run with
  *   TODOIST_API_KEY.
+ * - ALLOWED_HOSTS: Optional. Comma-separated hostnames (in addition to the
+ *   loopback defaults) trusted in the Host and Origin headers for DNS-rebinding
+ *   protection. Required when binding to 0.0.0.0 so LAN clients' hostnames are
+ *   accepted. IPv6 entries must be bracketed, e.g. [2001:db8::1].
+ *
+ * The /mcp endpoint validates the Host and Origin headers against this allowlist
+ * before any request handling (DNS-rebinding protection). /health is exempt so
+ * deployment health probes (which use the target's private IP in the Host
+ * header) keep working.
  *
  * @see https://github.com/Doist/todoist-mcp/issues/239
  */
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import dotenv from 'dotenv'
-import express, { type Request, type Response } from 'express'
-import { getMcpServer } from './mcp-server.js'
-import { requireValidTodoistToken } from './middleware/require-valid-todoist-token.js'
+import { createHttpApp } from './http-app.js'
+import { buildAllowedHosts } from './middleware/require-trusted-host.js'
+import { isLoopbackHost, normalizeListenHost } from './utils/host.js'
 
 dotenv.config({ quiet: true })
 
 const PORT = Number.parseInt(process.env.PORT || '3000', 10)
 const HOST = process.env.HOST || '127.0.0.1'
 const LISTEN_HOST = normalizeListenHost(HOST)
-
-function normalizeListenHost(host: string): string {
-    if (host.startsWith('[') && host.endsWith(']')) {
-        return host.slice(1, -1)
-    }
-    return host
-}
 
 function formatUrlHost(host: string): string {
     if (host === '0.0.0.0' || host === '::') {
@@ -50,20 +53,6 @@ function formatListenHost(host: string): string {
     return host
 }
 
-function isLoopbackHost(host: string): boolean {
-    host = normalizeListenHost(host)
-    if (host === 'localhost') {
-        return true
-    }
-    if (host === '::1' || host === '0:0:0:0:0:0:0:1') {
-        return true
-    }
-    if (isIP(host) === 4) {
-        return host.split('.')[0] === '127'
-    }
-    return false
-}
-
 function main() {
     const baseUrl = process.env.TODOIST_BASE_URL
     const todoistApiKey = process.env.TODOIST_API_KEY
@@ -73,48 +62,8 @@ function main() {
         process.exit(1)
     }
 
-    const app = express()
-    app.use(express.json())
-
-    // Health check endpoint
-    app.get('/health', (_req: Request, res: Response) => {
-        res.json({ status: 'ok' })
-    })
-
-    // MCP endpoint - POST for requests
-    // Validate the Todoist API token before MCP processing so that invalid
-    // tokens produce an HTTP 401 (per MCP spec) instead of being swallowed
-    // into a 200 JSON-RPC response with isError: true.
-    app.post(
-        '/mcp',
-        requireValidTodoistToken({ type: 'static', apiKey: todoistApiKey, baseUrl }),
-        async (req: Request, res: Response) => {
-            try {
-                const transport = new StreamableHTTPServerTransport({
-                    sessionIdGenerator: undefined,
-                })
-
-                const server = getMcpServer({ todoistApiKey, baseUrl })
-                await server.connect(transport)
-                await transport.handleRequest(req, res, req.body)
-            } catch (error) {
-                console.error('[Error] Request handling failed:', error)
-                res.status(500).json({
-                    jsonrpc: '2.0',
-                    error: {
-                        code: -32603,
-                        message: 'Internal server error',
-                    },
-                    id: null,
-                })
-            }
-        },
-    )
-
-    // MCP endpoint - GET returns 405 (needed for MCP client compatibility)
-    app.get('/mcp', (_req: Request, res: Response) => {
-        res.status(405).set('Allow', 'POST').send('Method Not Allowed')
-    })
+    const allowedHosts = buildAllowedHosts(HOST, process.env.ALLOWED_HOSTS)
+    const app = createHttpApp({ todoistApiKey, baseUrl, allowedHosts })
 
     app.listen(PORT, LISTEN_HOST, () => {
         const displayHost = formatUrlHost(LISTEN_HOST)
@@ -124,7 +73,8 @@ function main() {
         if (!isLoopbackHost(LISTEN_HOST)) {
             console.error(
                 'Warning: todoist-mcp-http is reachable from other hosts. ' +
-                    'Protect this service with trusted network/auth controls because requests run with TODOIST_API_KEY.',
+                    'Set ALLOWED_HOSTS to the hostnames clients use and protect this service with ' +
+                    'trusted network/auth controls because requests run with TODOIST_API_KEY.',
             )
         }
     })

--- a/src/middleware/require-trusted-host.test.ts
+++ b/src/middleware/require-trusted-host.test.ts
@@ -1,0 +1,190 @@
+import type { Request, Response } from 'express'
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+    DEFAULT_ALLOWED_HOSTS,
+    buildAllowedHosts,
+    requireTrustedHost,
+} from './require-trusted-host.js'
+
+function createMockRes(): Response {
+    const res = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+    }
+    return res as unknown as Response
+}
+
+function createReq(headers: { host?: string; origin?: string }): Request {
+    return { headers } as unknown as Request
+}
+
+describe('requireTrustedHost', () => {
+    let next: Mock
+
+    beforeEach(() => {
+        next = vi.fn()
+    })
+
+    describe('Host header validation (loopback defaults)', () => {
+        const middleware = requireTrustedHost({ allowedHosts: DEFAULT_ALLOWED_HOSTS })
+
+        it.each([
+            ['localhost:3000'],
+            ['127.0.0.1:3000'],
+            ['[::1]:3000'],
+            ['127.0.0.1'],
+            ['LOCALHOST:3000'],
+        ])('allows trusted host %s', (host) => {
+            const res = createMockRes()
+            middleware(createReq({ host }), res, next)
+
+            expect(next).toHaveBeenCalledOnce()
+            expect(res.status).not.toHaveBeenCalled()
+        })
+
+        it('rejects a missing Host header with 403', () => {
+            const res = createMockRes()
+            middleware(createReq({}), res, next)
+
+            expect(next).not.toHaveBeenCalled()
+            expect(res.status).toHaveBeenCalledWith(403)
+            expect(res.json).toHaveBeenCalledWith({
+                jsonrpc: '2.0',
+                error: { code: -32000, message: 'Missing Host header' },
+                id: null,
+            })
+        })
+
+        it.each([
+            ['attacker.com:3000'],
+            // The DNS-rebinding domain: we never resolve it, so the rebound
+            // Host (which still carries the attacker's domain) is rejected.
+            ['evil.com'],
+            ['http://'],
+        ])('rejects untrusted/unparseable host %s with 403', (host) => {
+            const res = createMockRes()
+            middleware(createReq({ host }), res, next)
+
+            expect(next).not.toHaveBeenCalled()
+            expect(res.status).toHaveBeenCalledWith(403)
+        })
+    })
+
+    describe('Host header validation (operator-configured allowlist)', () => {
+        const middleware = requireTrustedHost({
+            allowedHosts: [...DEFAULT_ALLOWED_HOSTS, 'mcp.lan'],
+        })
+
+        it('allows the configured host', () => {
+            const res = createMockRes()
+            middleware(createReq({ host: 'mcp.lan:3000' }), res, next)
+
+            expect(next).toHaveBeenCalledOnce()
+        })
+
+        it('rejects a host outside the configured allowlist', () => {
+            const res = createMockRes()
+            middleware(createReq({ host: 'other.lan' }), res, next)
+
+            expect(next).not.toHaveBeenCalled()
+            expect(res.status).toHaveBeenCalledWith(403)
+        })
+    })
+
+    describe('Origin header validation', () => {
+        const middleware = requireTrustedHost({ allowedHosts: DEFAULT_ALLOWED_HOSTS })
+
+        it('allows a trusted host with no Origin (non-browser client)', () => {
+            const res = createMockRes()
+            middleware(createReq({ host: 'localhost:3000' }), res, next)
+
+            expect(next).toHaveBeenCalledOnce()
+        })
+
+        it.each([['http://localhost:3000'], ['http://127.0.0.1:8080']])(
+            'allows a trusted Origin %s',
+            (origin) => {
+                const res = createMockRes()
+                middleware(createReq({ host: 'localhost:3000', origin }), res, next)
+
+                expect(next).toHaveBeenCalledOnce()
+            },
+        )
+
+        it.each([['http://attacker.com'], ['null'], ['not a url']])(
+            'rejects untrusted/unparseable Origin %s with 403',
+            (origin) => {
+                const res = createMockRes()
+                middleware(createReq({ host: 'localhost:3000', origin }), res, next)
+
+                expect(next).not.toHaveBeenCalled()
+                expect(res.status).toHaveBeenCalledWith(403)
+            },
+        )
+    })
+})
+
+describe('buildAllowedHosts', () => {
+    it('returns the loopback defaults when HOST is loopback and ALLOWED_HOSTS is unset', () => {
+        expect(buildAllowedHosts('127.0.0.1', undefined)).toEqual(DEFAULT_ALLOWED_HOSTS)
+    })
+
+    it('auto-includes a concrete non-loopback bind host', () => {
+        expect(buildAllowedHosts('192.168.1.50')).toEqual([
+            ...DEFAULT_ALLOWED_HOSTS,
+            '192.168.1.50',
+        ])
+    })
+
+    it.each([['[2001:db8::1]'], ['2001:db8::1']])(
+        'auto-includes a concrete IPv6 bind host %s in bracketed form',
+        (host) => {
+            expect(buildAllowedHosts(host)).toEqual([...DEFAULT_ALLOWED_HOSTS, '[2001:db8::1]'])
+        },
+    )
+
+    it('produces an allowlist that matches IPv6 request hosts end-to-end', () => {
+        const middleware = requireTrustedHost({ allowedHosts: buildAllowedHosts('[2001:db8::1]') })
+        const res = createMockRes()
+        const next = vi.fn()
+        middleware(createReq({ host: '[2001:db8::1]:3000' }), res, next)
+
+        expect(next).toHaveBeenCalledOnce()
+        expect(res.status).not.toHaveBeenCalled()
+    })
+
+    it('matches an expanded IPv6 bind host against a compressed request host', () => {
+        // HOST set to the fully expanded literal; the request uses the compressed
+        // canonical form. Both must normalise to the same value.
+        const middleware = requireTrustedHost({
+            allowedHosts: buildAllowedHosts('2001:db8:0:0:0:0:0:1'),
+        })
+        const res = createMockRes()
+        const next = vi.fn()
+        middleware(createReq({ host: '[2001:db8::1]:3000' }), res, next)
+
+        expect(next).toHaveBeenCalledOnce()
+        expect(res.status).not.toHaveBeenCalled()
+    })
+
+    it('does not add the 0.0.0.0 bind wildcard', () => {
+        expect(buildAllowedHosts('0.0.0.0')).toEqual(DEFAULT_ALLOWED_HOSTS)
+    })
+
+    it('does not add the :: bind wildcard', () => {
+        expect(buildAllowedHosts('::')).toEqual(DEFAULT_ALLOWED_HOSTS)
+    })
+
+    it('parses ALLOWED_HOSTS, trimming whitespace and dropping empties', () => {
+        expect(buildAllowedHosts('0.0.0.0', 'a.lan, b.lan ,')).toEqual([
+            ...DEFAULT_ALLOWED_HOSTS,
+            'a.lan',
+            'b.lan',
+        ])
+    })
+
+    it('deduplicates entries already present in the defaults', () => {
+        expect(buildAllowedHosts('127.0.0.1', 'localhost')).toEqual(DEFAULT_ALLOWED_HOSTS)
+    })
+})

--- a/src/middleware/require-trusted-host.test.ts
+++ b/src/middleware/require-trusted-host.test.ts
@@ -62,7 +62,10 @@ describe('requireTrustedHost', () => {
             // Host (which still carries the attacker's domain) is rejected.
             ['evil.com'],
             ['http://'],
-        ])('rejects untrusted/unparseable host %s with 403', (host) => {
+            // URL-only syntax that must not be normalised to a trusted host.
+            ['foo@127.0.0.1'],
+            ['127.0.0.1/../evil'],
+        ])('rejects untrusted/malformed host %s with 403', (host) => {
             const res = createMockRes()
             middleware(createReq({ host }), res, next)
 
@@ -168,6 +171,10 @@ describe('buildAllowedHosts', () => {
         expect(res.status).not.toHaveBeenCalled()
     })
 
+    it('auto-includes a non-default loopback alias bind host (e.g. 127.0.1.1)', () => {
+        expect(buildAllowedHosts('127.0.1.1')).toEqual([...DEFAULT_ALLOWED_HOSTS, '127.0.1.1'])
+    })
+
     it('does not add the 0.0.0.0 bind wildcard', () => {
         expect(buildAllowedHosts('0.0.0.0')).toEqual(DEFAULT_ALLOWED_HOSTS)
     })
@@ -186,5 +193,23 @@ describe('buildAllowedHosts', () => {
 
     it('deduplicates entries already present in the defaults', () => {
         expect(buildAllowedHosts('127.0.0.1', 'localhost')).toEqual(DEFAULT_ALLOWED_HOSTS)
+    })
+})
+
+describe('requireTrustedHost construction', () => {
+    it.each([
+        ['unbracketed IPv6', '2001:db8::1'],
+        ['whitespace', 'bad host'],
+        ['userinfo', 'a@b'],
+    ])('throws fast on an invalid allowed host (%s)', (_label, badEntry) => {
+        expect(() => requireTrustedHost({ allowedHosts: [badEntry] })).toThrow(
+            /Invalid allowed host/,
+        )
+    })
+
+    it('does not throw for valid entries', () => {
+        expect(() =>
+            requireTrustedHost({ allowedHosts: [...DEFAULT_ALLOWED_HOSTS, 'mcp.lan'] }),
+        ).not.toThrow()
     })
 })

--- a/src/middleware/require-trusted-host.ts
+++ b/src/middleware/require-trusted-host.ts
@@ -1,12 +1,12 @@
 import { isIP } from 'node:net'
 import type { NextFunction, Request, RequestHandler, Response } from 'express'
-import { isLoopbackHost, normalizeListenHost } from '../utils/host.js'
+import { normalizeListenHost } from '../utils/host.js'
 
 type RequireTrustedHostOptions = {
     /**
      * Port-agnostic hostnames permitted in the `Host` and `Origin` headers.
-     * IPv6 entries must be bracketed, e.g. `[::1]`, to match how the URL parser
-     * normalises hostnames.
+     * IPv6 entries must be bracketed, e.g. `[::1]`. Invalid entries cause
+     * {@link requireTrustedHost} to throw at construction time (fail fast).
      */
     allowedHosts: string[]
 }
@@ -17,25 +17,53 @@ type RequireTrustedHostOptions = {
  */
 const DEFAULT_ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]']
 
+// Characters that may appear in a URL but never in a bare `host[:port]`
+// authority. Rejecting them keeps `Host` parsing from being fooled by URL-only
+// syntax such as `foo@127.0.0.1` (which `new URL()` would normalise to a
+// trusted host) or embedded paths/queries/fragments.
+const NON_AUTHORITY_CHARS = /[@/\\?#\s]/
+
 /**
- * Extract the hostname from a `Host` (scheme-less) or `Origin` (with scheme)
- * header value, port-agnostic and lowercased. Returns `undefined` when the
- * value cannot be parsed (e.g. the literal `null` origin).
+ * Canonicalise a bare `host[:port]` authority (a `Host` header value or an
+ * allowlist entry) to its port-agnostic, lowercased hostname. Returns
+ * `undefined` for anything that isn't a valid authority. IPv6 is canonicalised
+ * too, so `[2001:db8:0:0:0:0:0:1]` and `[2001:db8::1]` compare equal.
  */
-function parseHostname(value: string): string | undefined {
+function canonicalHostFromAuthority(value: string): string | undefined {
+    if (NON_AUTHORITY_CHARS.test(value)) {
+        return undefined
+    }
     try {
-        const url = value.includes('://') ? new URL(value) : new URL(`http://${value}`)
-        return url.hostname.toLowerCase()
+        return new URL(`http://${value}`).hostname.toLowerCase()
     } catch {
         return undefined
     }
 }
 
 /**
+ * Canonicalise an `Origin` header (`scheme://host[:port]`) to its lowercased
+ * hostname. Returns `undefined` for the literal `null` origin, malformed values,
+ * or anything carrying userinfo / path / query / fragment (a real Origin has
+ * none of those).
+ */
+function canonicalHostFromOrigin(value: string): string | undefined {
+    let url: URL
+    try {
+        url = new URL(value)
+    } catch {
+        return undefined
+    }
+    if (url.username || url.password || url.pathname !== '/' || url.search || url.hash) {
+        return undefined
+    }
+    return url.hostname.toLowerCase()
+}
+
+/**
  * Build the list of hostnames trusted in the Host and Origin headers. Always
  * includes the loopback defaults, plus any names from `allowedHostsEnv`
- * (comma-separated), plus the configured `host` when it is a concrete
- * non-loopback interface (e.g. a direct bind to 192.168.1.50). Bind wildcards
+ * (comma-separated), plus the configured `host` (so an explicit bind — loopback
+ * alias like 127.0.1.1, a LAN IP, etc. — is always trusted). Bind wildcards
  * (0.0.0.0/::) are never added because they are never valid Host header values —
  * operators exposing on a wildcard must enumerate client hostnames via
  * ALLOWED_HOSTS.
@@ -51,14 +79,9 @@ function buildAllowedHosts(host: string, allowedHostsEnv?: string): string[] {
     }
 
     const normalizedHost = normalizeListenHost(host)
-    if (
-        normalizedHost &&
-        normalizedHost !== '0.0.0.0' &&
-        normalizedHost !== '::' &&
-        !isLoopbackHost(normalizedHost)
-    ) {
-        // Re-bracket IPv6 so the entry matches what parseHostname() produces for
-        // request headers (e.g. `[2001:db8::1]`); otherwise IPv6 binds 403.
+    if (normalizedHost && normalizedHost !== '0.0.0.0' && normalizedHost !== '::') {
+        // Re-bracket IPv6 so the entry is a valid authority and matches what the
+        // request side produces (e.g. `[2001:db8::1]`); otherwise IPv6 binds 403.
         hosts.add(isIP(normalizedHost) === 6 ? `[${normalizedHost}]` : normalizedHost)
     }
 
@@ -85,19 +108,26 @@ function forbidden(res: Response, message: string): void {
  * - `Origin` absent → allowed (non-browser clients such as `mcp-remote`/`curl`
  *   send none; the browser attack path always sends one).
  * - `Origin` present but untrusted or unparseable → 403.
+ *
+ * Throws at construction time if `allowedHosts` contains an entry that isn't a
+ * valid authority, so misconfiguration fails fast instead of becoming opaque
+ * 403s at request time.
  */
 function requireTrustedHost(options: RequireTrustedHostOptions): RequestHandler {
     // Canonicalise each allowed host through the same parser used for incoming
     // headers so differently formatted-but-equivalent literals match — e.g. an
     // expanded IPv6 entry `[2001:db8:0:0:0:0:0:1]` and a request's compressed
-    // `[2001:db8::1]` both normalise to the same value. Unparseable entries are
-    // dropped rather than silently mismatching.
+    // `[2001:db8::1]` both normalise to the same value.
     const allow = new Set<string>()
     for (const host of options.allowedHosts) {
-        const canonical = parseHostname(host)
-        if (canonical) {
-            allow.add(canonical)
+        const canonical = canonicalHostFromAuthority(host)
+        if (!canonical) {
+            throw new Error(
+                `Invalid allowed host ${JSON.stringify(host)}: must be a hostname or host:port ` +
+                    '(IPv6 literals must be bracketed, e.g. [::1])',
+            )
         }
+        allow.add(canonical)
     }
 
     return (req: Request, res: Response, next: NextFunction): void => {
@@ -107,7 +137,7 @@ function requireTrustedHost(options: RequireTrustedHostOptions): RequestHandler 
             return
         }
 
-        const hostname = parseHostname(hostHeader)
+        const hostname = canonicalHostFromAuthority(hostHeader)
         if (!hostname || !allow.has(hostname)) {
             forbidden(res, `Invalid Host: ${hostHeader}`)
             return
@@ -115,7 +145,7 @@ function requireTrustedHost(options: RequireTrustedHostOptions): RequestHandler 
 
         const origin = req.headers.origin
         if (origin) {
-            const originHostname = parseHostname(origin)
+            const originHostname = canonicalHostFromOrigin(origin)
             if (!originHostname || !allow.has(originHostname)) {
                 forbidden(res, `Invalid Origin: ${origin}`)
                 return

--- a/src/middleware/require-trusted-host.ts
+++ b/src/middleware/require-trusted-host.ts
@@ -1,0 +1,134 @@
+import { isIP } from 'node:net'
+import type { NextFunction, Request, RequestHandler, Response } from 'express'
+import { isLoopbackHost, normalizeListenHost } from '../utils/host.js'
+
+type RequireTrustedHostOptions = {
+    /**
+     * Port-agnostic hostnames permitted in the `Host` and `Origin` headers.
+     * IPv6 entries must be bracketed, e.g. `[::1]`, to match how the URL parser
+     * normalises hostnames.
+     */
+    allowedHosts: string[]
+}
+
+/**
+ * Loopback hostnames always trusted by {@link requireTrustedHost}. Stored
+ * bracketed for IPv6 because `new URL('http://[::1]').hostname` returns `[::1]`.
+ */
+const DEFAULT_ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]']
+
+/**
+ * Extract the hostname from a `Host` (scheme-less) or `Origin` (with scheme)
+ * header value, port-agnostic and lowercased. Returns `undefined` when the
+ * value cannot be parsed (e.g. the literal `null` origin).
+ */
+function parseHostname(value: string): string | undefined {
+    try {
+        const url = value.includes('://') ? new URL(value) : new URL(`http://${value}`)
+        return url.hostname.toLowerCase()
+    } catch {
+        return undefined
+    }
+}
+
+/**
+ * Build the list of hostnames trusted in the Host and Origin headers. Always
+ * includes the loopback defaults, plus any names from `allowedHostsEnv`
+ * (comma-separated), plus the configured `host` when it is a concrete
+ * non-loopback interface (e.g. a direct bind to 192.168.1.50). Bind wildcards
+ * (0.0.0.0/::) are never added because they are never valid Host header values —
+ * operators exposing on a wildcard must enumerate client hostnames via
+ * ALLOWED_HOSTS.
+ */
+function buildAllowedHosts(host: string, allowedHostsEnv?: string): string[] {
+    const hosts = new Set(DEFAULT_ALLOWED_HOSTS)
+
+    for (const entry of (allowedHostsEnv ?? '').split(',')) {
+        const trimmed = entry.trim()
+        if (trimmed) {
+            hosts.add(trimmed)
+        }
+    }
+
+    const normalizedHost = normalizeListenHost(host)
+    if (
+        normalizedHost &&
+        normalizedHost !== '0.0.0.0' &&
+        normalizedHost !== '::' &&
+        !isLoopbackHost(normalizedHost)
+    ) {
+        // Re-bracket IPv6 so the entry matches what parseHostname() produces for
+        // request headers (e.g. `[2001:db8::1]`); otherwise IPv6 binds 403.
+        hosts.add(isIP(normalizedHost) === 6 ? `[${normalizedHost}]` : normalizedHost)
+    }
+
+    return [...hosts]
+}
+
+function forbidden(res: Response, message: string): void {
+    res.status(403).json({
+        jsonrpc: '2.0',
+        error: { code: -32000, message },
+        id: null,
+    })
+}
+
+/**
+ * Express middleware that rejects requests whose `Host` or `Origin` header is
+ * not in the trusted allowlist. This is DNS-rebinding protection: a malicious
+ * website that rebinds its domain to a victim's loopback address keeps its own
+ * `Host`/`Origin`, so string-matching against the allowlist (we never DNS
+ * resolve) blocks the request before it can reach the MCP transport.
+ *
+ * - Missing `Host` → 403.
+ * - `Host` hostname not in the allowlist → 403.
+ * - `Origin` absent → allowed (non-browser clients such as `mcp-remote`/`curl`
+ *   send none; the browser attack path always sends one).
+ * - `Origin` present but untrusted or unparseable → 403.
+ */
+function requireTrustedHost(options: RequireTrustedHostOptions): RequestHandler {
+    // Canonicalise each allowed host through the same parser used for incoming
+    // headers so differently formatted-but-equivalent literals match — e.g. an
+    // expanded IPv6 entry `[2001:db8:0:0:0:0:0:1]` and a request's compressed
+    // `[2001:db8::1]` both normalise to the same value. Unparseable entries are
+    // dropped rather than silently mismatching.
+    const allow = new Set<string>()
+    for (const host of options.allowedHosts) {
+        const canonical = parseHostname(host)
+        if (canonical) {
+            allow.add(canonical)
+        }
+    }
+
+    return (req: Request, res: Response, next: NextFunction): void => {
+        const hostHeader = req.headers.host
+        if (!hostHeader) {
+            forbidden(res, 'Missing Host header')
+            return
+        }
+
+        const hostname = parseHostname(hostHeader)
+        if (!hostname || !allow.has(hostname)) {
+            forbidden(res, `Invalid Host: ${hostHeader}`)
+            return
+        }
+
+        const origin = req.headers.origin
+        if (origin) {
+            const originHostname = parseHostname(origin)
+            if (!originHostname || !allow.has(originHostname)) {
+                forbidden(res, `Invalid Origin: ${origin}`)
+                return
+            }
+        }
+
+        next()
+    }
+}
+
+export {
+    DEFAULT_ALLOWED_HOSTS,
+    buildAllowedHosts,
+    requireTrustedHost,
+    type RequireTrustedHostOptions,
+}

--- a/src/utils/host.test.ts
+++ b/src/utils/host.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { isLoopbackHost, normalizeListenHost } from './host.js'
+
+describe('normalizeListenHost', () => {
+    it('strips brackets from a bracketed IPv6 literal', () => {
+        expect(normalizeListenHost('[::1]')).toBe('::1')
+        expect(normalizeListenHost('[2001:db8::1]')).toBe('2001:db8::1')
+    })
+
+    it('leaves non-bracketed hosts unchanged', () => {
+        expect(normalizeListenHost('127.0.0.1')).toBe('127.0.0.1')
+        expect(normalizeListenHost('localhost')).toBe('localhost')
+    })
+})
+
+describe('isLoopbackHost', () => {
+    it.each([
+        ['localhost'],
+        ['127.0.0.1'],
+        ['127.10.20.30'],
+        ['::1'],
+        ['[::1]'],
+        ['0:0:0:0:0:0:0:1'],
+    ])('treats %s as loopback', (host) => {
+        expect(isLoopbackHost(host)).toBe(true)
+    })
+
+    it.each([['0.0.0.0'], ['::'], ['192.168.1.50'], ['2001:db8::1'], ['mcp.lan']])(
+        'treats %s as non-loopback',
+        (host) => {
+            expect(isLoopbackHost(host)).toBe(false)
+        },
+    )
+})

--- a/src/utils/host.ts
+++ b/src/utils/host.ts
@@ -1,0 +1,26 @@
+import { isIP } from 'node:net'
+
+/** Strip the surrounding brackets from a bracketed IPv6 literal, if present. */
+function normalizeListenHost(host: string): string {
+    if (host.startsWith('[') && host.endsWith(']')) {
+        return host.slice(1, -1)
+    }
+    return host
+}
+
+/** Whether `host` refers to a loopback interface (localhost / 127.0.0.0/8 / ::1). */
+function isLoopbackHost(host: string): boolean {
+    host = normalizeListenHost(host)
+    if (host === 'localhost') {
+        return true
+    }
+    if (host === '::1' || host === '0:0:0:0:0:0:0:1') {
+        return true
+    }
+    if (isIP(host) === 4) {
+        return host.split('.')[0] === '127'
+    }
+    return false
+}
+
+export { isLoopbackHost, normalizeListenHost }


### PR DESCRIPTION
## Summary

The standalone `todoist-mcp-http` server dispatched `POST /mcp` to the MCP transport **without validating the `Host` or `Origin` header**. Binding to `127.0.0.1` (PR #510) did not protect it: a malicious website could use **DNS rebinding** to reach the loopback server same-origin (bypassing CORS) and invoke Todoist tools with the operator's `TODOIST_API_KEY` — with no caller credential.

Resolves the critical advisory **GHSA-833v-v58w-294h** (also raised as Doist/Issues#20524).

## What changed

- **New `requireTrustedHost` middleware** (`src/middleware/require-trusted-host.ts`) validates the `Host` and `Origin` headers against a trusted-hostname allowlist:
  - Defaults: `localhost`, `127.0.0.1`, `[::1]`.
  - Operators extend it with a new `ALLOWED_HOSTS` env var (comma-separated); a concrete non-loopback `HOST` (e.g. `192.168.1.50`) is auto-included. Bind wildcards (`0.0.0.0`/`::`) are never trusted.
  - Untrusted `Host` or `Origin` → `403` before the request reaches the transport. Absent `Origin` is allowed so non-browser clients (mcp-remote, curl) keep working.
  - Allowed hosts and incoming headers are canonicalised through the same parser, so equivalent IPv6 literals match.
- **Guard scoped to the `/mcp` routes**, running ahead of body parsing and token auth. `/health` is intentionally left unguarded so deployment health probes (which use the target's private IP in the `Host` header) keep working.
- **Refactor for testability:** the Express app is extracted into a pure `createHttpApp()` (`src/http-app.ts`), leaving `main-http.ts` as a thin bootstrap; shared host helpers moved to `src/utils/host.ts`.
- Docs (`docs/mcp-server.md`) and `CODEBASE.md` updated.

A per-request bearer token was considered but deferred — it would break existing no-credential local clients, and the advisory lists it as optional extra hardening. `Host`/`Origin` validation closes the DNS-rebinding vector.

## Scope

Only the optional HTTP transport (`todoist-mcp-http`) is affected. The stdio entrypoint is not browser-reachable and is unchanged.

## Testing

- New unit tests for the middleware and the allowlist builder (`require-trusted-host.test.ts`), the host helpers (`utils/host.test.ts`), and the wired middleware chain via an ephemeral server (`http-app.test.ts`).
- Full suite green (968 tests), type-check and format clean.
- Manually verified against the built server: `/mcp` with a spoofed `Host`/`Origin` → `403`; trusted `Host` → passes the guard (`401` for a bad token); `/health` with a spoofed `Host` → `200`; LAN mode (`HOST=0.0.0.0 ALLOWED_HOSTS=mcp.lan`) accepts the configured host and rejects others.

Fixes https://github.com/Doist/Issues/issues/20524

🤖 Generated with [Claude Code](https://claude.com/claude-code)