### PR TITLE
fix(retry): add full jitter to backoff delays

### DIFF
--- a/src/utils/retry.test.ts
+++ b/src/utils/retry.test.ts
@@ -1,4 +1,10 @@
-import { executeWithRetry, extractHttpStatusCode, isTransientError } from './retry.js'
+import {
+    executeWithRetry,
+    extractHttpStatusCode,
+    getRetryDelay,
+    isTransientError,
+    MIN_RETRY_DELAY_MS,
+} from './retry.js'
 
 const NO_DELAY: { baseDelayMs: number; maxDelayMs: number } = {
     baseDelayMs: 0,
@@ -222,7 +228,7 @@ describe('executeWithRetry', () => {
         expect(fn).toHaveBeenCalledTimes(2)
     })
 
-    it('should use exponential backoff delays', async () => {
+    it('should use exponential backoff delays, drawing up to the ceiling', async () => {
         vi.useFakeTimers()
 
         const error503 = Object.assign(new Error('HTTP 503: Service Unavailable'), {
@@ -231,7 +237,12 @@ describe('executeWithRetry', () => {
         const fn = vi.fn().mockRejectedValueOnce(error503).mockResolvedValue('recovered')
         const sleepSpy = vi.spyOn(globalThis, 'setTimeout')
 
-        const promise = executeWithRetry(fn, { baseDelayMs: 500, maxDelayMs: 2000 })
+        // random: () => 1 draws the top of the jitter range, making the ceiling exact
+        const promise = executeWithRetry(fn, {
+            baseDelayMs: 500,
+            maxDelayMs: 2000,
+            random: () => 1,
+        })
         await vi.advanceTimersByTimeAsync(500)
         const result = await promise
 
@@ -259,7 +270,11 @@ describe('executeWithRetry', () => {
             .mockResolvedValue('recovered')
         const sleepSpy = vi.spyOn(globalThis, 'setTimeout')
 
-        const promise = executeWithRetry(fn, { baseDelayMs: 1000, maxDelayMs: 1500 })
+        const promise = executeWithRetry(fn, {
+            baseDelayMs: 1000,
+            maxDelayMs: 1500,
+            random: () => 1,
+        })
         await vi.advanceTimersByTimeAsync(1000)
         await vi.advanceTimersByTimeAsync(1500)
         const result = await promise
@@ -275,6 +290,81 @@ describe('executeWithRetry', () => {
         expect(retryDelays).not.toContain(2000)
 
         vi.useRealTimers()
+    })
+
+    it('should spread concurrent retries instead of retrying in lockstep', async () => {
+        vi.useFakeTimers()
+
+        const error503 = Object.assign(new Error('HTTP 503: Service Unavailable'), {
+            httpStatusCode: 503,
+        })
+        const makeFn = () => vi.fn().mockRejectedValueOnce(error503).mockResolvedValue('recovered')
+        const sleepSpy = vi.spyOn(globalThis, 'setTimeout')
+
+        const first = executeWithRetry(makeFn(), {
+            baseDelayMs: 1000,
+            maxDelayMs: 2000,
+            random: () => 0.25,
+        })
+        const second = executeWithRetry(makeFn(), {
+            baseDelayMs: 1000,
+            maxDelayMs: 2000,
+            random: () => 0.75,
+        })
+
+        await vi.advanceTimersByTimeAsync(1000)
+        await Promise.all([first, second])
+
+        const retryDelays = sleepSpy.mock.calls
+            .filter(([, delay]) => typeof delay === 'number' && delay >= MIN_RETRY_DELAY_MS)
+            .map(([, delay]) => delay)
+
+        expect(retryDelays).toContain(250)
+        expect(retryDelays).toContain(750)
+
+        vi.useRealTimers()
+    })
+})
+
+describe('getRetryDelay', () => {
+    const CONFIG = { baseDelayMs: 500, maxDelayMs: 2000 }
+
+    it('should return the full ceiling on the highest draw', () => {
+        expect(getRetryDelay({ attempt: 0, ...CONFIG, random: () => 1 })).toBe(500)
+        expect(getRetryDelay({ attempt: 1, ...CONFIG, random: () => 1 })).toBe(1000)
+        expect(getRetryDelay({ attempt: 2, ...CONFIG, random: () => 1 })).toBe(2000)
+    })
+
+    it('should never return the ceiling when the draw is lower', () => {
+        expect(getRetryDelay({ attempt: 1, ...CONFIG, random: () => 0.5 })).toBe(500)
+    })
+
+    it('should floor a low draw at MIN_RETRY_DELAY_MS so retries are not immediate', () => {
+        expect(getRetryDelay({ attempt: 0, ...CONFIG, random: () => 0 })).toBe(MIN_RETRY_DELAY_MS)
+    })
+
+    it('should honour an explicit zero-delay config over the floor', () => {
+        expect(getRetryDelay({ attempt: 0, baseDelayMs: 0, maxDelayMs: 0, random: () => 1 })).toBe(
+            0,
+        )
+    })
+
+    it('should stay within [MIN_RETRY_DELAY_MS, ceiling] across many draws', () => {
+        const draws = Array.from({ length: 50 }, (_, index) => index / 50)
+        for (const draw of draws) {
+            const delay = getRetryDelay({ attempt: 1, ...CONFIG, random: () => draw })
+            expect(delay).toBeGreaterThanOrEqual(MIN_RETRY_DELAY_MS)
+            expect(delay).toBeLessThanOrEqual(1000)
+        }
+    })
+
+    it('should produce different delays for different draws', () => {
+        const delays = new Set(
+            [0.1, 0.4, 0.9].map((draw) =>
+                getRetryDelay({ attempt: 2, ...CONFIG, random: () => draw }),
+            ),
+        )
+        expect(delays.size).toBe(3)
     })
 
     it('should use default config when none provided', async () => {

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -2,12 +2,21 @@ const DEFAULT_MAX_RETRIES = 2
 const DEFAULT_BASE_DELAY_MS = 500
 const DEFAULT_MAX_DELAY_MS = 2000
 
+/**
+ * Floor for a jittered delay so a low random draw can't turn a retry into an
+ * immediate re-request. Clamped by the computed ceiling, so an explicit
+ * zero-delay config (used by tests) still waits nothing.
+ */
+const MIN_RETRY_DELAY_MS = 50
+
 const RETRYABLE_STATUS_CODES = new Set([502, 503, 504])
 
 type RetryConfig = {
     maxRetries?: number
     baseDelayMs?: number
     maxDelayMs?: number
+    /** Injectable randomness for deterministic tests. Defaults to `Math.random`. */
+    random?: () => number
 }
 
 function extractHttpStatusCode(error: unknown): number | undefined {
@@ -44,17 +53,28 @@ function isTransientError(error: unknown): boolean {
     return statusCode !== undefined && RETRYABLE_STATUS_CODES.has(statusCode)
 }
 
+/**
+ * Exponential backoff with full jitter: the delay is a random point in
+ * `[0, cap]` rather than the cap itself.
+ *
+ * Without jitter, a batch of requests that all fail together retry in lockstep
+ * and hit the server as another simultaneous burst — the same contention that
+ * caused the first failure. Spreading the retries is what breaks that cycle.
+ */
 function getRetryDelay({
     attempt,
     baseDelayMs,
     maxDelayMs,
+    random = Math.random,
 }: {
     attempt: number
     baseDelayMs: number
     maxDelayMs: number
+    random?: () => number
 }): number {
-    const delay = baseDelayMs * 2 ** attempt
-    return Math.min(delay, maxDelayMs)
+    const cap = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs)
+    const jittered = Math.round(random() * cap)
+    return Math.min(cap, Math.max(MIN_RETRY_DELAY_MS, jittered))
 }
 
 function sleep(ms: number): Promise<void> {
@@ -65,6 +85,7 @@ async function executeWithRetry<T>(fn: () => Promise<T>, config: RetryConfig = {
     const maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES
     const baseDelayMs = config.baseDelayMs ?? DEFAULT_BASE_DELAY_MS
     const maxDelayMs = config.maxDelayMs ?? DEFAULT_MAX_DELAY_MS
+    const random = config.random
 
     let lastError: unknown
 
@@ -75,7 +96,7 @@ async function executeWithRetry<T>(fn: () => Promise<T>, config: RetryConfig = {
             lastError = error
 
             if (attempt < maxRetries && isTransientError(error)) {
-                const delay = getRetryDelay({ attempt, baseDelayMs, maxDelayMs })
+                const delay = getRetryDelay({ attempt, baseDelayMs, maxDelayMs, random })
                 await sleep(delay)
                 continue
             }
@@ -87,4 +108,11 @@ async function executeWithRetry<T>(fn: () => Promise<T>, config: RetryConfig = {
     throw lastError
 }
 
-export { executeWithRetry, extractHttpStatusCode, isTransientError, type RetryConfig }
+export {
+    executeWithRetry,
+    extractHttpStatusCode,
+    getRetryDelay,
+    isTransientError,
+    MIN_RETRY_DELAY_MS,
+    type RetryConfig,
+}


### PR DESCRIPTION
## Context

[Janusz flagged on Comms](https://comms.todoist.com/69/ch/AK6drPS98yMaYmyWmztS2/t/CdffD1JCLJMYmWYSf3Fi2) that `todoist-mcp` accounts for almost all failing task moves the API sees, and that backend locking is changing so conflicting concurrent moves in the same task tree will fail with **503 + Retry-After**. That makes our retry behaviour load-bearing in a way it wasn't before.

Retries used a fixed exponential delay — 500ms, then 1000ms, identical for every caller. A batch of requests that fails together therefore retries in lockstep and arrives as another simultaneous burst, which is the same contention that caused the first failure.

This is the first of three PRs from that thread. It is independent of the other two and safe to land on its own.

## What changed

The delay is now a random point in `[0, cap]` (full jitter) rather than the cap itself, with a 50ms floor so a low draw can't turn a retry into an effectively immediate re-request. The floor is clamped by the cap, so an explicit zero-delay config — which the tests use — still waits nothing.

`RetryConfig` gains an injectable `random` (defaulting to `Math.random`) and `getRetryDelay` is exported, so delays are assertable rather than timing-dependent.

Deliberately unchanged: `maxRetries` stays at 2, and 429 stays non-retryable. More attempts under lock contention would mean more load, not fewer failures.

## Testing

The two existing exact-delay tests now inject `random: () => 1`, which pins the ceiling exactly. New coverage: the floor at the lowest draw, an explicit zero-delay config beating the floor, delays staying inside `[floor, ceiling]` across 50 draws, and a regression guard that two retriers with different draws get different delays.

`npm test` (1062 tests), `npm run type-check`, `npm run check` all pass.

## Follow-up, not in this PR

Honouring the `Retry-After` header itself. `TodoistRequestError` carries no response headers, but `createTrackedFetch` in `src/usage-tracking.ts` does see the raw `Response`. Doing it there would stack a third retry layer on top of `executeWithRetry` and the SDK's own `fetchWithRetry`, multiplying attempts, so it wants its own change that moves 5xx retry authority down to the transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)