### PR TITLE
feat(fetch-object): add includeChildren for subtasks and sub-projects

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -126,6 +126,7 @@ New tool? Full checklist in `AGENTS.md`. Short version: copy `add-tasks.ts`; imp
 - `tool-names.ts` — `ToolNames` enum of every registered tool name
 - `output-schemas.ts` — Reusable Zod schemas: TaskSchema, ProjectSchema, SectionSchema, CommentSchema, etc.
 - `schema-helpers.ts` — Zod builders used across tools
+- `children.ts` — `ChildrenOutputSchema` plus `getTaskChildren`/`getProjectChildren` for returning an object's direct subtasks or sub-projects
 - `priorities.ts` — `"p1"`–`"p4"` ↔ SDK integer conversion (**strings only in tool I/O**)
 - `duration-parser.ts` — `"2h30m"` ↔ ms, plus `formatDuration`
 - `date.ts` — date parsing/formatting (ISO, Todoist strings)

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -119,7 +119,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 
 **General Operations:**
 - **delete-object**: Remove projects, sections, tasks, comments, labels, filters, reminders, or location reminders by type and ID. Deletes both active and archived projects (workspace projects must be archived first; use find-projects with archivedStatus to locate archived projects)
-- **fetch-object**: Fetch a single task, project, comment, or section by its ID
+- **fetch-object**: Fetch a single task, project, comment, or section by its ID. Pass includeChildren=true to also get its direct children (subtasks for a task, sub-projects for a project) with a childCount - use this to check whether a task hides subtasks rather than a speculative find-tasks call
 - **reorder-objects**: Reorder sibling projects or sections, and optionally move projects to a new parent. For projects: set order to reorder siblings, and/or set parentId to move under a new parent (use "root" for top level). For sections: set order to reorder within a project
 - **user-info**: Get user details including timezone, goals, and plan information
 

--- a/src/tools/fetch-object.test.ts
+++ b/src/tools/fetch-object.test.ts
@@ -400,10 +400,19 @@ describe(`${FETCH_OBJECT} tool`, () => {
                 expect(result.textContent).toContain('subtasks=unavailable')
             })
 
-            it('should report a failed grandchild probe without failing the fetch', async () => {
+            it('should keep the subtask list when a grandchild probe fails', async () => {
                 mockTodoistApi.getTasks.mockImplementation(async (args) => {
                     if (args?.parentId === 'task123') {
-                        return { results: [createMockTask({ id: 'sub1' })], nextCursor: null }
+                        return {
+                            results: [
+                                createMockTask({ id: 'sub1' }),
+                                createMockTask({ id: 'sub2' }),
+                            ],
+                            nextCursor: null,
+                        }
+                    }
+                    if (args?.parentId === 'sub2') {
+                        return { results: [], nextCursor: null }
                     }
                     throw new Error('Probe failed')
                 })
@@ -413,8 +422,36 @@ describe(`${FETCH_OBJECT} tool`, () => {
                     mockTodoistApi,
                 )
 
-                expect(childrenOf(result).childrenError).toBe('Probe failed')
-                expect(result.structuredContent).not.toHaveProperty('childCount')
+                expect(childrenOf(result)).toMatchObject({
+                    childCount: 2,
+                    children: [
+                        { id: 'sub1', hasChildren: false },
+                        { id: 'sub2', hasChildren: false },
+                    ],
+                    childrenError:
+                        'Could not check 1 of 2 subtasks for subtasks of their own; those are reported as hasChildren=false.',
+                })
+                expect(result.textContent).toContain('subtasks=2 (partial)')
+            })
+
+            it('should fetch the task and its children concurrently', async () => {
+                const calls: string[] = []
+                mockTodoistApi.getTask.mockImplementation(async () => {
+                    calls.push('getTask')
+                    return createMockTask({ id: 'task123' })
+                })
+                mockTodoistApi.getTasks.mockImplementation(async () => {
+                    calls.push('getTasks')
+                    return { results: [], nextCursor: null }
+                })
+
+                await fetchObject.execute(
+                    { type: 'task', id: 'task123', includeChildren: true },
+                    mockTodoistApi,
+                )
+
+                // Both requests are issued before either has resolved.
+                expect(calls).toEqual(['getTask', 'getTasks'])
             })
         })
 
@@ -469,6 +506,32 @@ describe(`${FETCH_OBJECT} tool`, () => {
                 )
 
                 expect(result.structuredContent).toMatchObject({ childCount: 0, children: [] })
+            })
+
+            it('should flag a truncated sub-project list', async () => {
+                mockTodoistApi.getProject.mockResolvedValue(createMockProject({ id: 'parent' }))
+                mockTodoistApi.getProjects.mockResolvedValue({
+                    results: Array.from({ length: 30 }, (_, index) =>
+                        createMockProject({
+                            id: `child${index}`,
+                            parentId: 'parent',
+                            childOrder: index,
+                        }),
+                    ),
+                    nextCursor: null,
+                })
+
+                const result = await fetchObject.execute(
+                    { type: 'project', id: 'parent', includeChildren: true },
+                    mockTodoistApi,
+                )
+
+                expect(childrenOf(result).children).toHaveLength(25)
+                expect(result.structuredContent).toMatchObject({
+                    childCount: 25,
+                    hasMoreChildren: true,
+                })
+                expect(result.textContent).toContain('subProjects=25+')
             })
 
             it('should short-circuit workspace projects, which nest under folders', async () => {

--- a/src/tools/fetch-object.test.ts
+++ b/src/tools/fetch-object.test.ts
@@ -1,6 +1,10 @@
-import type { Comment, Section, TodoistApi } from '@doist/todoist-sdk'
+import type { Comment, Section, Task, TodoistApi } from '@doist/todoist-sdk'
 import { type Mocked, vi } from 'vitest'
-import { createMockProject, createMockTask } from '../utils/test-helpers.js'
+import {
+    createMockProject,
+    createMockTask,
+    createMockWorkspaceProject,
+} from '../utils/test-helpers.js'
 import { ToolNames } from '../utils/tool-names.js'
 import { fetchObject } from './fetch-object.js'
 
@@ -10,6 +14,8 @@ const mockTodoistApi = {
     getProject: vi.fn(),
     getComment: vi.fn(),
     getSection: vi.fn(),
+    getTasks: vi.fn(),
+    getProjects: vi.fn(),
 } as unknown as Mocked<TodoistApi>
 
 const { FETCH_OBJECT } = ToolNames
@@ -239,6 +245,278 @@ describe(`${FETCH_OBJECT} tool`, () => {
                 fetchObject.execute({ type: 'section', id: 'section123' }, mockTodoistApi),
             ).rejects.toThrow('Failed to fetch section with id section123: API error')
         })
+    })
+
+    describe('includeChildren', () => {
+        /**
+         * The children fields only exist on the task and project branches of the
+         * structured content union, so narrow to them before asserting on one.
+         */
+        function childrenOf(result: Awaited<ReturnType<typeof fetchObject.execute>>) {
+            return (result.structuredContent ?? {}) as {
+                childCount?: number
+                children?: Record<string, unknown>[]
+                hasMoreChildren?: boolean
+                childrenError?: string
+            }
+        }
+
+        /** Answers the direct-children call for `parentId`, and treats every other task as a leaf. */
+        function mockSubtasksOf(
+            parentId: string,
+            subtasks: Task[],
+            nextCursor: string | null = null,
+        ) {
+            mockTodoistApi.getTasks.mockImplementation(async (args) =>
+                args?.parentId === parentId
+                    ? { results: subtasks, nextCursor }
+                    : { results: [], nextCursor: null },
+            )
+        }
+
+        describe('for tasks', () => {
+            beforeEach(() => {
+                mockTodoistApi.getTask.mockResolvedValue(createMockTask({ id: 'task123' }))
+            })
+
+            it('should not look up children unless asked', async () => {
+                const result = await fetchObject.execute(
+                    { type: 'task', id: 'task123' },
+                    mockTodoistApi,
+                )
+
+                expect(mockTodoistApi.getTasks).not.toHaveBeenCalled()
+                expect(result.structuredContent).not.toHaveProperty('childCount')
+                expect(result.structuredContent).not.toHaveProperty('children')
+            })
+
+            it('should report zero children for a leaf task', async () => {
+                mockSubtasksOf('task123', [])
+
+                const result = await fetchObject.execute(
+                    { type: 'task', id: 'task123', includeChildren: true },
+                    mockTodoistApi,
+                )
+
+                expect(mockTodoistApi.getTasks).toHaveBeenCalledTimes(1)
+                expect(mockTodoistApi.getTasks).toHaveBeenCalledWith({
+                    parentId: 'task123',
+                    limit: 25,
+                })
+                expect(result.structuredContent).toMatchObject({ childCount: 0, children: [] })
+                expect(result.textContent).toContain('subtasks=0')
+            })
+
+            it('should return compact subtasks and flag the ones that nest further', async () => {
+                const undatedSubtask = createMockTask({ id: 'sub1', content: 'Undated subtask' })
+                const datedSubtask = createMockTask({
+                    id: 'sub2',
+                    content: 'Dated subtask',
+                    checked: true,
+                    due: {
+                        isRecurring: false,
+                        string: '2 Aug',
+                        date: '2026-08-02',
+                        timezone: null,
+                        lang: 'en',
+                    },
+                })
+                mockTodoistApi.getTasks.mockImplementation(async (args) => {
+                    if (args?.parentId === 'task123') {
+                        return { results: [undatedSubtask, datedSubtask], nextCursor: null }
+                    }
+                    if (args?.parentId === 'sub1') {
+                        return {
+                            results: [createMockTask({ id: 'grandchild' })],
+                            nextCursor: null,
+                        }
+                    }
+                    return { results: [], nextCursor: null }
+                })
+
+                const result = await fetchObject.execute(
+                    { type: 'task', id: 'task123', includeChildren: true },
+                    mockTodoistApi,
+                )
+
+                // One call for the children, then one cheap probe per child.
+                expect(mockTodoistApi.getTasks).toHaveBeenCalledTimes(3)
+                expect(mockTodoistApi.getTasks).toHaveBeenCalledWith({
+                    parentId: 'sub1',
+                    limit: 1,
+                })
+                expect(result.structuredContent).toMatchObject({
+                    childCount: 2,
+                    children: [
+                        {
+                            id: 'sub1',
+                            content: 'Undated subtask',
+                            checked: false,
+                            hasChildren: true,
+                        },
+                        {
+                            id: 'sub2',
+                            content: 'Dated subtask',
+                            dueDate: '2026-08-02',
+                            checked: true,
+                            hasChildren: false,
+                        },
+                    ],
+                })
+                expect(childrenOf(result).children?.[0]).toHaveProperty('dueDate', undefined)
+                expect(result.textContent).toContain('subtasks=2')
+            })
+
+            it('should flag a truncated child list', async () => {
+                const subtasks = Array.from({ length: 25 }, (_, index) =>
+                    createMockTask({ id: `sub${index}` }),
+                )
+                mockSubtasksOf('task123', subtasks, 'next-page')
+
+                const result = await fetchObject.execute(
+                    { type: 'task', id: 'task123', includeChildren: true },
+                    mockTodoistApi,
+                )
+
+                expect(childrenOf(result).children).toHaveLength(25)
+                expect(result.structuredContent).toMatchObject({
+                    childCount: 25,
+                    hasMoreChildren: true,
+                })
+                expect(result.textContent).toContain('subtasks=25+')
+            })
+
+            it('should report a failed children lookup without failing the fetch', async () => {
+                mockTodoistApi.getTasks.mockRejectedValue(new Error('Rate limited'))
+
+                const result = await fetchObject.execute(
+                    { type: 'task', id: 'task123', includeChildren: true },
+                    mockTodoistApi,
+                )
+
+                expect(result.structuredContent?.object).toMatchObject({ id: 'task123' })
+                expect(childrenOf(result).childrenError).toBe('Rate limited')
+                expect(result.structuredContent).not.toHaveProperty('childCount')
+                expect(result.textContent).toContain('subtasks=unavailable')
+            })
+
+            it('should report a failed grandchild probe without failing the fetch', async () => {
+                mockTodoistApi.getTasks.mockImplementation(async (args) => {
+                    if (args?.parentId === 'task123') {
+                        return { results: [createMockTask({ id: 'sub1' })], nextCursor: null }
+                    }
+                    throw new Error('Probe failed')
+                })
+
+                const result = await fetchObject.execute(
+                    { type: 'task', id: 'task123', includeChildren: true },
+                    mockTodoistApi,
+                )
+
+                expect(childrenOf(result).childrenError).toBe('Probe failed')
+                expect(result.structuredContent).not.toHaveProperty('childCount')
+            })
+        })
+
+        describe('for projects', () => {
+            it('should return sub-projects in child order, flagging the ones that nest further', async () => {
+                mockTodoistApi.getProject.mockResolvedValue(createMockProject({ id: 'parent' }))
+                mockTodoistApi.getProjects.mockResolvedValue({
+                    results: [
+                        createMockProject({
+                            id: 'childB',
+                            name: 'B',
+                            parentId: 'parent',
+                            childOrder: 2,
+                        }),
+                        createMockProject({
+                            id: 'childA',
+                            name: 'A',
+                            parentId: 'parent',
+                            childOrder: 1,
+                        }),
+                        createMockProject({ id: 'grandchild', name: 'A1', parentId: 'childA' }),
+                        createMockProject({ id: 'unrelated', name: 'Elsewhere' }),
+                    ],
+                    nextCursor: null,
+                })
+
+                const result = await fetchObject.execute(
+                    { type: 'project', id: 'parent', includeChildren: true },
+                    mockTodoistApi,
+                )
+
+                expect(result.structuredContent).toMatchObject({
+                    childCount: 2,
+                    children: [
+                        { id: 'childA', name: 'A', hasChildren: true },
+                        { id: 'childB', name: 'B', hasChildren: false },
+                    ],
+                })
+                expect(result.textContent).toContain('subProjects=2')
+            })
+
+            it('should report zero sub-projects for a leaf project', async () => {
+                mockTodoistApi.getProject.mockResolvedValue(createMockProject({ id: 'parent' }))
+                mockTodoistApi.getProjects.mockResolvedValue({
+                    results: [createMockProject({ id: 'unrelated' })],
+                    nextCursor: null,
+                })
+
+                const result = await fetchObject.execute(
+                    { type: 'project', id: 'parent', includeChildren: true },
+                    mockTodoistApi,
+                )
+
+                expect(result.structuredContent).toMatchObject({ childCount: 0, children: [] })
+            })
+
+            it('should short-circuit workspace projects, which nest under folders', async () => {
+                mockTodoistApi.getProject.mockResolvedValue(
+                    createMockWorkspaceProject({ id: 'workspace-project' }),
+                )
+
+                const result = await fetchObject.execute(
+                    { type: 'project', id: 'workspace-project', includeChildren: true },
+                    mockTodoistApi,
+                )
+
+                expect(mockTodoistApi.getProjects).not.toHaveBeenCalled()
+                expect(result.structuredContent).toMatchObject({ childCount: 0, children: [] })
+            })
+
+            it('should report a failed children lookup without failing the fetch', async () => {
+                mockTodoistApi.getProject.mockResolvedValue(createMockProject({ id: 'parent' }))
+                mockTodoistApi.getProjects.mockRejectedValue(new Error('Rate limited'))
+
+                const result = await fetchObject.execute(
+                    { type: 'project', id: 'parent', includeChildren: true },
+                    mockTodoistApi,
+                )
+
+                expect(result.structuredContent?.object).toMatchObject({ id: 'parent' })
+                expect(childrenOf(result).childrenError).toBe('Rate limited')
+                expect(result.textContent).toContain('subProjects=unavailable')
+            })
+        })
+
+        it.each(['comment', 'section'] as const)(
+            'should ignore includeChildren for a %s',
+            async (type) => {
+                mockTodoistApi.getComment.mockResolvedValue(createMockComment())
+                mockTodoistApi.getSection.mockResolvedValue(MOCK_SECTION)
+
+                const result = await fetchObject.execute(
+                    { type, id: `${type}123`, includeChildren: true },
+                    mockTodoistApi,
+                )
+
+                expect(mockTodoistApi.getTasks).not.toHaveBeenCalled()
+                expect(mockTodoistApi.getProjects).not.toHaveBeenCalled()
+                expect(result.structuredContent).not.toHaveProperty('childCount')
+                expect(result.structuredContent).not.toHaveProperty('children')
+            },
+        )
     })
 
     describe('error handling', () => {

--- a/src/tools/fetch-object.ts
+++ b/src/tools/fetch-object.ts
@@ -1,6 +1,15 @@
+import type { PersonalProject, TodoistApi } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
-import { mapComment, mapProject, mapTask } from '../tool-helpers.js'
+import {
+    fetchAllActiveProjects,
+    isPersonalProject,
+    mapComment,
+    mapProject,
+    mapTask,
+    type Project,
+} from '../tool-helpers.js'
+import { ApiLimits } from '../utils/constants.js'
 import {
     CommentSchema,
     ProjectSchema,
@@ -12,9 +21,37 @@ import { ToolNames } from '../utils/tool-names.js'
 
 const ObjectTypes = ['task', 'project', 'comment', 'section'] as const
 
+const ChildTaskSchema = z.object({
+    id: z.string().describe('The unique ID of the subtask.'),
+    content: z.string().describe('The subtask title/content.'),
+    dueDate: z.string().optional().describe('The due date of the subtask (ISO 8601 format).'),
+    checked: z.boolean().describe('Whether the subtask is completed.'),
+    hasChildren: z
+        .boolean()
+        .describe(
+            'Whether this subtask has subtasks of its own. Fetch it with includeChildren to expand.',
+        ),
+})
+
+const ChildProjectSchema = z.object({
+    id: z.string().describe('The unique ID of the sub-project.'),
+    name: z.string().describe('The name of the sub-project.'),
+    hasChildren: z
+        .boolean()
+        .describe(
+            'Whether this sub-project has sub-projects of its own. Fetch it with includeChildren to expand.',
+        ),
+})
+
 const ArgsSchema = {
     type: z.enum(ObjectTypes).describe('The type of object to fetch.'),
     id: z.string().min(1).describe('The unique ID of the object to fetch.'),
+    includeChildren: z
+        .boolean()
+        .optional()
+        .describe(
+            'Also return the direct children of the object: subtasks for a task, sub-projects for a project. Returns childCount plus a compact list, flagging each child that has children of its own. Use this to check whether a task hides subtasks instead of a speculative find-tasks lookup. Ignored for comments and sections.',
+        ),
 }
 
 const OutputSchema = {
@@ -23,41 +60,170 @@ const OutputSchema = {
     object: z
         .union([TaskSchema, ProjectSchema, CommentSchema, SectionSchema])
         .describe('The fetched object data.'),
+    childCount: z
+        .number()
+        .optional()
+        .describe(
+            'The number of direct children listed in children. Only present when includeChildren is set and the type supports children. 0 means the object definitively has none.',
+        ),
+    children: z
+        .array(z.union([ChildTaskSchema, ChildProjectSchema]))
+        .optional()
+        .describe(
+            'Direct children only: subtasks for a task, sub-projects for a project. Completed subtasks and archived sub-projects are excluded.',
+        ),
+    hasMoreChildren: z
+        .boolean()
+        .optional()
+        .describe(
+            `Present when the object has more than ${ApiLimits.CHILDREN_MAX} direct children and the list was truncated. Use find-tasks with parentId to page through subtasks.`,
+        ),
+    childrenError: z
+        .string()
+        .optional()
+        .describe(
+            'Present when the children lookup failed. childCount is then unknown - do not read its absence as "no children".',
+        ),
+}
+
+type ChildSummary = z.infer<typeof ChildTaskSchema> | z.infer<typeof ChildProjectSchema>
+
+type ChildrenResult = {
+    childCount?: number
+    children?: ChildSummary[]
+    hasMoreChildren?: boolean
+    childrenError?: string
+}
+
+/**
+ * Fetches the direct subtasks of a task, flagging which of them nest further.
+ *
+ * The API exposes no child count on a task, so each child needs its own probe.
+ * That keeps the cost proportional to the number of subtasks rather than to the
+ * size of the project, which matters because the common case is a task with none.
+ */
+async function getTaskChildren(client: TodoistApi, taskId: string): Promise<ChildrenResult> {
+    const { results, nextCursor } = await client.getTasks({
+        parentId: taskId,
+        limit: ApiLimits.CHILDREN_MAX,
+    })
+
+    const grandchildFlags = await Promise.all(
+        results.map(async ({ id }) => {
+            const { results: grandchildren } = await client.getTasks({ parentId: id, limit: 1 })
+            return grandchildren.length > 0
+        }),
+    )
+
+    return {
+        childCount: results.length,
+        children: results.map((child, index) => ({
+            id: child.id,
+            content: child.content,
+            dueDate: child.due?.date,
+            checked: child.checked,
+            hasChildren: grandchildFlags[index] ?? false,
+        })),
+        hasMoreChildren: nextCursor ? true : undefined,
+    }
+}
+
+/**
+ * Fetches the direct sub-projects of a project, flagging which of them nest further.
+ *
+ * Projects cannot be filtered by parent server-side, so the hierarchy is derived
+ * from a single fetch of every active project.
+ */
+async function getProjectChildren(client: TodoistApi, project: Project): Promise<ChildrenResult> {
+    // Workspace projects live in folders rather than under a parent project, so
+    // they never have sub-projects and need no lookup at all.
+    if (!isPersonalProject(project)) {
+        return { childCount: 0, children: [] }
+    }
+
+    const allProjects = await fetchAllActiveProjects(client)
+    const byParent = new Map<string, PersonalProject[]>()
+    for (const candidate of allProjects) {
+        if (!isPersonalProject(candidate) || !candidate.parentId) continue
+        const siblings = byParent.get(candidate.parentId) ?? []
+        siblings.push(candidate)
+        byParent.set(candidate.parentId, siblings)
+    }
+
+    const direct = [...(byParent.get(project.id) ?? [])].sort((a, b) => a.childOrder - b.childOrder)
+    const listed = direct.slice(0, ApiLimits.CHILDREN_MAX)
+
+    return {
+        childCount: listed.length,
+        children: listed.map((child) => ({
+            id: child.id,
+            name: child.name,
+            hasChildren: (byParent.get(child.id)?.length ?? 0) > 0,
+        })),
+        hasMoreChildren: direct.length > listed.length ? true : undefined,
+    }
+}
+
+/**
+ * Runs a children lookup without letting its failure sink the whole fetch. The
+ * error is reported rather than swallowed: a missing childCount would otherwise
+ * read as "no children", which is the exact mistake the field exists to prevent.
+ */
+async function resolveChildren(load: () => Promise<ChildrenResult>): Promise<ChildrenResult> {
+    try {
+        return await load()
+    } catch (error) {
+        return { childrenError: error instanceof Error ? error.message : String(error) }
+    }
+}
+
+function formatChildrenSummary(label: string, result: ChildrenResult): string {
+    if (result.childrenError) return ` • ${label}=unavailable`
+    if (result.childCount === undefined) return ''
+    return ` • ${label}=${result.childCount}${result.hasMoreChildren ? '+' : ''}`
 }
 
 const fetchObject = {
     name: ToolNames.FETCH_OBJECT,
     description:
-        'Fetch a single task, project, comment, or section by its ID. Use this when you have a specific object ID and want to retrieve its full details.',
+        'Fetch a single task, project, comment, or section by its ID. Use this when you have a specific object ID and want to retrieve its full details. Set includeChildren to also get its direct subtasks or sub-projects.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
-        const { type, id } = args
+        const { type, id, includeChildren } = args
 
         try {
             switch (type) {
                 case 'task': {
                     const task = await client.getTask(id)
                     const mappedTask = mapTask(task)
+                    const children = includeChildren
+                        ? await resolveChildren(() => getTaskChildren(client, id))
+                        : {}
                     return {
-                        textContent: `Found task: ${mappedTask.content} • id=${mappedTask.id} • priority=${mappedTask.priority} • project=${mappedTask.projectId}`,
+                        textContent: `Found task: ${mappedTask.content} • id=${mappedTask.id} • priority=${mappedTask.priority} • project=${mappedTask.projectId}${formatChildrenSummary('subtasks', children)}`,
                         structuredContent: {
                             type,
                             id,
                             object: mappedTask,
+                            ...children,
                         },
                     }
                 }
                 case 'project': {
                     const project = await client.getProject(id)
                     const mappedProject = mapProject(project)
+                    const children = includeChildren
+                        ? await resolveChildren(() => getProjectChildren(client, project))
+                        : {}
                     return {
-                        textContent: `Found project: ${mappedProject.name} • id=${mappedProject.id} • color=${mappedProject.color} • viewStyle=${mappedProject.viewStyle}`,
+                        textContent: `Found project: ${mappedProject.name} • id=${mappedProject.id} • color=${mappedProject.color} • viewStyle=${mappedProject.viewStyle}${formatChildrenSummary('subProjects', children)}`,
                         structuredContent: {
                             type,
                             id,
                             object: mappedProject,
+                            ...children,
                         },
                     }
                 }

--- a/src/tools/fetch-object.ts
+++ b/src/tools/fetch-object.ts
@@ -1,15 +1,13 @@
-import type { PersonalProject, TodoistApi } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
+import { mapComment, mapProject, mapTask } from '../tool-helpers.js'
 import {
-    fetchAllActiveProjects,
-    isPersonalProject,
-    mapComment,
-    mapProject,
-    mapTask,
-    type Project,
-} from '../tool-helpers.js'
-import { ApiLimits } from '../utils/constants.js'
+    ChildrenOutputSchema,
+    formatChildrenSummary,
+    getProjectChildren,
+    getTaskChildren,
+    resolveChildren,
+} from '../utils/children.js'
 import {
     CommentSchema,
     ProjectSchema,
@@ -20,28 +18,6 @@ import {
 import { ToolNames } from '../utils/tool-names.js'
 
 const ObjectTypes = ['task', 'project', 'comment', 'section'] as const
-
-const ChildTaskSchema = z.object({
-    id: z.string().describe('The unique ID of the subtask.'),
-    content: z.string().describe('The subtask title/content.'),
-    dueDate: z.string().optional().describe('The due date of the subtask (ISO 8601 format).'),
-    checked: z.boolean().describe('Whether the subtask is completed.'),
-    hasChildren: z
-        .boolean()
-        .describe(
-            'Whether this subtask has subtasks of its own. Fetch it with includeChildren to expand.',
-        ),
-})
-
-const ChildProjectSchema = z.object({
-    id: z.string().describe('The unique ID of the sub-project.'),
-    name: z.string().describe('The name of the sub-project.'),
-    hasChildren: z
-        .boolean()
-        .describe(
-            'Whether this sub-project has sub-projects of its own. Fetch it with includeChildren to expand.',
-        ),
-})
 
 const ArgsSchema = {
     type: z.enum(ObjectTypes).describe('The type of object to fetch.'),
@@ -60,127 +36,7 @@ const OutputSchema = {
     object: z
         .union([TaskSchema, ProjectSchema, CommentSchema, SectionSchema])
         .describe('The fetched object data.'),
-    childCount: z
-        .number()
-        .optional()
-        .describe(
-            'The number of direct children listed in children. Only present when includeChildren is set and the type supports children. 0 means the object definitively has none.',
-        ),
-    children: z
-        .array(z.union([ChildTaskSchema, ChildProjectSchema]))
-        .optional()
-        .describe(
-            'Direct children only: subtasks for a task, sub-projects for a project. Completed subtasks and archived sub-projects are excluded.',
-        ),
-    hasMoreChildren: z
-        .boolean()
-        .optional()
-        .describe(
-            `Present when the object has more than ${ApiLimits.CHILDREN_MAX} direct children and the list was truncated. Use find-tasks with parentId to page through subtasks.`,
-        ),
-    childrenError: z
-        .string()
-        .optional()
-        .describe(
-            'Present when the children lookup failed. childCount is then unknown - do not read its absence as "no children".',
-        ),
-}
-
-type ChildSummary = z.infer<typeof ChildTaskSchema> | z.infer<typeof ChildProjectSchema>
-
-type ChildrenResult = {
-    childCount?: number
-    children?: ChildSummary[]
-    hasMoreChildren?: boolean
-    childrenError?: string
-}
-
-/**
- * Fetches the direct subtasks of a task, flagging which of them nest further.
- *
- * The API exposes no child count on a task, so each child needs its own probe.
- * That keeps the cost proportional to the number of subtasks rather than to the
- * size of the project, which matters because the common case is a task with none.
- */
-async function getTaskChildren(client: TodoistApi, taskId: string): Promise<ChildrenResult> {
-    const { results, nextCursor } = await client.getTasks({
-        parentId: taskId,
-        limit: ApiLimits.CHILDREN_MAX,
-    })
-
-    const grandchildFlags = await Promise.all(
-        results.map(async ({ id }) => {
-            const { results: grandchildren } = await client.getTasks({ parentId: id, limit: 1 })
-            return grandchildren.length > 0
-        }),
-    )
-
-    return {
-        childCount: results.length,
-        children: results.map((child, index) => ({
-            id: child.id,
-            content: child.content,
-            dueDate: child.due?.date,
-            checked: child.checked,
-            hasChildren: grandchildFlags[index] ?? false,
-        })),
-        hasMoreChildren: nextCursor ? true : undefined,
-    }
-}
-
-/**
- * Fetches the direct sub-projects of a project, flagging which of them nest further.
- *
- * Projects cannot be filtered by parent server-side, so the hierarchy is derived
- * from a single fetch of every active project.
- */
-async function getProjectChildren(client: TodoistApi, project: Project): Promise<ChildrenResult> {
-    // Workspace projects live in folders rather than under a parent project, so
-    // they never have sub-projects and need no lookup at all.
-    if (!isPersonalProject(project)) {
-        return { childCount: 0, children: [] }
-    }
-
-    const allProjects = await fetchAllActiveProjects(client)
-    const byParent = new Map<string, PersonalProject[]>()
-    for (const candidate of allProjects) {
-        if (!isPersonalProject(candidate) || !candidate.parentId) continue
-        const siblings = byParent.get(candidate.parentId) ?? []
-        siblings.push(candidate)
-        byParent.set(candidate.parentId, siblings)
-    }
-
-    const direct = [...(byParent.get(project.id) ?? [])].sort((a, b) => a.childOrder - b.childOrder)
-    const listed = direct.slice(0, ApiLimits.CHILDREN_MAX)
-
-    return {
-        childCount: listed.length,
-        children: listed.map((child) => ({
-            id: child.id,
-            name: child.name,
-            hasChildren: (byParent.get(child.id)?.length ?? 0) > 0,
-        })),
-        hasMoreChildren: direct.length > listed.length ? true : undefined,
-    }
-}
-
-/**
- * Runs a children lookup without letting its failure sink the whole fetch. The
- * error is reported rather than swallowed: a missing childCount would otherwise
- * read as "no children", which is the exact mistake the field exists to prevent.
- */
-async function resolveChildren(load: () => Promise<ChildrenResult>): Promise<ChildrenResult> {
-    try {
-        return await load()
-    } catch (error) {
-        return { childrenError: error instanceof Error ? error.message : String(error) }
-    }
-}
-
-function formatChildrenSummary(label: string, result: ChildrenResult): string {
-    if (result.childrenError) return ` • ${label}=unavailable`
-    if (result.childCount === undefined) return ''
-    return ` • ${label}=${result.childCount}${result.hasMoreChildren ? '+' : ''}`
+    ...ChildrenOutputSchema,
 }
 
 const fetchObject = {
@@ -196,11 +52,15 @@ const fetchObject = {
         try {
             switch (type) {
                 case 'task': {
-                    const task = await client.getTask(id)
+                    // Subtasks are looked up by parent id alone, so both requests
+                    // can go out at once rather than one after the other.
+                    const [task, children] = await Promise.all([
+                        client.getTask(id),
+                        includeChildren
+                            ? resolveChildren(() => getTaskChildren(client, id))
+                            : Promise.resolve({}),
+                    ])
                     const mappedTask = mapTask(task)
-                    const children = includeChildren
-                        ? await resolveChildren(() => getTaskChildren(client, id))
-                        : {}
                     return {
                         textContent: `Found task: ${mappedTask.content} • id=${mappedTask.id} • priority=${mappedTask.priority} • project=${mappedTask.projectId}${formatChildrenSummary('subtasks', children)}`,
                         structuredContent: {

--- a/src/utils/children.ts
+++ b/src/utils/children.ts
@@ -1,0 +1,173 @@
+import type { PersonalProject, TodoistApi } from '@doist/todoist-sdk'
+import { z } from 'zod'
+import { fetchAllActiveProjects, isPersonalProject, type Project } from '../tool-helpers.js'
+import { ApiLimits } from './constants.js'
+import { ProjectSchema, TaskSchema } from './output-schemas.js'
+
+const ChildTaskSchema = TaskSchema.pick({
+    id: true,
+    content: true,
+    dueDate: true,
+    checked: true,
+}).extend({
+    hasChildren: z
+        .boolean()
+        .describe(
+            'Whether this subtask has subtasks of its own. Fetch it with includeChildren to expand.',
+        ),
+})
+
+const ChildProjectSchema = ProjectSchema.pick({ id: true, name: true }).extend({
+    hasChildren: z
+        .boolean()
+        .describe(
+            'Whether this sub-project has sub-projects of its own. Fetch it with includeChildren to expand.',
+        ),
+})
+
+/**
+ * Output schema fragment for tools that can return an object's direct children.
+ * Spread it into the tool's own output schema.
+ */
+const ChildrenOutputSchema = {
+    childCount: z
+        .number()
+        .optional()
+        .describe(
+            'The number of direct children listed in children. Only present when children were requested and the type supports them. 0 means the object definitively has none.',
+        ),
+    children: z
+        .array(z.union([ChildTaskSchema, ChildProjectSchema]))
+        .optional()
+        .describe(
+            'Direct children only: subtasks for a task, sub-projects for a project. Completed subtasks and archived sub-projects are excluded.',
+        ),
+    hasMoreChildren: z
+        .boolean()
+        .optional()
+        .describe(
+            `Present when the object has more than ${ApiLimits.CHILDREN_MAX} direct children and the list was truncated. Page through the rest with find-tasks by parentId for subtasks, or find-projects for sub-projects.`,
+        ),
+    childrenError: z
+        .string()
+        .optional()
+        .describe(
+            'Present when the children lookup failed or returned incomplete information. When no children are listed alongside it, childCount is unknown - do not read its absence as "no children".',
+        ),
+}
+
+type ChildSummary = z.infer<typeof ChildTaskSchema> | z.infer<typeof ChildProjectSchema>
+
+type ChildrenResult = {
+    childCount?: number
+    children?: ChildSummary[]
+    hasMoreChildren?: boolean
+    childrenError?: string
+}
+
+/**
+ * Fetches the direct subtasks of a task, flagging which of them nest further.
+ *
+ * The API exposes no child count on a task, so each child needs its own probe.
+ * That keeps the cost proportional to the number of subtasks rather than to the
+ * size of the project, which matters because the common case is a task with none.
+ */
+async function getTaskChildren(client: TodoistApi, taskId: string): Promise<ChildrenResult> {
+    const { results, nextCursor } = await client.getTasks({
+        parentId: taskId,
+        limit: ApiLimits.CHILDREN_MAX,
+    })
+
+    // Settled rather than all: a probe that fails should cost its own nesting
+    // flag, not the whole subtask listing that was already fetched.
+    const probes = await Promise.allSettled(
+        results.map(({ id }) => client.getTasks({ parentId: id, limit: 1 })),
+    )
+    const unprobed = probes.filter((probe) => probe.status === 'rejected').length
+
+    return {
+        childCount: results.length,
+        children: results.map((child, index) => {
+            const probe = probes[index]
+            return {
+                id: child.id,
+                content: child.content,
+                dueDate: child.due?.date,
+                checked: child.checked,
+                hasChildren: probe?.status === 'fulfilled' && probe.value.results.length > 0,
+            }
+        }),
+        hasMoreChildren: nextCursor ? true : undefined,
+        childrenError: unprobed
+            ? `Could not check ${unprobed} of ${results.length} subtasks for subtasks of their own; those are reported as hasChildren=false.`
+            : undefined,
+    }
+}
+
+/**
+ * Fetches the direct sub-projects of a project, flagging which of them nest further.
+ *
+ * Projects cannot be filtered by parent server-side, so the hierarchy is derived
+ * from a single fetch of every active project.
+ */
+async function getProjectChildren(client: TodoistApi, project: Project): Promise<ChildrenResult> {
+    // Workspace projects live in folders rather than under a parent project, so
+    // they never have sub-projects and need no lookup at all.
+    if (!isPersonalProject(project)) {
+        return { childCount: 0, children: [] }
+    }
+
+    const allProjects = await fetchAllActiveProjects(client)
+    const byParent = new Map<string, PersonalProject[]>()
+    for (const candidate of allProjects) {
+        if (!isPersonalProject(candidate) || !candidate.parentId) continue
+        const siblings = byParent.get(candidate.parentId) ?? []
+        siblings.push(candidate)
+        byParent.set(candidate.parentId, siblings)
+    }
+
+    const direct = [...(byParent.get(project.id) ?? [])].sort((a, b) => a.childOrder - b.childOrder)
+    const listed = direct.slice(0, ApiLimits.CHILDREN_MAX)
+
+    return {
+        childCount: listed.length,
+        children: listed.map((child) => ({
+            id: child.id,
+            name: child.name,
+            hasChildren: (byParent.get(child.id)?.length ?? 0) > 0,
+        })),
+        hasMoreChildren: direct.length > listed.length ? true : undefined,
+    }
+}
+
+/**
+ * Runs a children lookup without letting its failure sink the fetch it belongs to.
+ * The error is reported rather than swallowed: a missing childCount would otherwise
+ * read as "no children", which is the exact mistake these fields exist to prevent.
+ */
+async function resolveChildren(load: () => Promise<ChildrenResult>): Promise<ChildrenResult> {
+    try {
+        return await load()
+    } catch (error) {
+        return { childrenError: error instanceof Error ? error.message : String(error) }
+    }
+}
+
+/** Renders a children result as a suffix for a tool's one-line text summary. */
+function formatChildrenSummary(label: string, result: ChildrenResult): string {
+    if (result.childCount === undefined) {
+        return result.childrenError ? ` • ${label}=unavailable` : ''
+    }
+    const truncated = result.hasMoreChildren ? '+' : ''
+    const partial = result.childrenError ? ' (partial)' : ''
+    return ` • ${label}=${result.childCount}${truncated}${partial}`
+}
+
+export {
+    ChildrenOutputSchema,
+    formatChildrenSummary,
+    getProjectChildren,
+    getTaskChildren,
+    resolveChildren,
+}
+export type { ChildrenResult }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -23,6 +23,8 @@ export const ApiLimits = {
     SECTIONS_MAX: 200,
     /** Batch size for fetching all tasks in a project */
     TASKS_BATCH_SIZE: 50,
+    /** Maximum number of direct children returned when children are requested alongside an object */
+    CHILDREN_MAX: 25,
     /** Default limit for comment listings */
     COMMENTS_DEFAULT: 10,
     /** Maximum limit for comment search and list operations */


### PR DESCRIPTION
Closes #542.

`fetch-object` only ever exposed the child→parent link (`parentId`), so nothing on a fetched task told you it *had* children. The only way to find out was a speculative `find-tasks` call with `parentId` — which an agent only makes if it already suspects subtasks exist. The result is the failure mode in the issue: a parent due today quietly hides an undated subtask that never appears in a normal overdue/today/no-date scan.

Setting `includeChildren` now returns `childCount` plus a compact list of the object's **direct** children — subtasks for a task, sub-projects for a project — and flags each child that has children of its own, so deeper nesting stays discoverable without returning the whole tree.

```
Found task: Create a utility to share redux state • id=5w8QJV23M8QQFPg6 • priority=p3 • project=6Pqhp2QXr7vrq7xc • subtasks=3
```
```json
"childCount": 3,
"children": [
  { "id": "5x3gpvWhMcMRQXV6", "content": "Write light spec and share with Frontend team", "checked": false, "hasChildren": false },
  { "id": "5wgmV5mHVGQF6R3c", "content": "Implement utility", "checked": false, "hasChildren": false },
  { "id": "5whFQWWWh66F86c6", "content": "Once merged, announce on affected issues:", "checked": false, "hasChildren": false }
]
```

## How children are read

**Tasks** — one `getTasks({ parentId })` call, then one cheap `limit: 1` probe per child to set `hasChildren` (the API carries no child count on a task). The cost tracks the size of the *answer*, not the size of the project: a leaf task costs exactly one extra call, which is the common case. I deliberately did not scan every task in the project and group by `parentId` in memory (what `get-overview` does) — that is unbounded in project size and sequentially paginated, which just moves the token problem server-side.

**Projects** — projects cannot be filtered by parent server-side, so the hierarchy comes from a single `fetchAllActiveProjects()` grouped by `parentId`, which gives exact grandchild presence for free. Workspace projects nest under folders rather than under a parent project, so they short-circuit to `childCount: 0` with no lookup at all.

The children fields sit at the top level of the structured content rather than inside `object`, which is a union of the shared `TaskSchema`/`ProjectSchema` used by 13+ other tools — nesting would have meant either polluting those or adding union variants to what is already the largest output schema in the repo.

## Behaviour worth knowing

- Only **active** subtasks are counted (`parent_id` listing excludes completed ones) and only **non-archived** sub-projects.
- `childCount` is the length of the returned list, capped at 25; when `hasMoreChildren` is set it is a floor, and `find-tasks` with `parentId` pages the rest.
- A failed children lookup reports `childrenError` instead of failing the fetch **or** silently omitting the count — an absent `childCount` would otherwise read as "no children", which is exactly the bug this is meant to prevent.
- `comment` and `section` ignore the parameter entirely: no fields, no API calls.

## Testing

12 new cases in `fetch-object.test.ts` covering leaf/populated/truncated children, grandchild flags, both failure paths, workspace short-circuit, and the ignored types. Full suite passes (972 tests), plus `type-check`, `format:check` and `lint:schemas`. Also smoke-tested against a real account: parent task with three undated subtasks, a leaf task, a project with four sub-projects, and a section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)