### PR TITLE
fix: scope collaborator caches to authenticated accounts (Doist/Issues#20711)

### DIFF
--- a/src/utils/user-resolver.test.ts
+++ b/src/utils/user-resolver.test.ts
@@ -101,6 +101,110 @@ describe('UserResolver', () => {
             // Only the two shared projects should have been queried for collaborators.
             expect(mockClient.getProjectCollaborators).toHaveBeenCalledTimes(2)
             expect(collaborators.map((c) => c.id).sort()).toEqual(['user-p1', 'user-p2'])
+            expect(mockClient.getUser).toHaveBeenCalledOnce()
+        })
+
+        it('keeps cached collaborators isolated between authenticated accounts', async () => {
+            const clientA = {
+                getUser: vi.fn().mockResolvedValue({
+                    id: 'account-a',
+                    fullName: 'Account A',
+                    email: 'a@example.com',
+                }),
+                getProjects: vi.fn().mockResolvedValue({
+                    results: [{ id: 'project-a', isShared: true }],
+                    nextCursor: null,
+                }),
+                getProjectCollaborators: vi.fn().mockResolvedValue({
+                    results: [{ id: 'collaborator-a', name: 'Alice', email: 'alice@example.com' }],
+                    nextCursor: null,
+                }),
+            } as unknown as Mocked<TodoistApi>
+            const clientB = {
+                getUser: vi.fn().mockResolvedValue({
+                    id: 'account-b',
+                    fullName: 'Account B',
+                    email: 'b@example.com',
+                }),
+                getProjects: vi.fn().mockResolvedValue({
+                    results: [{ id: 'project-b', isShared: true }],
+                    nextCursor: null,
+                }),
+                getProjectCollaborators: vi.fn().mockResolvedValue({
+                    results: [{ id: 'collaborator-b', name: 'Bob', email: 'bob@example.com' }],
+                    nextCursor: null,
+                }),
+            } as unknown as Mocked<TodoistApi>
+
+            await expect(resolver.getAllCollaborators(clientA)).resolves.toMatchObject([
+                { id: 'collaborator-a' },
+            ])
+            await expect(resolver.getAllCollaborators(clientB)).resolves.toMatchObject([
+                { id: 'collaborator-b' },
+            ])
+
+            expect(clientB.getProjects).toHaveBeenCalledOnce()
+            expect(clientB.getProjectCollaborators).toHaveBeenCalledWith('project-b')
+        })
+    })
+
+    describe('resolveUser', () => {
+        it('keeps cached user resolutions isolated between authenticated accounts', async () => {
+            const clientA = {
+                getUser: vi.fn().mockResolvedValue({
+                    id: 'account-a',
+                    fullName: 'Account A',
+                    email: 'a@example.com',
+                }),
+                getProjects: vi.fn().mockResolvedValue({
+                    results: [{ id: 'project-a', isShared: true }],
+                    nextCursor: null,
+                }),
+                getProjectCollaborators: vi.fn().mockResolvedValue({
+                    results: [{ id: 'alex-a', name: 'Alex', email: 'alex-a@example.com' }],
+                    nextCursor: null,
+                }),
+            } as unknown as Mocked<TodoistApi>
+            const clientB = {
+                getUser: vi.fn().mockResolvedValue({
+                    id: 'account-b',
+                    fullName: 'Account B',
+                    email: 'b@example.com',
+                }),
+                getProjects: vi.fn().mockResolvedValue({
+                    results: [{ id: 'project-b', isShared: true }],
+                    nextCursor: null,
+                }),
+                getProjectCollaborators: vi.fn().mockResolvedValue({
+                    results: [{ id: 'alex-b', name: 'Alex', email: 'alex-b@example.com' }],
+                    nextCursor: null,
+                }),
+            } as unknown as Mocked<TodoistApi>
+
+            await expect(resolver.resolveUser(clientA, 'Alex')).resolves.toMatchObject({
+                userId: 'alex-a',
+            })
+            await expect(resolver.resolveUser(clientB, 'Alex')).resolves.toMatchObject({
+                userId: 'alex-b',
+            })
+        })
+
+        it('resolves users without caching when the authenticated identity is unavailable', async () => {
+            mockClient.getUser.mockRejectedValue(new Error('Auth unavailable'))
+            mockClient.getProjects = vi.fn().mockResolvedValue({
+                results: [{ id: 'project-1', isShared: true }],
+                nextCursor: null,
+            }) as unknown as typeof mockClient.getProjects
+            mockClient.getProjectCollaborators = vi.fn().mockResolvedValue({
+                results: [{ id: 'ada-id', name: 'Ada', email: 'ada@example.com' }],
+                nextCursor: null,
+            }) as unknown as typeof mockClient.getProjectCollaborators
+
+            await expect(resolver.resolveUser(mockClient, 'Ada')).resolves.toEqual({
+                userId: 'ada-id',
+                displayName: 'Ada',
+                email: 'ada@example.com',
+            })
         })
     })
 })

--- a/src/utils/user-resolver.test.ts
+++ b/src/utils/user-resolver.test.ts
@@ -1,6 +1,50 @@
 import type { TodoistApi } from '@doist/todoist-sdk'
 import { type Mocked, vi } from 'vitest'
-import { SELF_USER_KEYWORD, UserResolver } from './user-resolver.js'
+import { BoundedTtlCache, SELF_USER_KEYWORD, UserResolver } from './user-resolver.js'
+
+describe('BoundedTtlCache', () => {
+    it('evicts the least recently used entry at capacity', () => {
+        const cache = new BoundedTtlCache<string>(2, 1_000)
+
+        cache.set('first', 'one')
+        cache.set('second', 'two')
+        expect(cache.get('first')).toBe('one')
+
+        cache.set('third', 'three')
+
+        expect(cache.size).toBe(2)
+        expect(cache.get('first')).toBe('one')
+        expect(cache.get('second')).toBeUndefined()
+        expect(cache.get('third')).toBe('three')
+    })
+
+    it('removes expired entries when they are read', () => {
+        vi.useFakeTimers()
+        const cache = new BoundedTtlCache<string>(2, 1_000)
+        cache.set('expired', 'value')
+
+        vi.advanceTimersByTime(1_000)
+
+        expect(cache.get('expired')).toBeUndefined()
+        expect(cache.size).toBe(0)
+        vi.useRealTimers()
+    })
+
+    it('prunes expired entries before evicting live entries at capacity', () => {
+        vi.useFakeTimers()
+        const cache = new BoundedTtlCache<string>(2, 1_000)
+        cache.set('expired', 'old')
+        vi.advanceTimersByTime(1_000)
+        cache.set('live', 'current')
+        cache.set('new', 'next')
+
+        expect(cache.size).toBe(2)
+        expect(cache.get('expired')).toBeUndefined()
+        expect(cache.get('live')).toBe('current')
+        expect(cache.get('new')).toBe('next')
+        vi.useRealTimers()
+    })
+})
 
 describe('UserResolver', () => {
     let resolver: UserResolver

--- a/src/utils/user-resolver.ts
+++ b/src/utils/user-resolver.ts
@@ -13,25 +13,86 @@ export type ProjectCollaborator = {
     email: string
 }
 
-// User resolution cache for performance with TTL
-const userResolutionCache = new Map<
-    string,
-    {
-        result: ResolvedUser | null
-        timestamp: number
-    }
->()
-
-// Project collaborators cache
-const collaboratorsCache = new Map<
-    string,
-    {
-        result: ProjectCollaborator[]
-        timestamp: number
-    }
->()
-
 const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+const MAX_USER_RESOLUTION_CACHE_ENTRIES = 10_000
+const MAX_COLLABORATORS_CACHE_ENTRIES = 1_000
+
+type CacheEntry<T> = {
+    result: T
+    timestamp: number
+}
+
+/**
+ * A bounded, TTL-aware LRU cache. Expired entries are removed when read and
+ * when space is needed; the least recently used live entry is then evicted.
+ */
+export class BoundedTtlCache<T> {
+    private readonly entries = new Map<string, CacheEntry<T>>()
+
+    constructor(
+        private readonly maxEntries: number,
+        private readonly ttl: number,
+    ) {}
+
+    get(key: string): T | undefined {
+        const entry = this.entries.get(key)
+        if (!entry) return undefined
+
+        if (Date.now() - entry.timestamp >= this.ttl) {
+            this.entries.delete(key)
+            return undefined
+        }
+
+        // Reinsert so Map insertion order tracks least- to most-recent use.
+        this.entries.delete(key)
+        this.entries.set(key, entry)
+        return entry.result
+    }
+
+    set(key: string, result: T): void {
+        // Replacing an entry must not consume another cache slot.
+        this.entries.delete(key)
+
+        if (this.entries.size >= this.maxEntries) {
+            this.pruneExpiredEntries()
+        }
+        if (this.entries.size >= this.maxEntries) {
+            const oldestKey = this.entries.keys().next().value
+            if (oldestKey !== undefined) this.entries.delete(oldestKey)
+        }
+
+        this.entries.set(key, { result, timestamp: Date.now() })
+    }
+
+    clear(): void {
+        this.entries.clear()
+    }
+
+    get size(): number {
+        return this.entries.size
+    }
+
+    private pruneExpiredEntries(): void {
+        const now = Date.now()
+        for (const [key, entry] of this.entries) {
+            if (now - entry.timestamp >= this.ttl) {
+                this.entries.delete(key)
+            }
+        }
+    }
+}
+
+// User resolution cache for performance with TTL.
+const userResolutionCache = new BoundedTtlCache<ResolvedUser | null>(
+    MAX_USER_RESOLUTION_CACHE_ENTRIES,
+    CACHE_TTL,
+)
+
+// Project and aggregate collaborator caches store larger result sets, so use a lower limit.
+const collaboratorsCache = new BoundedTtlCache<ProjectCollaborator[]>(
+    MAX_COLLABORATORS_CACHE_ENTRIES,
+    CACHE_TTL,
+)
 
 /** Keyword that resolves to the current authenticated user. */
 export const SELF_USER_KEYWORD = 'me' as const
@@ -80,13 +141,11 @@ export class UserResolver {
         const cacheScope = await this.getCacheScope(client)
         const cacheKey = this.getCacheKey(cacheScope, `user_${trimmedInput}`)
         const cached = cacheKey ? userResolutionCache.get(cacheKey) : undefined
-        if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-            return cached.result
-        }
+        if (cached !== undefined) return cached
 
         const cacheResult = (result: ResolvedUser | null) => {
             if (cacheKey) {
-                userResolutionCache.set(cacheKey, { result, timestamp: Date.now() })
+                userResolutionCache.set(cacheKey, result)
             }
             return result
         }
@@ -206,9 +265,7 @@ export class UserResolver {
             cacheScope === undefined ? await this.getCacheScope(client) : cacheScope
         const cacheKey = this.getCacheKey(resolvedCacheScope, `project_${projectId}`)
         const cached = cacheKey ? collaboratorsCache.get(cacheKey) : undefined
-        if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-            return cached.result
-        }
+        if (cached !== undefined) return cached
 
         try {
             const response = await client.getProjectCollaborators(projectId)
@@ -218,10 +275,7 @@ export class UserResolver {
             const validCollaborators = collaborators.filter((c) => c?.id && c.name && c.email)
 
             if (cacheKey) {
-                collaboratorsCache.set(cacheKey, {
-                    result: validCollaborators,
-                    timestamp: Date.now(),
-                })
+                collaboratorsCache.set(cacheKey, validCollaborators)
             }
 
             return validCollaborators
@@ -242,9 +296,7 @@ export class UserResolver {
             cacheScope === undefined ? await this.getCacheScope(client) : cacheScope
         const cacheKey = this.getCacheKey(resolvedCacheScope, 'all_collaborators')
         const cached = cacheKey ? collaboratorsCache.get(cacheKey) : undefined
-        if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-            return cached.result
-        }
+        if (cached !== undefined) return cached
 
         try {
             // Get all projects to find shared ones (paginated — accounts with
@@ -259,7 +311,7 @@ export class UserResolver {
             if (sharedProjects.length === 0) {
                 const result: ProjectCollaborator[] = []
                 if (cacheKey) {
-                    collaboratorsCache.set(cacheKey, { result, timestamp: Date.now() })
+                    collaboratorsCache.set(cacheKey, result)
                 }
                 return result
             }
@@ -287,10 +339,7 @@ export class UserResolver {
             }
 
             if (cacheKey) {
-                collaboratorsCache.set(cacheKey, {
-                    result: allCollaborators,
-                    timestamp: Date.now(),
-                })
+                collaboratorsCache.set(cacheKey, allCollaborators)
             }
 
             return allCollaborators

--- a/src/utils/user-resolver.ts
+++ b/src/utils/user-resolver.ts
@@ -77,7 +77,8 @@ export class UserResolver {
             return { userId: trimmedInput, displayName: trimmedInput, email: trimmedInput }
         }
 
-        const cacheKey = await this.getCacheKey(client, `user_${trimmedInput}`)
+        const cacheScope = await this.getCacheScope(client)
+        const cacheKey = this.getCacheKey(cacheScope, `user_${trimmedInput}`)
         const cached = cacheKey ? userResolutionCache.get(cacheKey) : undefined
         if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
             return cached.result
@@ -92,7 +93,7 @@ export class UserResolver {
 
         try {
             // Get all collaborators from shared projects
-            let allCollaborators = await this.getAllCollaborators(client)
+            let allCollaborators = await this.getAllCollaborators(client, cacheScope)
 
             // Try to get current user and prepend to collaborators list
             // This ensures the current user is found even if they have no shared projects
@@ -199,8 +200,11 @@ export class UserResolver {
     async getProjectCollaborators(
         client: TodoistApi,
         projectId: string,
+        cacheScope?: string | null,
     ): Promise<ProjectCollaborator[]> {
-        const cacheKey = await this.getCacheKey(client, `project_${projectId}`)
+        const resolvedCacheScope =
+            cacheScope === undefined ? await this.getCacheScope(client) : cacheScope
+        const cacheKey = this.getCacheKey(resolvedCacheScope, `project_${projectId}`)
         const cached = cacheKey ? collaboratorsCache.get(cacheKey) : undefined
         if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
             return cached.result
@@ -230,8 +234,13 @@ export class UserResolver {
     /**
      * Get all collaborators from all shared projects, deduplicated by user ID.
      */
-    async getAllCollaborators(client: TodoistApi): Promise<ProjectCollaborator[]> {
-        const cacheKey = await this.getCacheKey(client, 'all_collaborators')
+    async getAllCollaborators(
+        client: TodoistApi,
+        cacheScope?: string | null,
+    ): Promise<ProjectCollaborator[]> {
+        const resolvedCacheScope =
+            cacheScope === undefined ? await this.getCacheScope(client) : cacheScope
+        const cacheKey = this.getCacheKey(resolvedCacheScope, 'all_collaborators')
         const cached = cacheKey ? collaboratorsCache.get(cacheKey) : undefined
         if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
             return cached.result
@@ -260,7 +269,7 @@ export class UserResolver {
             const seenIds = new Set<string>()
 
             const collaboratorPromises = sharedProjects.map((project) =>
-                this.getProjectCollaborators(client, project.id),
+                this.getProjectCollaborators(client, project.id, resolvedCacheScope),
             )
 
             const collaboratorResults = await Promise.allSettled(collaboratorPromises)
@@ -291,13 +300,17 @@ export class UserResolver {
         }
     }
 
-    private async getCacheKey(client: TodoistApi, cacheKey: string): Promise<string | null> {
+    private async getCacheScope(client: TodoistApi): Promise<string | null> {
         try {
             const currentUser = await client.getUser()
-            return currentUser?.id ? `${currentUser.id}:${cacheKey}` : null
+            return currentUser?.id ?? null
         } catch (_error) {
             return null
         }
+    }
+
+    private getCacheKey(cacheScope: string | null, cacheKey: string): string | null {
+        return cacheScope ? `${cacheScope}:${cacheKey}` : null
     }
 
     /**

--- a/src/utils/user-resolver.ts
+++ b/src/utils/user-resolver.ts
@@ -49,15 +49,9 @@ export class UserResolver {
 
         const trimmedInput = nameOrId.trim()
 
-        // Check cache first
-        const cached = userResolutionCache.get(trimmedInput)
-        if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-            return cached.result
-        }
-
         // Handle "me" keyword — resolve to the current authenticated user
         // Case-insensitive: LLMs may send "Me", "ME", etc.
-        // Not cached: the cache is process-global and "me" resolves differently per client/account
+        // Not cached because it always reflects the current authenticated user
         if (trimmedInput.toLowerCase() === SELF_USER_KEYWORD) {
             try {
                 const currentUser = await client.getUser()
@@ -80,8 +74,19 @@ export class UserResolver {
                 !/^[a-z]+[\s-]/.test(trimmedInput) &&
                 /[0-9_]/.test(trimmedInput))
         ) {
-            const result = { userId: trimmedInput, displayName: trimmedInput, email: trimmedInput }
-            userResolutionCache.set(trimmedInput, { result, timestamp: Date.now() })
+            return { userId: trimmedInput, displayName: trimmedInput, email: trimmedInput }
+        }
+
+        const cacheKey = await this.getCacheKey(client, `user_${trimmedInput}`)
+        const cached = cacheKey ? userResolutionCache.get(cacheKey) : undefined
+        if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+            return cached.result
+        }
+
+        const cacheResult = (result: ResolvedUser | null) => {
+            if (cacheKey) {
+                userResolutionCache.set(cacheKey, { result, timestamp: Date.now() })
+            }
             return result
         }
 
@@ -109,9 +114,7 @@ export class UserResolver {
             }
 
             if (allCollaborators.length === 0) {
-                const result = null // No users found (no current user, no shared projects)
-                userResolutionCache.set(trimmedInput, { result, timestamp: Date.now() })
-                return result
+                return cacheResult(null)
             }
 
             const searchTerm = nameOrId.toLowerCase().trim()
@@ -119,52 +122,58 @@ export class UserResolver {
             // Try exact ID match first
             let match = allCollaborators.find((c) => c.id === trimmedInput)
             if (match) {
-                const result = { userId: match.id, displayName: match.name, email: match.email }
-                userResolutionCache.set(trimmedInput, { result, timestamp: Date.now() })
-                return result
+                return cacheResult({
+                    userId: match.id,
+                    displayName: match.name,
+                    email: match.email,
+                })
             }
 
             // Try exact name match
             match = allCollaborators.find((c) => c.name.toLowerCase() === searchTerm)
             if (match) {
-                const result = { userId: match.id, displayName: match.name, email: match.email }
-                userResolutionCache.set(trimmedInput, { result, timestamp: Date.now() })
-                return result
+                return cacheResult({
+                    userId: match.id,
+                    displayName: match.name,
+                    email: match.email,
+                })
             }
 
             // Try exact email match
             match = allCollaborators.find((c) => c.email.toLowerCase() === searchTerm)
             if (match) {
-                const result = { userId: match.id, displayName: match.name, email: match.email }
-                userResolutionCache.set(trimmedInput, { result, timestamp: Date.now() })
-                return result
+                return cacheResult({
+                    userId: match.id,
+                    displayName: match.name,
+                    email: match.email,
+                })
             }
 
             // Try partial name match (contains)
             match = allCollaborators.find((c) => c.name.toLowerCase().includes(searchTerm))
             if (match) {
-                const result = { userId: match.id, displayName: match.name, email: match.email }
-                userResolutionCache.set(trimmedInput, { result, timestamp: Date.now() })
-                return result
+                return cacheResult({
+                    userId: match.id,
+                    displayName: match.name,
+                    email: match.email,
+                })
             }
 
             // Try partial email match
             match = allCollaborators.find((c) => c.email.toLowerCase().includes(searchTerm))
             if (match) {
-                const result = { userId: match.id, displayName: match.name, email: match.email }
-                userResolutionCache.set(trimmedInput, { result, timestamp: Date.now() })
-                return result
+                return cacheResult({
+                    userId: match.id,
+                    displayName: match.name,
+                    email: match.email,
+                })
             }
 
             // No match found
-            const result = null
-            userResolutionCache.set(trimmedInput, { result, timestamp: Date.now() })
-            return result
+            return cacheResult(null)
         } catch (_error) {
             // If we can't fetch collaborators, return null instead of dangerous fallback
-            const result = null
-            userResolutionCache.set(trimmedInput, { result, timestamp: Date.now() })
-            return result
+            return cacheResult(null)
         }
     }
 
@@ -191,9 +200,8 @@ export class UserResolver {
         client: TodoistApi,
         projectId: string,
     ): Promise<ProjectCollaborator[]> {
-        // Check cache first
-        const cacheKey = `project_${projectId}`
-        const cached = collaboratorsCache.get(cacheKey)
+        const cacheKey = await this.getCacheKey(client, `project_${projectId}`)
+        const cached = cacheKey ? collaboratorsCache.get(cacheKey) : undefined
         if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
             return cached.result
         }
@@ -205,10 +213,12 @@ export class UserResolver {
 
             const validCollaborators = collaborators.filter((c) => c?.id && c.name && c.email)
 
-            collaboratorsCache.set(cacheKey, {
-                result: validCollaborators,
-                timestamp: Date.now(),
-            })
+            if (cacheKey) {
+                collaboratorsCache.set(cacheKey, {
+                    result: validCollaborators,
+                    timestamp: Date.now(),
+                })
+            }
 
             return validCollaborators
         } catch (_error) {
@@ -221,9 +231,8 @@ export class UserResolver {
      * Get all collaborators from all shared projects, deduplicated by user ID.
      */
     async getAllCollaborators(client: TodoistApi): Promise<ProjectCollaborator[]> {
-        // Check cache first
-        const cacheKey = 'all_collaborators'
-        const cached = collaboratorsCache.get(cacheKey)
+        const cacheKey = await this.getCacheKey(client, 'all_collaborators')
+        const cached = cacheKey ? collaboratorsCache.get(cacheKey) : undefined
         if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
             return cached.result
         }
@@ -240,7 +249,9 @@ export class UserResolver {
 
             if (sharedProjects.length === 0) {
                 const result: ProjectCollaborator[] = []
-                collaboratorsCache.set(cacheKey, { result, timestamp: Date.now() })
+                if (cacheKey) {
+                    collaboratorsCache.set(cacheKey, { result, timestamp: Date.now() })
+                }
                 return result
             }
 
@@ -266,15 +277,26 @@ export class UserResolver {
                 // Skip failed projects, continue with others
             }
 
-            collaboratorsCache.set(cacheKey, {
-                result: allCollaborators,
-                timestamp: Date.now(),
-            })
+            if (cacheKey) {
+                collaboratorsCache.set(cacheKey, {
+                    result: allCollaborators,
+                    timestamp: Date.now(),
+                })
+            }
 
             return allCollaborators
         } catch (_error) {
             // Return empty array on error, don't cache failed requests
             return []
+        }
+    }
+
+    private async getCacheKey(client: TodoistApi, cacheKey: string): Promise<string | null> {
+        try {
+            const currentUser = await client.getUser()
+            return currentUser?.id ? `${currentUser.id}:${cacheKey}` : null
+        } catch (_error) {
+            return null
         }
     }
 


### PR DESCRIPTION
> [!NOTE]
> This PR has extensive changes by **Ernesto** on top of the original more naive attempt made by **Doistbot**.

## Short description

Scopes `UserResolver` caches to the authenticated Todoist account, preventing collaborator and user-resolution results from being served from another account’s cache entry.

The caches are now bounded TTL/LRU caches: expired entries are removed on access and when capacity is needed, and the least-recently-used live entry is evicted at capacity. User-resolution entries are capped at 10,000; larger collaborator result sets at 1,000. Cache use is skipped when the current identity cannot be verified.

## Validation

- Added two-account regression coverage for collaborator discovery and user resolution.
- Added cache expiry, pruning, and LRU-eviction coverage.
- `npm test`, `npm run type-check`, `npm run format:check`, and `npm run build` pass locally.

Closes https://github.com/Doist/Issues/issues/20711

## PR Checklist

- [x] Added tests for bugs / new features
- [ ] Updated docs (README, etc.) — not needed; no user-facing behavior changes
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts` — not applicable