### PR TITLE
feat(projects): support archived projects in find-projects

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -43,7 +43,7 @@ src/
 ├─ mcp-helpers.ts             # registerTool(), FEATURE_NAMES, output formatting, retry wrapping
 ├─ usage-tracking.ts          # Shared Todoist request headers + SDK customFetch wrapper for MCP usage attribution
 ├─ todoist-tool.ts            # TodoistTool<Params, Output> contract (the tool interface)
-├─ tool-helpers.ts            # Shared transforms: mapTask, fetchAllPages, resolveInboxProjectId, isInboxProjectId, isPersonalProject, isWorkspaceProject. Re-exports filter-helpers.
+├─ tool-helpers.ts            # Shared transforms: mapTask, fetchAllPages, toWildcardQuery, matchesWildcardQuery (client-side name match), resolveInboxProjectId, isInboxProjectId, isPersonalProject, isWorkspaceProject. Re-exports filter-helpers.
 ├─ filter-helpers.ts          # appendToQuery, buildResponsibleUserQueryFilter, resolveResponsibleUser
 ├─ tool-execution-error.ts    # ToolExecutionError: wraps SDK errors with user/system classification
 ├─ prompts/                   # MCP prompts (productivity-analysis)

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -43,7 +43,7 @@ src/
 ├─ mcp-helpers.ts             # registerTool(), FEATURE_NAMES, output formatting, retry wrapping
 ├─ usage-tracking.ts          # Shared Todoist request headers + SDK customFetch wrapper for MCP usage attribution
 ├─ todoist-tool.ts            # TodoistTool<Params, Output> contract (the tool interface)
-├─ tool-helpers.ts            # Shared transforms: mapTask, fetchAllPages, toWildcardQuery, matchesWildcardQuery (client-side name match), resolveInboxProjectId, isInboxProjectId, isPersonalProject, isWorkspaceProject. Re-exports filter-helpers.
+├─ tool-helpers.ts            # Shared transforms: mapTask, fetchAllPages, toWildcardQuery, compileWildcardQuery + matchesWildcardQuery (client-side name match), resolveInboxProjectId, isInboxProjectId, isPersonalProject, isWorkspaceProject. Re-exports filter-helpers.
 ├─ filter-helpers.ts          # appendToQuery, buildResponsibleUserQueryFilter, resolveResponsibleUser
 ├─ tool-execution-error.ts    # ToolExecutionError: wraps SDK errors with user/system classification
 ├─ prompts/                   # MCP prompts (productivity-analysis)

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -86,8 +86,9 @@ You have access to comprehensive Todoist management tools for personal productiv
 - **find-completed-tasks**: View completed tasks by completion date or original due date; if since/until are omitted, defaults to the last 7 days (returns all collaborators unless filtered)
 
 **Project & Organization:**
-- **add-projects/update-projects/find-projects**: Manage project lifecycle with names, descriptions (Markdown), favorites, view styles (list/board/calendar), and workspace assignment for new projects (by name or ID)
+- **add-projects/update-projects/find-projects**: Manage project lifecycle with names, descriptions (Markdown), favorites, view styles (list/board/calendar), and workspace assignment for new projects (by name or ID). find-projects returns active projects by default; pass archivedStatus ('archived' or 'all') to include archived projects. Every returned project includes an isArchived field
 - **project-management**: Archive or unarchive projects by ID
+- To delete a project (active or archived), use **delete-object** with type "project". Note: workspace projects must be archived first; personal projects can be deleted regardless
 - **project-move**: Move projects between personal and workspace contexts
 - **add-sections/update-sections/find-sections**: Organize tasks within projects using sections
 - **find-goals/add-goals/update-goals**: Manage goals (personal or workspace). Goals track progress via linked tasks
@@ -125,7 +126,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 - **get-workspace-insights**: Get aggregated health and progress insights across all projects in a workspace. Accepts workspace name or ID, with optional project ID filtering.
 
 **General Operations:**
-- **delete-object**: Remove projects, sections, tasks, comments, labels, filters, reminders, or location reminders by type and ID
+- **delete-object**: Remove projects, sections, tasks, comments, labels, filters, reminders, or location reminders by type and ID. Deletes both active and archived projects (workspace projects must be archived first; use find-projects with archivedStatus to locate archived projects)
 - **fetch-object**: Fetch a single task, project, comment, or section by its ID
 - **reorder-objects**: Reorder sibling projects or sections, and optionally move projects to a new parent. For projects: set order to reorder siblings, and/or set parentId to move under a new parent (use "root" for top level). For sections: set order to reorder within a project
 - **user-info**: Get user details including timezone, goals, and plan information

--- a/src/tool-helpers.test.ts
+++ b/src/tool-helpers.test.ts
@@ -413,6 +413,13 @@ End of description.`)
             expect(matchesWildcardQuery('back\\slash notes', 'back\\slash*')).toBe(true)
         })
 
+        it('treats an escaped backslash followed by a wildcard as literal-backslash + wildcard', () => {
+            // Query `a\\*b`: `\\` is a literal backslash, `*` is a wildcard, matching
+            // `a\` + anything + `b` (same as server-side search), not the literal `a\\*b`.
+            expect(matchesWildcardQuery('a\\Xb', 'a\\\\*b')).toBe(true)
+            expect(matchesWildcardQuery('aXb', 'a\\\\*b')).toBe(false)
+        })
+
         it('compiles a reusable case-insensitive RegExp', () => {
             const regex = compileWildcardQuery('work*')
             expect(regex).toBeInstanceOf(RegExp)

--- a/src/tool-helpers.test.ts
+++ b/src/tool-helpers.test.ts
@@ -1,10 +1,12 @@
 import type { PersonalProject, Section, TodoistApi } from '@doist/todoist-sdk'
 import { type Mocked, vi } from 'vitest'
 import {
+    compileWildcardQuery,
     createMoveTaskArgs,
     fetchAllPages,
     mapProject,
     mapTask,
+    matchesWildcardQuery,
     searchAllProjects,
     searchAllSections,
     toWildcardQuery,
@@ -148,6 +150,7 @@ End of description.`)
                 inboxProject: false,
                 viewStyle: 'list',
                 childOrder: 1,
+                isArchived: false,
             } as unknown as PersonalProject
 
             expect(mapProject(mockPersonalProject)).toEqual({
@@ -162,6 +165,7 @@ End of description.`)
                 workspaceId: undefined,
                 folderId: undefined,
                 childOrder: 1,
+                isArchived: false,
             })
         })
 
@@ -189,6 +193,7 @@ End of description.`)
                 workspaceId: TEST_IDS.WORKSPACE_1,
                 folderId: undefined,
                 childOrder: 1,
+                isArchived: false,
             })
         })
 
@@ -218,6 +223,7 @@ End of description.`)
                 workspaceId: TEST_IDS.WORKSPACE_1,
                 folderId: 'folder-42',
                 childOrder: 5,
+                isArchived: false,
             })
         })
     })
@@ -368,6 +374,51 @@ End of description.`)
 
         it('should detect unescaped wildcard after escaped backslash', () => {
             expect(toWildcardQuery('a\\\\*b')).toBe('a\\\\*b')
+        })
+    })
+
+    describe('compileWildcardQuery / matchesWildcardQuery', () => {
+        it('matches as a substring when the query has no wildcard', () => {
+            expect(matchesWildcardQuery('Old work notes', 'work')).toBe(true)
+            expect(matchesWildcardQuery('Personal Stuff', 'work')).toBe(false)
+        })
+
+        it('is case-insensitive', () => {
+            expect(matchesWildcardQuery('WORK Project', 'work')).toBe(true)
+            expect(matchesWildcardQuery('work project', 'WORK')).toBe(true)
+        })
+
+        it('treats a trailing wildcard as a prefix match', () => {
+            expect(matchesWildcardQuery('Work Archive', 'work*')).toBe(true)
+            expect(matchesWildcardQuery('Old work notes', 'work*')).toBe(false)
+        })
+
+        it('treats a leading wildcard as a suffix match', () => {
+            expect(matchesWildcardQuery('My Work', '*work')).toBe(true)
+            expect(matchesWildcardQuery('Work stuff', '*work')).toBe(false)
+        })
+
+        it('escapes regex special characters in the query', () => {
+            expect(matchesWildcardQuery('a.b', 'a.b')).toBe(true)
+            expect(matchesWildcardQuery('axb', 'a.b')).toBe(false)
+        })
+
+        it('treats an escaped asterisk as a literal asterisk', () => {
+            expect(matchesWildcardQuery('a*b', 'a\\*b')).toBe(true)
+            expect(matchesWildcardQuery('aXb', 'a\\*b')).toBe(false)
+        })
+
+        it('preserves literal backslashes when the query also contains a wildcard', () => {
+            // Regression: the backslash before "slash" must not be dropped as an escape.
+            expect(matchesWildcardQuery('back\\slash notes', 'back\\slash*')).toBe(true)
+        })
+
+        it('compiles a reusable case-insensitive RegExp', () => {
+            const regex = compileWildcardQuery('work*')
+            expect(regex).toBeInstanceOf(RegExp)
+            expect(regex.flags).toContain('i')
+            expect(regex.test('Work Archive')).toBe(true)
+            expect(regex.test('Old work notes')).toBe(false)
         })
     })
 

--- a/src/tool-helpers.ts
+++ b/src/tool-helpers.ts
@@ -156,6 +156,79 @@ export async function searchAllProjects(client: TodoistApi, query: string): Prom
 }
 
 /**
+ * Fetches all active (non-archived) projects across every page.
+ *
+ * @param client - The Todoist API client
+ * @returns Promise resolving to array of active projects
+ */
+export async function fetchAllActiveProjects(client: TodoistApi): Promise<Project[]> {
+    return fetchAllPages({
+        apiMethod: client.getProjects.bind(client),
+        args: {},
+        limit: ApiLimits.PROJECTS_MAX,
+    })
+}
+
+/**
+ * Fetches all archived projects across every page.
+ *
+ * The API has no server-side search for archived projects, so callers that need
+ * to filter by name should fetch all and filter client-side with
+ * {@link matchesWildcardQuery}.
+ *
+ * @param client - The Todoist API client
+ * @returns Promise resolving to array of archived projects
+ */
+export async function fetchAllArchivedProjects(client: TodoistApi): Promise<Project[]> {
+    return fetchAllPages({
+        apiMethod: client.getArchivedProjects.bind(client),
+        args: {},
+        limit: ApiLimits.PROJECTS_MAX,
+    })
+}
+
+/**
+ * Compiles a search query into a case-insensitive RegExp using the same wildcard
+ * semantics as server-side search (see {@link toWildcardQuery}): `*` matches any
+ * sequence, `\*` is a literal asterisk, and every other character (backslashes
+ * included) is matched literally. A query without an unescaped `*` matches as a
+ * substring; otherwise the whole name must match.
+ *
+ * Compile once and reuse the result when filtering many names (e.g. archived
+ * projects), rather than calling {@link matchesWildcardQuery} per item.
+ */
+export function compileWildcardQuery(query: string): RegExp {
+    const escapeRegex = (char: string) => char.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    // Unescaped wildcard = `*` preceded by an even number of backslashes
+    const hasWildcard = /(?<!\\)(?:\\\\)*\*/.test(query)
+    const chars = [...query]
+    let pattern = ''
+    for (let i = 0; i < chars.length; i++) {
+        const char = chars[i] as string
+        if (char === '\\' && chars[i + 1] === '*') {
+            pattern += '\\*' // literal asterisk
+            i++
+        } else if (char === '*') {
+            pattern += '.*' // wildcard
+        } else {
+            pattern += escapeRegex(char)
+        }
+    }
+    // No wildcard → substring (unanchored) match; wildcard → match the whole name.
+    return new RegExp(hasWildcard ? `^${pattern}$` : pattern, 'iu')
+}
+
+/**
+ * Tests whether a name matches a search query using the same wildcard semantics
+ * as server-side search. Used for client-side filtering where the API exposes no
+ * search endpoint (e.g. archived projects). For bulk filtering, prefer
+ * {@link compileWildcardQuery} so the pattern is compiled only once.
+ */
+export function matchesWildcardQuery(name: string, query: string): boolean {
+    return compileWildcardQuery(query).test(name)
+}
+
+/**
  * Searches labels by name and fetches all matching pages.
  *
  * @param client - The Todoist API client
@@ -284,6 +357,7 @@ function mapProject(project: Project) {
         workspaceId: isWorkspaceProject(project) ? project.workspaceId : undefined,
         folderId: isWorkspaceProject(project) ? (project.folderId ?? undefined) : undefined,
         childOrder: project.childOrder,
+        isArchived: project.isArchived,
     }
 }
 

--- a/src/tool-helpers.ts
+++ b/src/tool-helpers.ts
@@ -205,8 +205,11 @@ export function compileWildcardQuery(query: string): RegExp {
     let pattern = ''
     for (let i = 0; i < chars.length; i++) {
         const char = chars[i] as string
-        if (char === '\\' && chars[i + 1] === '*') {
-            pattern += '\\*' // literal asterisk
+        if (char === '\\' && chars[i + 1] === '\\') {
+            pattern += '\\\\' // escaped backslash → literal backslash
+            i++
+        } else if (char === '\\' && chars[i + 1] === '*') {
+            pattern += '\\*' // escaped asterisk → literal asterisk
             i++
         } else if (char === '*') {
             pattern += '.*' // wildcard

--- a/src/tools/add-projects.test.ts
+++ b/src/tools/add-projects.test.ts
@@ -339,6 +339,7 @@ describe(`${ADD_PROJECTS} tool`, () => {
                 'workspaceId',
                 'folderId',
                 'childOrder',
+                'isArchived',
             ]
             const actualKeys = Object.keys(project)
             expect(actualKeys.sort()).toEqual(allowedKeys.sort())
@@ -348,7 +349,6 @@ describe(`${ADD_PROJECTS} tool`, () => {
                 'createdAt',
                 'updatedAt',
                 'defaultOrder',
-                'isArchived',
                 'isCollapsed',
                 'isDeleted',
                 'isFrozen',

--- a/src/tools/delete-object.ts
+++ b/src/tools/delete-object.ts
@@ -33,7 +33,7 @@ const OutputSchema = {
 const deleteObject = {
     name: ToolNames.DELETE_OBJECT,
     description:
-        'Delete a project, section, task, comment, label, filter, goal, reminder, or location_reminder by its ID.',
+        'Delete a project, section, task, comment, label, filter, goal, reminder, or location_reminder by its ID. Projects can be deleted whether active or archived (find archived ones via find-projects with archivedStatus); note a workspace project must be archived before it can be deleted, while personal projects can be deleted regardless.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },

--- a/src/tools/find-projects.test.ts
+++ b/src/tools/find-projects.test.ts
@@ -15,6 +15,7 @@ import { findProjects } from './find-projects.js'
 const mockTodoistApi = {
     getProjects: vi.fn(),
     searchProjects: vi.fn(),
+    getArchivedProjects: vi.fn(),
 } as unknown as Mocked<TodoistApi>
 
 const { FIND_PROJECTS } = ToolNames
@@ -269,6 +270,7 @@ describe(`${FIND_PROJECTS} tool`, () => {
                     inboxProject: true,
                     viewStyle: 'list',
                     childOrder: 0,
+                    isArchived: false,
                 }
                 // Should parse without throwing
                 const parsed = ProjectSchema.parse(project)
@@ -288,6 +290,7 @@ describe(`${FIND_PROJECTS} tool`, () => {
                     inboxProject: true,
                     viewStyle: 'list',
                     childOrder: 0,
+                    isArchived: false,
                 }
                 expect(() => ProjectSchema.parse(project)).not.toThrow()
             })
@@ -361,6 +364,176 @@ describe(`${FIND_PROJECTS} tool`, () => {
 
             expect(result.structuredContent.projects).toHaveLength(1)
             expect(result.structuredContent.projects[0]?.name).toBe('Work Project')
+        })
+    })
+
+    describe('archived projects', () => {
+        it("should list only archived projects when archivedStatus is 'archived'", async () => {
+            const archivedProjects = [
+                createMockProject({
+                    id: 'archived-1',
+                    name: 'Old Project',
+                    isArchived: true,
+                }),
+            ]
+            mockTodoistApi.getArchivedProjects.mockResolvedValue(
+                createMockApiResponse(archivedProjects),
+            )
+
+            const result = await findProjects.execute(
+                { limit: 50, archivedStatus: 'archived' },
+                mockTodoistApi,
+            )
+
+            // Uses the archived endpoint, never the active one
+            expect(mockTodoistApi.getArchivedProjects).toHaveBeenCalledWith({
+                limit: 50,
+                cursor: null,
+            })
+            expect(mockTodoistApi.getProjects).not.toHaveBeenCalled()
+
+            const structuredContent = result.structuredContent
+            expect(structuredContent.projects).toHaveLength(1)
+            expect(structuredContent.projects[0]?.isArchived).toBe(true)
+            expect(structuredContent.totalCount).toBe(1)
+        })
+
+        it("should paginate archived projects when archivedStatus is 'archived'", async () => {
+            mockTodoistApi.getArchivedProjects.mockResolvedValue(
+                createMockApiResponse(
+                    [createMockProject({ id: 'archived-1', isArchived: true })],
+                    'next-archived-cursor',
+                ),
+            )
+
+            const result = await findProjects.execute(
+                { limit: 10, cursor: 'archived-cursor', archivedStatus: 'archived' },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.getArchivedProjects).toHaveBeenCalledWith({
+                limit: 10,
+                cursor: 'archived-cursor',
+            })
+            expect(result.structuredContent.hasMore).toBe(true)
+            expect(result.structuredContent.nextCursor).toBe('next-archived-cursor')
+        })
+
+        it("should merge active and archived projects when archivedStatus is 'all'", async () => {
+            mockTodoistApi.getProjects.mockResolvedValue(
+                createMockApiResponse([
+                    createMockProject({ id: 'active-1', name: 'Active', isArchived: false }),
+                ]),
+            )
+            mockTodoistApi.getArchivedProjects.mockResolvedValue(
+                createMockApiResponse([
+                    createMockProject({ id: 'archived-1', name: 'Archived', isArchived: true }),
+                ]),
+            )
+
+            const result = await findProjects.execute(
+                { limit: 50, archivedStatus: 'all' },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.getProjects).toHaveBeenCalled()
+            expect(mockTodoistApi.getArchivedProjects).toHaveBeenCalled()
+
+            const structuredContent = result.structuredContent
+            expect(structuredContent.projects).toHaveLength(2)
+            expect(structuredContent.projects.map((p) => p.isArchived).sort()).toEqual([
+                false,
+                true,
+            ])
+            // Combined results are not cursor-paginated
+            expect(structuredContent.hasMore).toBe(false)
+            expect(structuredContent.nextCursor).toBeUndefined()
+        })
+
+        it("should filter archived projects by searchText client-side when archivedStatus is 'archived'", async () => {
+            mockTodoistApi.getArchivedProjects.mockResolvedValue(
+                createMockApiResponse([
+                    createMockProject({ id: 'a1', name: 'Work Archive', isArchived: true }),
+                    createMockProject({ id: 'a2', name: 'Personal Stuff', isArchived: true }),
+                    createMockProject({ id: 'a3', name: 'Old work notes', isArchived: true }),
+                ]),
+            )
+
+            const result = await findProjects.execute(
+                { limit: 50, searchText: 'work', archivedStatus: 'archived' },
+                mockTodoistApi,
+            )
+
+            // No server-side search for archived; the active search endpoint is not used
+            expect(mockTodoistApi.searchProjects).not.toHaveBeenCalled()
+
+            const names = result.structuredContent.projects.map((p) => p.name)
+            expect(names).toEqual(['Work Archive', 'Old work notes'])
+            expect(result.structuredContent.hasMore).toBe(false)
+        })
+
+        it('should support prefix wildcard search for archived projects', async () => {
+            mockTodoistApi.getArchivedProjects.mockResolvedValue(
+                createMockApiResponse([
+                    createMockProject({ id: 'a1', name: 'Work Archive', isArchived: true }),
+                    createMockProject({ id: 'a2', name: 'Old work notes', isArchived: true }),
+                ]),
+            )
+
+            const result = await findProjects.execute(
+                { limit: 50, searchText: 'work*', archivedStatus: 'archived' },
+                mockTodoistApi,
+            )
+
+            // Prefix match: only names starting with "work" (case-insensitive)
+            expect(result.structuredContent.projects.map((p) => p.name)).toEqual(['Work Archive'])
+        })
+
+        it("should search across both active and archived when archivedStatus is 'all' with searchText", async () => {
+            // Active projects use server-side search; archived are filtered client-side.
+            mockTodoistApi.searchProjects.mockResolvedValue(
+                createMockApiResponse([
+                    createMockProject({
+                        id: 'active-work',
+                        name: 'Active Work',
+                        isArchived: false,
+                    }),
+                ]),
+            )
+            mockTodoistApi.getArchivedProjects.mockResolvedValue(
+                createMockApiResponse([
+                    createMockProject({ id: 'arch-work', name: 'Archived Work', isArchived: true }),
+                    createMockProject({ id: 'arch-other', name: 'Old notes', isArchived: true }),
+                ]),
+            )
+
+            const result = await findProjects.execute(
+                { limit: 50, searchText: 'work', archivedStatus: 'all' },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.searchProjects).toHaveBeenCalledWith({
+                query: '*work*',
+                limit: 200,
+                cursor: null,
+            })
+
+            const projects = result.structuredContent.projects
+            expect(projects.map((p) => p.name)).toEqual(['Active Work', 'Archived Work'])
+            expect(projects.map((p) => p.isArchived)).toEqual([false, true])
+            expect(result.structuredContent.hasMore).toBe(false)
+        })
+
+        it('should report no archived projects when none exist', async () => {
+            mockTodoistApi.getArchivedProjects.mockResolvedValue(createMockApiResponse([]))
+
+            const result = await findProjects.execute(
+                { limit: 50, archivedStatus: 'archived' },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.totalCount).toBe(0)
+            expect(result.textContent).toContain('No archived projects')
         })
     })
 

--- a/src/tools/find-projects.ts
+++ b/src/tools/find-projects.ts
@@ -1,12 +1,25 @@
+import type { Project } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
-import { mapProject, searchAllProjects } from '../tool-helpers.js'
+import {
+    compileWildcardQuery,
+    fetchAllActiveProjects,
+    fetchAllArchivedProjects,
+    mapProject,
+    searchAllProjects,
+} from '../tool-helpers.js'
 import { ApiLimits } from '../utils/constants.js'
 import { ProjectSchema as ProjectOutputSchema } from '../utils/output-schemas.js'
 import { formatProjectPreview, summarizeList } from '../utils/response-builders.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 const { ADD_PROJECTS } = ToolNames
+
+const SCOPE_NOUNS = {
+    active: 'projects',
+    archived: 'archived projects',
+    all: 'projects (active and archived)',
+} as const
 
 const ArgsSchema = {
     searchText: z
@@ -28,6 +41,12 @@ const ArgsSchema = {
         .describe(
             'The cursor to get the next page of projects (cursor is obtained from the previous call to this tool, with the same parameters).',
         ),
+    archivedStatus: z
+        .enum(['active', 'archived', 'all'])
+        .optional()
+        .describe(
+            "Which projects to return by archive status: 'active' (default, non-archived only), 'archived' (archived only), or 'all' (both active and archived). Each project includes an isArchived field. Archived projects can be deleted via the delete-object tool (type: 'project').",
+        ),
 }
 
 const OutputSchema = {
@@ -43,25 +62,46 @@ const OutputSchema = {
 const findProjects = {
     name: ToolNames.FIND_PROJECTS,
     description:
-        'List all projects or search for projects by name. When searching, all matching projects are returned (pagination is ignored). When not searching, projects are returned with pagination.',
+        "List all projects or search for projects by name. By default only active projects are returned; use archivedStatus ('archived' or 'all') to include archived projects. When searching or when archivedStatus is 'all', all matching projects are returned (pagination is ignored). Otherwise projects are returned with pagination.",
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
-        let results: Awaited<ReturnType<typeof client.getProjects>>['results']
-        let nextCursor = null
+        const { searchText } = args
+        const archivedStatus = args.archivedStatus ?? 'active'
+        let results: Project[]
+        let nextCursor: string | null = null
 
-        if (args.searchText) {
-            // When searching, fetch ALL matching projects (server-side search)
-            results = await searchAllProjects(client, args.searchText)
-            // When searching, we have all results so no pagination
-            nextCursor = null
+        if (searchText || archivedStatus === 'all') {
+            // Fetch-all path: cannot cursor-paginate across two sources or while
+            // filtering archived projects client-side, so all results are returned.
+            const empty = Promise.resolve<Project[]>([])
+            const [active, archived] = await Promise.all([
+                archivedStatus === 'archived'
+                    ? empty
+                    : searchText
+                      ? searchAllProjects(client, searchText)
+                      : fetchAllActiveProjects(client),
+                archivedStatus === 'active' ? empty : fetchAllArchivedProjects(client),
+            ])
+
+            // Archived projects have no server-side search; filter client-side with
+            // a single compiled pattern rather than recompiling per project.
+            const wildcard = searchText ? compileWildcardQuery(searchText) : null
+            const filteredArchived = wildcard
+                ? archived.filter((project) => wildcard.test(project.name))
+                : archived
+
+            results = [...active, ...filteredArchived]
         } else {
-            // Normal pagination when not searching
-            const response = await client.getProjects({
-                limit: args.limit,
-                cursor: args.cursor ?? null,
-            })
+            // Paginated single-source path
+            const response =
+                archivedStatus === 'archived'
+                    ? await client.getArchivedProjects({
+                          limit: args.limit,
+                          cursor: args.cursor ?? null,
+                      })
+                    : await client.getProjects({ limit: args.limit, cursor: args.cursor ?? null })
             results = response.results
             nextCursor = response.nextCursor
         }
@@ -91,12 +131,18 @@ function generateTextContent({
     nextCursor: string | null
 }) {
     // Generate subject description
-    const subject = args.searchText ? `All projects matching "${args.searchText}"` : 'Projects'
+    const scopeNoun = SCOPE_NOUNS[args.archivedStatus ?? 'active']
+    const subject = args.searchText
+        ? `All ${scopeNoun} matching "${args.searchText}"`
+        : `${scopeNoun.charAt(0).toUpperCase()}${scopeNoun.slice(1)}`
 
     // Generate filter hints
     const filterHints: string[] = []
     if (args.searchText) {
         filterHints.push(`searchText: "${args.searchText}"`)
+    }
+    if (args.archivedStatus && args.archivedStatus !== 'active') {
+        filterHints.push(`archivedStatus: "${args.archivedStatus}"`)
     }
 
     // Generate project preview lines
@@ -114,8 +160,16 @@ function generateTextContent({
             zeroReasonHints.push('Try broader search terms')
             zeroReasonHints.push('Check spelling')
             zeroReasonHints.push('Remove searchText to see all projects')
-        } else {
+        } else if (args.archivedStatus === 'archived') {
+            zeroReasonHints.push('No archived projects')
+            zeroReasonHints.push("Use archivedStatus: 'all' to also see active projects")
+        } else if (args.archivedStatus === 'all') {
             zeroReasonHints.push('No projects created yet')
+            zeroReasonHints.push(`Use ${ADD_PROJECTS} to create a project`)
+        } else {
+            // Default active-only scope: archived projects (if any) are excluded.
+            zeroReasonHints.push('No active projects')
+            zeroReasonHints.push("Use archivedStatus: 'all' to include archived projects")
             zeroReasonHints.push(`Use ${ADD_PROJECTS} to create a project`)
         }
     }
@@ -123,7 +177,7 @@ function generateTextContent({
     return summarizeList({
         subject,
         count: projects.length,
-        limit: args.searchText ? undefined : args.limit,
+        limit: args.searchText || args.archivedStatus === 'all' ? undefined : args.limit,
         nextCursor: nextCursor ?? undefined,
         filterHints,
         previewLines: previewWithMore,

--- a/src/tools/update-projects.test.ts
+++ b/src/tools/update-projects.test.ts
@@ -447,6 +447,7 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
                 'workspaceId',
                 'folderId',
                 'childOrder',
+                'isArchived',
             ]
             const actualKeys = Object.keys(project)
             expect(actualKeys.sort()).toEqual(allowedKeys.sort())
@@ -456,7 +457,6 @@ describe(`${UPDATE_PROJECTS} tool`, () => {
                 'createdAt',
                 'updatedAt',
                 'defaultOrder',
-                'isArchived',
                 'isCollapsed',
                 'isDeleted',
                 'isFrozen',

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -63,6 +63,7 @@ const ProjectSchema = z.object({
         .optional()
         .describe('The ID of the folder this project belongs to (workspace projects only).'),
     childOrder: z.number().describe('The ordering index of the project among its siblings.'),
+    isArchived: z.boolean().describe('Whether the project is archived.'),
 })
 
 /**

--- a/src/utils/response-builders.ts
+++ b/src/utils/response-builders.ts
@@ -33,6 +33,7 @@ type ProjectLike = {
     parentId?: string | null
     inboxProject?: boolean
     viewStyle?: string
+    isArchived?: boolean
 }
 
 type TaskOperationOptions = {
@@ -143,10 +144,11 @@ export function formatProjectPreview(project: ProjectLike): string {
     const isInbox = project.inboxProject ? ' • Inbox' : ''
     const isFavorite = project.isFavorite ? ' • ⭐' : ''
     const isShared = project.isShared ? ' • Shared' : ''
+    const isArchived = project.isArchived ? ' • Archived' : ''
     const viewStyle =
         project.viewStyle && project.viewStyle !== 'list' ? ` • ${project.viewStyle}` : ''
     const id = ` • id=${project.id}`
-    return `    ${project.name}${isInbox}${isFavorite}${isShared}${viewStyle}${id}`
+    return `    ${project.name}${isInbox}${isFavorite}${isShared}${isArchived}${viewStyle}${id}`
 }
 
 /**


### PR DESCRIPTION
## Context

[Doist/automations#3207](https://github.com/Doist/automations/issues/3207): a user built an automation to delete their archived Todoist projects. It ran but found 0 archived projects, because the MCP integration had no way to **discover** them:

- `find-projects` only called `getProjects()`, which returns active projects only.
- The mapped project object never exposed `isArchived`, so a generated filter like `project?.isArchived === true` always evaluated false.

Deletion itself already worked — `delete-object` (`type: 'project'`) is archive-aware (workspace projects must be archived first; personal projects delete regardless). So the only real gap was discovery.

## Changes

- **`find-projects`**: new `archivedStatus` param — `'active'` (default, unchanged), `'archived'` (SDK `getArchivedProjects`), or `'all'` (both, fetched concurrently and merged). Archived projects have no server-side search, so `searchText` filters them client-side.
- **`isArchived`** surfaced on the shared `ProjectSchema` / `mapProject`, plus an `Archived` preview marker.
- New helpers in `tool-helpers`: `compileWildcardQuery` (client-side wildcard matching, compiled once per query), `fetchAllActiveProjects`, `fetchAllArchivedProjects` — mirroring the existing `searchAllProjects` family.
- **Docs**: server guidance + `delete-object` description now explain how to find and delete archived projects.

## Behaviour notes

- Pagination is preserved for single-source scopes (`active`, `archived`). The combined `all` scope and any `searchText` query return all matches without a cursor (same precedent as existing search behaviour).
- Backward compatible: omitting `archivedStatus` behaves exactly as before.

## Acceptance criteria

- [x] Automations can identify archived projects via the MCP
- [x] Automations can delete an archived project (existing `delete-object`)
- [x] Behaviour/limitations documented in tool schemas and server guidance

## Testing

- `tsc --noEmit`, build, and full suite (990 tests) pass; format clean.
- New tests: `find-projects` archived/all/search-combined paths and empty states; `compileWildcardQuery`/`matchesWildcardQuery` unit tests (incl. literal-backslash regression).

Closes https://github.com/Doist/automations/issues/3207

🤖 Generated with [Claude Code](https://claude.com/claude-code)