### PR TITLE
fix: preserve item limit details in task batch errors

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -45,7 +45,7 @@ src/
 ├─ todoist-tool.ts            # TodoistTool<Params, Output> contract (the tool interface)
 ├─ tool-helpers.ts            # Shared transforms: mapTask, fetchAllPages, toWildcardQuery, compileWildcardQuery + matchesWildcardQuery (client-side name match), resolveInboxProjectId, isInboxProjectId, isPersonalProject, isWorkspaceProject. Re-exports filter-helpers.
 ├─ filter-helpers.ts          # appendToQuery, buildResponsibleUserQueryFilter, resolveResponsibleUser
-├─ tool-execution-error.ts    # ToolExecutionError: wraps SDK errors with user/system classification
+├─ tool-execution-error.ts    # formatToolExecutionError (actionable API-error formatting, incl. known error_tag hints like MAX_ITEMS_LIMIT_REACHED) + formatBatchItemError (single-line per-item failure summaries — use in batch tools instead of error.message)
 ├─ prompts/                   # MCP prompts (productivity-analysis)
 ├─ middleware/                # require-trusted-host (Host/Origin allowlist, DNS-rebinding protection), require-valid-todoist-token (HTTP auth)
 ├─ mcp-apps/                  # React UI widgets (task list). Built separately. Ignore unless task mentions widgets.

--- a/src/tool-execution-error.test.ts
+++ b/src/tool-execution-error.test.ts
@@ -1,5 +1,5 @@
 import z from 'zod'
-import { formatToolExecutionError } from './tool-execution-error.js'
+import { formatBatchItemError, formatToolExecutionError } from './tool-execution-error.js'
 
 describe('formatToolExecutionError', () => {
     it('formats Todoist API errors with actionable details', () => {
@@ -88,6 +88,108 @@ describe('formatToolExecutionError', () => {
         expect(output).toContain('[REDACTED]')
         expect(output).not.toContain('secret_token_123456789')
         expect(output).not.toContain('another_secret_value')
+    })
+
+    describe('project item-limit errors (MAX_ITEMS_LIMIT_REACHED)', () => {
+        it('surfaces item-limit guidance instead of the generic 403 auth hint', () => {
+            // Shape thrown by the SDK for REST calls: an Error with
+            // httpStatusCode + the raw snake_case API body in responseData.
+            const error = Object.assign(new Error('HTTP 403: Forbidden'), {
+                httpStatusCode: 403,
+                responseData: {
+                    error: 'Maximum number of items exceeded',
+                    error_code: 49,
+                    error_tag: 'MAX_ITEMS_LIMIT_REACHED',
+                    http_code: 403,
+                },
+            })
+
+            const output = formatToolExecutionError(error)
+
+            expect(output).toContain(
+                'Todoist API request failed (HTTP 403, code 49, tag MAX_ITEMS_LIMIT_REACHED).',
+            )
+            expect(output).toContain('Message: Maximum number of items exceeded')
+            expect(output).toContain('maximum number of active tasks')
+            expect(output).toContain('not an authentication or permission problem')
+            // The cap is identical on Beginner/Pro/Business (per the Todoist
+            // usage-limits docs), so the copy must not nudge a plan upgrade.
+            expect(output).toContain('upgrading will not raise it')
+            expect(output).not.toContain('Verify your API token')
+        })
+
+        it('supports camelCase item-limit payloads', () => {
+            const output = formatToolExecutionError({
+                httpStatusCode: 403,
+                responseData: {
+                    error: 'Maximum number of items exceeded',
+                    errorCode: 49,
+                    errorTag: 'MAX_ITEMS_LIMIT_REACHED',
+                },
+            })
+
+            expect(output).toContain('tag MAX_ITEMS_LIMIT_REACHED')
+            expect(output).toContain('maximum number of active tasks')
+            expect(output).not.toContain('Verify your API token')
+        })
+
+        it('keeps the auth hint for plain 403s without item-limit signals', () => {
+            const output = formatToolExecutionError({
+                httpStatusCode: 403,
+                responseData: { error: 'Forbidden' },
+            })
+
+            expect(output).toContain('Todoist API request failed (HTTP 403).')
+            expect(output).toContain(
+                'Try next: Verify your API token and access permissions, then retry.',
+            )
+            expect(output).not.toContain('maximum number of active tasks')
+        })
+
+        it('recovers the item-limit tag from wrapper errors that embed per-item failures', () => {
+            // Shape thrown by batch tools (e.g. add-tasks) when every item
+            // fails: a plain Error whose message embeds the per-item summaries.
+            const output = formatToolExecutionError(
+                new Error(
+                    'All 1 task(s) failed to create: "one too many": Maximum number of items exceeded (HTTP 403, code 49, tag MAX_ITEMS_LIMIT_REACHED)',
+                ),
+            )
+
+            expect(output).toContain('maximum number of active tasks')
+            expect(output).not.toContain('Verify your API token')
+        })
+    })
+
+    describe('formatBatchItemError', () => {
+        it('preserves API error signals lost by error.message', () => {
+            const error = Object.assign(new Error('HTTP 403: Forbidden'), {
+                httpStatusCode: 403,
+                responseData: {
+                    error: 'Maximum number of items exceeded',
+                    error_code: 49,
+                    error_tag: 'MAX_ITEMS_LIMIT_REACHED',
+                    http_code: 403,
+                },
+            })
+
+            expect(formatBatchItemError(error)).toBe(
+                'Maximum number of items exceeded (HTTP 403, code 49, tag MAX_ITEMS_LIMIT_REACHED)',
+            )
+        })
+
+        it('avoids repeating generic HTTP messages when context is available', () => {
+            const error = Object.assign(new Error('HTTP 403: Forbidden'), {
+                httpStatusCode: 403,
+            })
+
+            expect(formatBatchItemError(error)).toBe('Todoist API request failed (HTTP 403)')
+        })
+
+        it('returns plain messages for non-API errors', () => {
+            expect(formatBatchItemError(new Error('Section "xyz" not found'))).toBe(
+                'Section "xyz" not found',
+            )
+        })
     })
 
     it('keeps Zod validation errors unchanged', () => {

--- a/src/tool-execution-error.test.ts
+++ b/src/tool-execution-error.test.ts
@@ -158,6 +158,18 @@ describe('formatToolExecutionError', () => {
             expect(output).toContain('maximum number of active tasks')
             expect(output).not.toContain('Verify your API token')
         })
+
+        it('recovers the item-limit tag from long wrapper errors before display truncation', () => {
+            const longTaskTitle = 'x'.repeat(260)
+            const output = formatToolExecutionError(
+                new Error(
+                    `All 1 task(s) failed to create: "${longTaskTitle}": Maximum number of items exceeded (HTTP 403, code 49, tag MAX_ITEMS_LIMIT_REACHED)`,
+                ),
+            )
+
+            expect(output).toContain('maximum number of active tasks')
+            expect(output).not.toContain('Verify your API token')
+        })
     })
 
     describe('formatBatchItemError', () => {

--- a/src/tool-execution-error.ts
+++ b/src/tool-execution-error.ts
@@ -6,6 +6,7 @@ type ApiErrorInfo = {
     tag?: string
     message?: string
     details?: string
+    rawText?: string[]
     fieldHints: string[]
 }
 
@@ -309,8 +310,9 @@ function getKnownErrorHint(error: ApiErrorInfo): string | undefined {
     }
 
     // Wrapper errors (e.g. batch tools embedding per-item failures into a new
-    // Error) lose the structured fields; recover known tags from the text.
-    return findKnownTagHintInText(error.message, error.details)
+    // Error) lose the structured fields; recover known tags from raw text
+    // before sanitized display text can truncate the tag.
+    return findKnownTagHintInText(...(error.rawText ?? []), error.message, error.details)
 }
 
 function getNextStepHint(error: ApiErrorInfo): string {
@@ -439,11 +441,12 @@ function extractApiErrorInfo(error: unknown): ApiErrorInfo | null {
         tag: tag ? sanitizeErrorText(tag, 80) : undefined,
         message: message ? sanitizeErrorText(message) : undefined,
         details: details ? sanitizeErrorText(details) : undefined,
+        rawText: rawMessageCandidates,
         fieldHints,
     }
 }
 
-function formatApiErrorMessage(error: ApiErrorInfo): string {
+function buildErrorContext(error: ApiErrorInfo): string[] {
     const context: string[] = []
     if (error.statusCode !== undefined) {
         context.push(`HTTP ${error.statusCode}`)
@@ -454,6 +457,12 @@ function formatApiErrorMessage(error: ApiErrorInfo): string {
     if (error.tag) {
         context.push(`tag ${error.tag}`)
     }
+
+    return context
+}
+
+function formatApiErrorMessage(error: ApiErrorInfo): string {
+    const context = buildErrorContext(error)
 
     const lines = [
         context.length > 0
@@ -503,17 +512,7 @@ export function formatBatchItemError(error: unknown): string {
         return formatGenericError(error)
     }
 
-    const context: string[] = []
-    if (parsedApiError.statusCode !== undefined) {
-        context.push(`HTTP ${parsedApiError.statusCode}`)
-    }
-    if (parsedApiError.code !== undefined) {
-        context.push(`code ${parsedApiError.code}`)
-    }
-    if (parsedApiError.tag) {
-        context.push(`tag ${parsedApiError.tag}`)
-    }
-
+    const context = buildErrorContext(parsedApiError)
     const message =
         parsedApiError.message &&
         !(context.length > 0 && isGenericHttpMessage(parsedApiError.message))

--- a/src/tool-execution-error.ts
+++ b/src/tool-execution-error.ts
@@ -269,7 +269,59 @@ function hasKnownApiErrorKeys(responseData: Record<string, unknown> | undefined)
     return KNOWN_TODOIST_API_ERROR_KEYS.some((key) => responseData[key] !== undefined)
 }
 
-function getNextStepHint(statusCode: number | undefined, hasFieldHints: boolean): string {
+/**
+ * Targeted guidance for specific Todoist API errors, keyed by canonical
+ * `error_tag`. These take precedence over the generic status-code hints:
+ * e.g. a full project surfaces as HTTP 403, and without this mapping the
+ * error would be indistinguishable from an auth/permission failure.
+ */
+const TODOIST_ERROR_TAG_HINTS: Record<string, string> = {
+    MAX_ITEMS_LIMIT_REACHED:
+        'This project has reached the maximum number of active tasks per project (subtasks count toward it; completed tasks do not). ' +
+        'The cap is the same on every Todoist plan — upgrading will not raise it — and it is not an authentication or permission problem. ' +
+        'Complete, delete, or move existing tasks out of the project, or add the task to a different project, then retry.',
+}
+
+function findKnownTagHintInText(...texts: Array<string | undefined>): string | undefined {
+    for (const text of texts) {
+        if (!text) {
+            continue
+        }
+
+        const normalized = text.toUpperCase()
+        const tag = Object.keys(TODOIST_ERROR_TAG_HINTS).find((knownTag) =>
+            normalized.includes(knownTag),
+        )
+        if (tag) {
+            return TODOIST_ERROR_TAG_HINTS[tag]
+        }
+    }
+
+    return undefined
+}
+
+function getKnownErrorHint(error: ApiErrorInfo): string | undefined {
+    if (error.tag) {
+        const hint = TODOIST_ERROR_TAG_HINTS[error.tag.toUpperCase()]
+        if (hint) {
+            return hint
+        }
+    }
+
+    // Wrapper errors (e.g. batch tools embedding per-item failures into a new
+    // Error) lose the structured fields; recover known tags from the text.
+    return findKnownTagHintInText(error.message, error.details)
+}
+
+function getNextStepHint(error: ApiErrorInfo): string {
+    const knownErrorHint = getKnownErrorHint(error)
+    if (knownErrorHint) {
+        return knownErrorHint
+    }
+
+    const { statusCode } = error
+    const hasFieldHints = error.fieldHints.length > 0
+
     if (statusCode === 401 || statusCode === 403) {
         return 'Verify your API token and access permissions, then retry.'
     }
@@ -421,7 +473,7 @@ function formatApiErrorMessage(error: ApiErrorInfo): string {
         lines.push(`Field hints: ${error.fieldHints.join('; ')}`)
     }
 
-    lines.push(`Try next: ${getNextStepHint(error.statusCode, error.fieldHints.length > 0)}`)
+    lines.push(`Try next: ${getNextStepHint(error)}`)
 
     return lines.join('\n')
 }
@@ -439,9 +491,40 @@ function formatGenericError(error: unknown): string {
 }
 
 /**
+ * Compact single-line variant of {@link formatToolExecutionError} for batch
+ * tools that report per-item failures. Unlike `error.message` (which for SDK
+ * errors is just "HTTP 403: Forbidden"), this preserves the API error signals
+ * (status, code, tag) so failures like MAX_ITEMS_LIMIT_REACHED stay
+ * recognizable after aggregation.
+ */
+export function formatBatchItemError(error: unknown): string {
+    const parsedApiError = extractApiErrorInfo(error)
+    if (!parsedApiError) {
+        return formatGenericError(error)
+    }
+
+    const context: string[] = []
+    if (parsedApiError.statusCode !== undefined) {
+        context.push(`HTTP ${parsedApiError.statusCode}`)
+    }
+    if (parsedApiError.code !== undefined) {
+        context.push(`code ${parsedApiError.code}`)
+    }
+    if (parsedApiError.tag) {
+        context.push(`tag ${parsedApiError.tag}`)
+    }
+
+    const message =
+        parsedApiError.message &&
+        !(context.length > 0 && isGenericHttpMessage(parsedApiError.message))
+            ? parsedApiError.message
+            : 'Todoist API request failed'
+
+    return context.length > 0 ? `${message} (${context.join(', ')})` : message
+}
+
+/**
  * Format tool execution errors in a consistent, actionable format.
- *
- * This is the only public API exposed by this module.
  */
 export function formatToolExecutionError(error: unknown): string {
     if (error instanceof ZodError) {

--- a/src/tools/add-tasks.test.ts
+++ b/src/tools/add-tasks.test.ts
@@ -579,6 +579,67 @@ describe(`${ADD_TASKS} tool`, () => {
                 ),
             ).rejects.toThrow('All 2 task(s) failed to create')
         })
+
+        it('should preserve the item-limit error tag when a project is full', async () => {
+            // Shape thrown by the SDK when the API rejects the add with the
+            // item-limit error (project at max active tasks): HTTP 403 plus
+            // the raw snake_case body in responseData.
+            const itemLimitError = Object.assign(new Error('HTTP 403: Forbidden'), {
+                httpStatusCode: 403,
+                responseData: {
+                    error: 'Maximum number of items exceeded',
+                    error_code: 49,
+                    error_tag: 'MAX_ITEMS_LIMIT_REACHED',
+                    http_code: 403,
+                },
+            })
+            mockTodoistApi.addTask.mockRejectedValue(itemLimitError)
+
+            await expect(
+                addTasks.execute(
+                    { tasks: [{ content: 'One too many', projectId: '6cfCcrrCFg2xP94Q' }] },
+                    mockTodoistApi,
+                ),
+            ).rejects.toThrow(
+                'Maximum number of items exceeded (HTTP 403, code 49, tag MAX_ITEMS_LIMIT_REACHED)',
+            )
+        })
+
+        it('should report the item-limit error tag in partial failures', async () => {
+            const mockApiResponse: Task = createMockTask({
+                id: '8485093752',
+                content: 'Fits in project',
+            })
+            const itemLimitError = Object.assign(new Error('HTTP 403: Forbidden'), {
+                httpStatusCode: 403,
+                responseData: {
+                    error: 'Maximum number of items exceeded',
+                    error_code: 49,
+                    error_tag: 'MAX_ITEMS_LIMIT_REACHED',
+                    http_code: 403,
+                },
+            })
+            mockTodoistApi.addTask
+                .mockResolvedValueOnce(mockApiResponse)
+                .mockRejectedValueOnce(itemLimitError)
+
+            const result = await addTasks.execute(
+                {
+                    tasks: [
+                        { content: 'Fits in project', projectId: '6cfCcrrCFg2xP94Q' },
+                        { content: 'One too many', projectId: '6cfCcrrCFg2xP94Q' },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent.failures[0]).toEqual(
+                expect.objectContaining({
+                    item: 'One too many',
+                    error: 'Maximum number of items exceeded (HTTP 403, code 49, tag MAX_ITEMS_LIMIT_REACHED)',
+                }),
+            )
+        })
     })
 
     describe('next steps logic', () => {

--- a/src/tools/add-tasks.ts
+++ b/src/tools/add-tasks.ts
@@ -1,6 +1,7 @@
 import type { AddTaskArgs, Task, TodoistApi } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
+import { formatBatchItemError } from '../tool-execution-error.js'
 import { isInboxProjectId, mapTask } from '../tool-helpers.js'
 import { assignmentValidator } from '../utils/assignment-validator.js'
 import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
@@ -132,10 +133,10 @@ const addTasks = {
             } else {
                 failures.push({
                     item: tasks[index]?.content ?? `Task ${index + 1}`,
-                    error:
-                        result.reason instanceof Error
-                            ? result.reason.message
-                            : String(result.reason),
+                    // Keep API error signals (status/code/tag) — `error.message`
+                    // alone collapses e.g. a full-project rejection into a bare
+                    // "HTTP 403: Forbidden"
+                    error: formatBatchItemError(result.reason),
                 })
             }
         }


### PR DESCRIPTION
## Short description

Closes Doist/Issues#20596.

**What:** Preserve Todoist API error details for task batch failures and show targeted guidance for `MAX_ITEMS_LIMIT_REACHED`.

**Why:** A full project is returned by the API as HTTP 403 with `error_tag: MAX_ITEMS_LIMIT_REACHED`, but the `add-tasks` batch path was reducing SDK errors to `error.message` (`HTTP 403: Forbidden`). Once that happened, the structured `error_code` / `error_tag` signals were lost before the shared formatter could provide useful guidance.

**How:**

- Adds targeted guidance for `MAX_ITEMS_LIMIT_REACHED` that explains the project active-task cap and avoids the token/auth hint.
- Adds `formatBatchItemError()` so batch tools can keep status/code/tag details in compact per-item failures.
- Uses the new formatter in `add-tasks`, covering both all-failed and partial-failure batches.
- Recovers known error-tag guidance from wrapper error text when structured fields have already been aggregated.

**Note:** This covers the direct formatter path and the `add-tasks` aggregation path, so the item-limit tag survives the real failure flow instead of being flattened to a generic 403.

