### PR TITLE
fix: stop blaming the API token for 403s caused by plan limits

### DIFF
--- a/src/tool-execution-error.test.ts
+++ b/src/tool-execution-error.test.ts
@@ -66,6 +66,77 @@ describe('formatToolExecutionError', () => {
         )
     })
 
+    it('points 403 limit errors at the limit, not the API token (Doist/Issues#20301)', () => {
+        const output = formatToolExecutionError({
+            responseData: {
+                error: 'Maximum number of items per user project limit reached',
+                error_code: 49,
+                error_tag: 'MAX_ITEMS_LIMIT_REACHED',
+                http_code: 403,
+                error_extra: {},
+            },
+        })
+
+        expect(output).toContain(
+            'Todoist API request failed (HTTP 403, code 49, tag MAX_ITEMS_LIMIT_REACHED).',
+        )
+        expect(output).toContain('Message: Maximum number of items per user project limit reached')
+        expect(output).toContain(
+            'Try next: A Todoist plan or project limit was reached. Complete, archive, or delete items — or upgrade the plan — then retry.',
+        )
+        expect(output).not.toContain('Verify your API token')
+    })
+
+    it('does not blame the API token for 403s with a specific error tag', () => {
+        const output = formatToolExecutionError({
+            responseData: {
+                error: 'Project is frozen',
+                error_code: 63,
+                error_tag: 'PROJECT_FROZEN',
+                http_code: 403,
+                error_extra: {},
+            },
+        })
+
+        expect(output).toContain(
+            'Try next: The request was rejected for the reason in the message above — this is not an API token problem. Address it and retry.',
+        )
+        expect(output).not.toContain('Verify your API token')
+    })
+
+    it('keeps the token hint for plain 403s', () => {
+        const output = formatToolExecutionError({
+            responseData: {
+                error: 'Forbidden',
+                error_tag: 'FORBIDDEN',
+                http_code: 403,
+            },
+        })
+
+        expect(output).toContain(
+            'Try next: Verify your API token and access permissions, then retry.',
+        )
+    })
+
+    it('keeps the token hint for 403s without a payload', () => {
+        const output = formatToolExecutionError({ httpStatusCode: 403 })
+
+        expect(output).toContain(
+            'Try next: Verify your API token and access permissions, then retry.',
+        )
+    })
+
+    it('keeps the token hint for 401s', () => {
+        const output = formatToolExecutionError({
+            httpStatusCode: 401,
+            responseData: { error: 'Unauthorized' },
+        })
+
+        expect(output).toContain(
+            'Try next: Verify your API token and access permissions, then retry.',
+        )
+    })
+
     it('extracts HTTP status from generic API error messages', () => {
         const output = formatToolExecutionError(new Error('HTTP 400: Bad Request'))
 

--- a/src/tool-execution-error.ts
+++ b/src/tool-execution-error.ts
@@ -269,8 +269,26 @@ function hasKnownApiErrorKeys(responseData: Record<string, unknown> | undefined)
     return KNOWN_TODOIST_API_ERROR_KEYS.some((key) => responseData[key] !== undefined)
 }
 
-function getNextStepHint(statusCode: number | undefined, hasFieldHints: boolean): string {
-    if (statusCode === 401 || statusCode === 403) {
+function getNextStepHint(error: ApiErrorInfo): string {
+    const { statusCode, tag, fieldHints } = error
+    const hasFieldHints = fieldHints.length > 0
+
+    // Todoist plan/usage limits (e.g. MAX_ITEMS_LIMIT_REACHED) come back as
+    // 403s; pointing users at their API token sends them down the wrong path.
+    if (tag && tag.endsWith('LIMIT_REACHED')) {
+        return 'A Todoist plan or project limit was reached. Complete, archive, or delete items — or upgrade the plan — then retry.'
+    }
+
+    if (statusCode === 401) {
+        return 'Verify your API token and access permissions, then retry.'
+    }
+
+    if (statusCode === 403) {
+        // A specific error tag means the request was authenticated and
+        // understood but rejected for the stated reason — not a token problem.
+        if (tag && tag !== 'FORBIDDEN' && tag !== 'UNAUTHORIZED') {
+            return 'The request was rejected for the reason in the message above — this is not an API token problem. Address it and retry.'
+        }
         return 'Verify your API token and access permissions, then retry.'
     }
 
@@ -421,7 +439,7 @@ function formatApiErrorMessage(error: ApiErrorInfo): string {
         lines.push(`Field hints: ${error.fieldHints.join('; ')}`)
     }
 
-    lines.push(`Try next: ${getNextStepHint(error.statusCode, error.fieldHints.length > 0)}`)
+    lines.push(`Try next: ${getNextStepHint(error)}`)
 
     return lines.join('\n')
 }


### PR DESCRIPTION
## Short description

Related to https://github.com/Doist/Issues/issues/20596

**What:** Stop appending "Verify your API token and access permissions, then retry." to 403 errors that are not auth problems — most notably `MAX_ITEMS_LIMIT_REACHED` (project at its task limit).

**Why:** The backend already returns a structured 403 body (`error_tag`, `error_code`, message), but `formatToolExecutionError` gave every 401/403 the same token-focused "Try next" hint. Users hitting the 300-item project cap were sent down an auth-debugging rabbit hole — ruling out tokens, scopes, and sharing — while their credentials were fine (two support tickets on Doist/Issues#20301).

**How:** `getNextStepHint` is now tag-aware:

- `*LIMIT_REACHED` tags → point at the limit: complete/archive/delete items or upgrade the plan
- other specific 403 tags (e.g. `PROJECT_FROZEN`) → defer to the error message and state explicitly it is **not** a token problem
- plain 403s (`FORBIDDEN` tag or no payload) and all 401s keep the existing token hint

**Trade-offs:**

- Matching `*LIMIT_REACHED` by suffix covers all backend limit tags (items, projects, sections, labels, reminders) without enumerating them, at the cost of assuming the backend keeps that naming convention.
- Unknown 403 tags get a neutral "not a token problem" hint rather than a tag-specific one — safer than guessing, and the backend message above carries the specifics.

## PR Checklist

- [x] Added tests for bugs / new features

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
