### PR TITLE
feat: expose addedAt field in task objects

### DIFF
--- a/src/tool-helpers.test.ts
+++ b/src/tool-helpers.test.ts
@@ -54,6 +54,7 @@ describe('shared utilities', () => {
                 completedAt: undefined,
                 deadlineDate: undefined,
                 responsibleUid: undefined,
+                addedAt: '2025-08-13T22:09:56.123Z',
             })
         })
 

--- a/src/tool-helpers.ts
+++ b/src/tool-helpers.ts
@@ -336,6 +336,7 @@ function mapTask(task: Task) {
         assignedByUid: task.assignedByUid ?? undefined,
         checked: task.checked,
         completedAt: task.completedAt?.toISOString() ?? undefined,
+        addedAt: task.addedAt?.toISOString() ?? undefined,
     }
 }
 

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -37,6 +37,7 @@ const TaskSchema = z.object({
     assignedByUid: z.string().optional().describe('The UID of the user who assigned this task.'),
     checked: z.boolean().describe('Whether the task is checked/completed.'),
     completedAt: z.string().optional().describe('When the task was completed (ISO 8601 format).'),
+    addedAt: z.string().optional().describe('When the task was created (ISO 8601 format).'),
 })
 
 /**

--- a/src/utils/test-helpers.ts
+++ b/src/utils/test-helpers.ts
@@ -218,6 +218,7 @@ export function createMappedTask(overrides: Partial<MappedTask> = {}): MappedTas
         assignedByUid: undefined,
         checked: false,
         completedAt: undefined,
+        addedAt: undefined,
         ...overrides,
     }
 }


### PR DESCRIPTION
Fixes: #533

## Short description

Exposes the `addedAt` field from the Todoist SDK/API in task objects returned by MCP tools. This enables:
- **AI**: To have date/time context regarding when tasks were created
- **Users**: To see task creation timestamps when fetching tasks via MCP/AI without checking the Todoist app directly

The field is converted to ISO 8601 format (same as `completedAt`) and available in all tools that return task data (find-tasks, add-tasks, update-tasks, etc.).

## Implementation details

- Added `addedAt` field to `TaskSchema` in output-schemas.ts with appropriate description
- Updated `mapTask()` function in tool-helpers.ts to serialize `task.addedAt` as ISO 8601 string
- Updated test expectations to include the new field
- Updated test helper to ensure type safety across all tests

All 1001 tests pass, and TypeScript compilation succeeds without errors.

## PR Checklist

- [x] Added tests for bugs / new features (updated existing test expectations)
- [ ] Updated docs (README, etc.) - N/A, field documentation is self-documenting in schema
- [ ] New tools added - N/A, this extends existing tools