### PR TITLE
fix(update-tasks): bound concurrent write requests

### DIFF
--- a/src/tools/update-tasks.test.ts
+++ b/src/tools/update-tasks.test.ts
@@ -1,6 +1,8 @@
 import type { Task, TodoistApi } from '@doist/todoist-sdk'
 import { type Mocked, vi } from 'vitest'
 import { z } from 'zod'
+import { resetLimitersForTesting } from '../utils/concurrency.js'
+import { ConcurrencyLimits } from '../utils/constants.js'
 import { convertPriorityToNumber } from '../utils/priorities.js'
 import { createMockTask, createMockUser, TEST_IDS } from '../utils/test-helpers.js'
 import { ToolNames } from '../utils/tool-names.js'
@@ -18,6 +20,9 @@ const { UPDATE_TASKS } = ToolNames
 describe(`${UPDATE_TASKS} tool`, () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        // The mock client is never registered, so it shares the process-wide
+        // fallback limiters — reset them so queued work can't leak between cases.
+        resetLimitersForTesting()
         mockTodoistApi.getUser.mockResolvedValue(createMockUser())
     })
 
@@ -1447,6 +1452,84 @@ describe(`${UPDATE_TASKS} tool`, () => {
                 updateTasks.execute({ tasks: makeTasks(26) }, mockTodoistApi),
             ).rejects.toThrow('Too big')
             expect(mockTodoistApi.updateTask).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('request concurrency', () => {
+        /** Records the peak number of simultaneously in-flight calls to a mock. */
+        function trackInFlight(mock: Mocked<TodoistApi>[keyof TodoistApi], result: Task) {
+            const state = { max: 0, active: 0 }
+            const release: Array<() => void> = []
+            const mocked = mock as unknown as ReturnType<typeof vi.fn>
+            mocked.mockImplementation(async () => {
+                state.active++
+                state.max = Math.max(state.max, state.active)
+                await new Promise<void>((resolve) => release.push(resolve))
+                state.active--
+                return result
+            })
+            return {
+                state,
+                /**
+                 * Releases calls as they arrive until the operation finishes, so the
+                 * limiter — not the mock — decides how many run at once.
+                 */
+                async drain<T>(operation: Promise<T>): Promise<T> {
+                    let settled = false
+                    const tracked = operation.finally(() => {
+                        settled = true
+                    })
+                    while (!settled) {
+                        await new Promise((resolve) => setImmediate(resolve))
+                        for (const resolve of release.splice(0)) {
+                            resolve()
+                        }
+                    }
+                    return tracked
+                },
+            }
+        }
+
+        it('never has more than one move in flight', async () => {
+            const moved = createMockTask({ id: 'task-0' })
+            const tracker = trackInFlight(mockTodoistApi.moveTask, moved)
+
+            await tracker.drain(
+                updateTasks.execute(
+                    {
+                        tasks: [
+                            { id: 'task-0', projectId: 'project-a' },
+                            { id: 'task-1', projectId: 'project-b' },
+                            { id: 'task-2', projectId: 'project-c' },
+                            { id: 'task-3', projectId: 'project-d' },
+                        ],
+                    },
+                    mockTodoistApi,
+                ),
+            )
+
+            expect(mockTodoistApi.moveTask).toHaveBeenCalledTimes(4)
+            expect(tracker.state.max).toBe(ConcurrencyLimits.TASK_MOVES)
+        })
+
+        it('bounds concurrent field updates', async () => {
+            const updated = createMockTask({ id: 'task-0' })
+            const tracker = trackInFlight(mockTodoistApi.updateTask, updated)
+
+            await tracker.drain(
+                updateTasks.execute(
+                    {
+                        tasks: Array.from({ length: 10 }, (_, index) => ({
+                            id: `task-${index}`,
+                            content: 'renamed',
+                        })),
+                    },
+                    mockTodoistApi,
+                ),
+            )
+
+            expect(mockTodoistApi.updateTask).toHaveBeenCalledTimes(10)
+            expect(tracker.state.max).toBe(ConcurrencyLimits.WRITES)
         })
     })
 })

--- a/src/tools/update-tasks.ts
+++ b/src/tools/update-tasks.ts
@@ -4,6 +4,7 @@ import type { TodoistTool } from '../todoist-tool.js'
 import { formatBatchItemError } from '../tool-execution-error.js'
 import { createMoveTaskArgs, mapTask, resolveInboxProjectId } from '../tool-helpers.js'
 import { assignmentValidator } from '../utils/assignment-validator.js'
+import { getMoveLimiter, getWriteLimiter } from '../utils/concurrency.js'
 import { BatchLimits, DisplayLimits } from '../utils/constants.js'
 import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
 import { FailureSchema, TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
@@ -294,23 +295,31 @@ async function processTaskUpdate(task: TaskUpdate, client: TodoistApi): Promise<
     // are retried per item. The registerTool() wrapper's retry only fires when execute()
     // throws, which never happens now that we settle each task — and the SDK transport
     // only retries network/timeout errors, not 5xx responses.
+    //
+    // The limiters bound how many of those calls are in flight at once. Moves get
+    // their own, tighter lane because the API locks a task's whole tree while
+    // moving it, so overlapping moves contend and one of them loses.
+    const moveLimiter = getMoveLimiter(client)
+    const writeLimiter = getWriteLimiter(client)
+    const updateTask = () =>
+        writeLimiter(() => executeWithRetry(() => client.updateTask(id, updateArgs)))
 
     // If no move parameters are provided, use updateTask without moveTask
     if (!resolvedProjectId && !sectionId && !parentId) {
         return {
             kind: 'updated',
-            task: await executeWithRetry(() => client.updateTask(id, updateArgs)),
+            task: await updateTask(),
         }
     }
 
     const moveArgs = createMoveTaskArgs(id, resolvedProjectId, sectionId, parentId)
-    const movedTask = await executeWithRetry(() => client.moveTask(id, moveArgs))
+    const movedTask = await moveLimiter(() => executeWithRetry(() => client.moveTask(id, moveArgs)))
 
     if (Object.keys(updateArgs).length > 0) {
         try {
             return {
                 kind: 'updated',
-                task: await executeWithRetry(() => client.updateTask(id, updateArgs)),
+                task: await updateTask(),
             }
         } catch (error) {
             return {

--- a/src/usage-tracking.ts
+++ b/src/usage-tracking.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 import { type CustomFetch, type CustomFetchResponse, TodoistApi } from '@doist/todoist-sdk'
 import packageJson from '../package.json' with { type: 'json' }
+import { registerClientLimiters } from './utils/concurrency.js'
 
 const TODOIST_MCP_NAME = 'todoist-mcp'
 const TODOIST_MCP_VERSION = packageJson.version
@@ -245,10 +246,15 @@ export function createTodoistClient(
         tracking?: UsageTrackingConfig
     } = {},
 ): TodoistApi {
-    return new TodoistApi(apiKey, {
+    const client = new TodoistApi(apiKey, {
         customFetch: createTrackedFetch(globalThis.fetch, tracking),
         ...(baseUrl ? { baseUrl } : {}),
     })
+    // The HTTP transport builds a client per request, so request-bounded limits
+    // would not bound anything. Registering by account shares one set of limits
+    // across every client for that account.
+    registerClientLimiters(client, apiKey)
+    return client
 }
 
 export { TODOIST_MCP_VERSION }

--- a/src/utils/concurrency.test.ts
+++ b/src/utils/concurrency.test.ts
@@ -1,0 +1,253 @@
+import {
+    createLimiter,
+    getMoveLimiter,
+    getWriteLimiter,
+    registerClientLimiters,
+    resetLimitersForTesting,
+} from './concurrency.js'
+import { ConcurrencyLimits } from './constants.js'
+
+/**
+ * A promise whose resolution the test controls, so it can hold tasks inside the
+ * limiter and observe how many are running.
+ */
+function deferred<T = void>() {
+    let resolve: (value: T) => void = () => {}
+    let reject: (reason: unknown) => void = () => {}
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res
+        reject = rej
+    })
+    return { promise, resolve, reject }
+}
+
+/** Lets queued continuations run without advancing real time. */
+function flush() {
+    return new Promise((resolve) => setImmediate(resolve))
+}
+
+beforeEach(() => {
+    resetLimitersForTesting()
+})
+
+describe('createLimiter', () => {
+    it('should reject a limit below 1', () => {
+        expect(() => createLimiter(0)).toThrow('maxConcurrent must be at least 1, received 0')
+    })
+
+    it('should never exceed the configured concurrency', async () => {
+        const limit = createLimiter(2)
+        const gates = Array.from({ length: 6 }, () => deferred())
+        let active = 0
+        let maxActive = 0
+
+        const tasks = gates.map((gate) =>
+            limit(async () => {
+                active++
+                maxActive = Math.max(maxActive, active)
+                await gate.promise
+                active--
+            }),
+        )
+
+        await flush()
+        expect(maxActive).toBe(2)
+
+        // Release one at a time; each release admits exactly one queued task.
+        for (const gate of gates) {
+            gate.resolve()
+            await flush()
+            expect(maxActive).toBe(2)
+        }
+
+        await Promise.all(tasks)
+        expect(maxActive).toBe(2)
+    })
+
+    it('should serialise everything at a limit of 1', async () => {
+        const limit = createLimiter(1)
+        const gates = Array.from({ length: 3 }, () => deferred())
+        let active = 0
+        let maxActive = 0
+
+        const tasks = gates.map((gate) =>
+            limit(async () => {
+                active++
+                maxActive = Math.max(maxActive, active)
+                await gate.promise
+                active--
+            }),
+        )
+
+        for (const gate of gates) {
+            await flush()
+            expect(maxActive).toBe(1)
+            gate.resolve()
+        }
+
+        await Promise.all(tasks)
+        expect(maxActive).toBe(1)
+    })
+
+    it('should run queued tasks in FIFO order', async () => {
+        const limit = createLimiter(1)
+        const started: number[] = []
+        const gates = Array.from({ length: 4 }, () => deferred())
+
+        const tasks = gates.map((gate, index) =>
+            limit(async () => {
+                started.push(index)
+                await gate.promise
+            }),
+        )
+
+        for (const gate of gates) {
+            await flush()
+            gate.resolve()
+        }
+        await Promise.all(tasks)
+
+        expect(started).toEqual([0, 1, 2, 3])
+    })
+
+    it('should release the slot when a task rejects', async () => {
+        const limit = createLimiter(1)
+
+        await expect(limit(() => Promise.reject(new Error('boom')))).rejects.toThrow('boom')
+
+        // A leaked slot would leave this pending forever.
+        await expect(limit(() => Promise.resolve('ok'))).resolves.toBe('ok')
+    })
+
+    it('should not admit a late arrival into a slot being handed off', async () => {
+        const limit = createLimiter(1)
+        const first = deferred()
+        const second = deferred()
+        let active = 0
+        let maxActive = 0
+
+        const track = async (gate: Promise<void>) => {
+            active++
+            maxActive = Math.max(maxActive, active)
+            await gate
+            active--
+        }
+
+        const firstTask = limit(() => track(first.promise))
+        const queuedTask = limit(() => track(second.promise))
+
+        await flush()
+        // Resolving the first task hands its slot to the queued task. A task
+        // arriving in that window must not slip past the limit.
+        first.resolve()
+        const lateTask = limit(() => track(Promise.resolve()))
+
+        await flush()
+        expect(maxActive).toBe(1)
+
+        second.resolve()
+        await Promise.all([firstTask, queuedTask, lateTask])
+        expect(maxActive).toBe(1)
+    })
+
+    it('should return the task result', async () => {
+        const limit = createLimiter(1)
+        await expect(limit(() => Promise.resolve(42))).resolves.toBe(42)
+    })
+})
+
+describe('per-account limiters', () => {
+    it('should share limiters across clients registered for the same account', async () => {
+        const clientA = {}
+        const clientB = {}
+        registerClientLimiters(clientA, 'token-1')
+        registerClientLimiters(clientB, 'token-1')
+
+        const first = deferred()
+        let active = 0
+        let maxActive = 0
+        const track = async (gate: Promise<void>) => {
+            active++
+            maxActive = Math.max(maxActive, active)
+            await gate
+            active--
+        }
+
+        const viaA = getMoveLimiter(clientA)(() => track(first.promise))
+        const viaB = getMoveLimiter(clientB)(() => track(Promise.resolve()))
+
+        await flush()
+        expect(maxActive).toBe(ConcurrencyLimits.TASK_MOVES)
+
+        first.resolve()
+        await Promise.all([viaA, viaB])
+    })
+
+    it('should keep separate accounts independent', async () => {
+        const clientA = {}
+        const clientB = {}
+        registerClientLimiters(clientA, 'token-1')
+        registerClientLimiters(clientB, 'token-2')
+
+        const gateA = deferred()
+        let active = 0
+        let maxActive = 0
+        const track = async (gate: Promise<void>) => {
+            active++
+            maxActive = Math.max(maxActive, active)
+            await gate
+            active--
+        }
+
+        const viaA = getMoveLimiter(clientA)(() => track(gateA.promise))
+        const viaB = getMoveLimiter(clientB)(() => track(Promise.resolve()))
+
+        await flush()
+        // Different accounts contend on different trees, so both may run.
+        expect(maxActive).toBe(2)
+
+        gateA.resolve()
+        await Promise.all([viaA, viaB])
+    })
+
+    it('should give moves and writes separate lanes', async () => {
+        const client = {}
+        registerClientLimiters(client, 'token-1')
+
+        const moveGate = deferred()
+        const movePromise = getMoveLimiter(client)(() => moveGate.promise)
+
+        // The move lane is saturated; a write must not be blocked behind it.
+        await expect(getWriteLimiter(client)(() => Promise.resolve('written'))).resolves.toBe(
+            'written',
+        )
+
+        moveGate.resolve()
+        await movePromise
+    })
+
+    it('should fall back to shared limiters for an unregistered client', async () => {
+        const unregistered = {}
+        const alsoUnregistered = {}
+
+        const gate = deferred()
+        let active = 0
+        let maxActive = 0
+        const track = async (waitFor: Promise<void>) => {
+            active++
+            maxActive = Math.max(maxActive, active)
+            await waitFor
+            active--
+        }
+
+        const first = getMoveLimiter(unregistered)(() => track(gate.promise))
+        const second = getMoveLimiter(alsoUnregistered)(() => track(Promise.resolve()))
+
+        await flush()
+        // Both resolve to the same fallback pair, so nothing is left unbounded.
+        expect(maxActive).toBe(ConcurrencyLimits.TASK_MOVES)
+
+        gate.resolve()
+        await Promise.all([first, second])
+    })
+})

--- a/src/utils/concurrency.test.ts
+++ b/src/utils/concurrency.test.ts
@@ -31,8 +31,16 @@ beforeEach(() => {
 })
 
 describe('createLimiter', () => {
-    it('should reject a limit below 1', () => {
-        expect(() => createLimiter(0)).toThrow('maxConcurrent must be at least 1, received 0')
+    it.each([
+        { label: 'zero', value: 0 },
+        { label: 'a negative number', value: -1 },
+        // Each of these would silently defeat the cap: NaN leaves every task queued,
+        // Infinity removes the bound, and a fraction admits an extra task.
+        { label: 'NaN', value: Number.NaN },
+        { label: 'Infinity', value: Number.POSITIVE_INFINITY },
+        { label: 'a fractional limit', value: 1.5 },
+    ])('should reject $label', ({ value }) => {
+        expect(() => createLimiter(value)).toThrow('maxConcurrent must be a positive integer')
     })
 
     it('should never exceed the configured concurrency', async () => {
@@ -153,6 +161,86 @@ describe('createLimiter', () => {
     it('should return the task result', async () => {
         const limit = createLimiter(1)
         await expect(limit(() => Promise.resolve(42))).resolves.toBe(42)
+    })
+
+    describe('queue deadline', () => {
+        it('should abandon a task that waits too long, without sending it', async () => {
+            vi.useFakeTimers()
+            const limit = createLimiter(1, { queueTimeoutMs: 1000 })
+            const holding = deferred()
+            const ran = vi.fn()
+
+            const held = limit(() => holding.promise)
+            const queued = limit(async () => {
+                ran()
+            })
+            const assertion = expect(queued).rejects.toThrow(
+                'Timed out after 1000ms waiting for an earlier request to finish; this request was not sent',
+            )
+
+            await vi.advanceTimersByTimeAsync(1000)
+            await assertion
+            // The point of the deadline: the request is never issued.
+            expect(ran).not.toHaveBeenCalled()
+
+            holding.resolve()
+            await held
+            vi.useRealTimers()
+        })
+
+        it('should not shrink the pool when a queued task is abandoned', async () => {
+            vi.useFakeTimers()
+            const limit = createLimiter(1, { queueTimeoutMs: 1000 })
+            const holding = deferred()
+
+            const held = limit(() => holding.promise)
+            const assertion = expect(limit(() => Promise.resolve('never runs'))).rejects.toThrow(
+                'Timed out',
+            )
+            await vi.advanceTimersByTimeAsync(1000)
+            await assertion
+
+            holding.resolve()
+            await held
+
+            // A slot handed to an abandoned task would never come back, so this hangs
+            // if the timeout left the queue in an inconsistent state.
+            vi.useRealTimers()
+            await expect(limit(() => Promise.resolve('ok'))).resolves.toBe('ok')
+        })
+
+        it('should not abandon a task admitted before its deadline', async () => {
+            vi.useFakeTimers()
+            const limit = createLimiter(1, { queueTimeoutMs: 1000 })
+            const holding = deferred()
+
+            const held = limit(() => holding.promise)
+            const queued = limit(() => Promise.resolve('ran'))
+
+            await vi.advanceTimersByTimeAsync(500)
+            holding.resolve()
+            await held
+            await expect(queued).resolves.toBe('ran')
+
+            // A cleared timer must not fire later and reject an already-settled task.
+            await vi.advanceTimersByTimeAsync(1000)
+            vi.useRealTimers()
+        })
+
+        it('should wait indefinitely when the deadline is disabled', async () => {
+            vi.useFakeTimers()
+            const limit = createLimiter(1, { queueTimeoutMs: 0 })
+            const holding = deferred()
+
+            const held = limit(() => holding.promise)
+            const queued = limit(() => Promise.resolve('ran'))
+
+            await vi.advanceTimersByTimeAsync(60_000)
+            holding.resolve()
+            await held
+            await expect(queued).resolves.toBe('ran')
+            vi.useRealTimers()
+        })
     })
 })
 

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,136 @@
+import { createHash } from 'node:crypto'
+import { ConcurrencyLimits } from './constants.js'
+
+/**
+ * Wraps a task so it only runs once a slot is free.
+ */
+type Limiter = <T>(fn: () => Promise<T>) => Promise<T>
+
+type LimiterPair = {
+    /** Serialises task-move requests, which contend on server-side tree locks. */
+    moves: Limiter
+    /** Bounds all other write requests. */
+    writes: Limiter
+}
+
+/**
+ * A FIFO semaphore. Tasks beyond `maxConcurrent` queue and start as slots free up.
+ *
+ * Deliberately applied at the tool layer rather than inside the SDK's
+ * `customFetch`: the SDK installs its request-timeout `AbortSignal` *before*
+ * calling `customFetch`, so gating there would charge queue time against the
+ * request timeout and fail long-queued requests that never actually ran.
+ */
+function createLimiter(maxConcurrent: number): Limiter {
+    if (maxConcurrent < 1) {
+        throw new Error(`maxConcurrent must be at least 1, received ${maxConcurrent}`)
+    }
+
+    const queue: Array<() => void> = []
+    let active = 0
+
+    async function acquire(): Promise<void> {
+        if (active < maxConcurrent) {
+            active++
+            return
+        }
+        // A queued task inherits the releasing task's slot, so `active` stays put.
+        await new Promise<void>((resolve) => queue.push(resolve))
+    }
+
+    function release() {
+        const next = queue.shift()
+        if (next) {
+            next()
+            return
+        }
+        active--
+    }
+
+    return async function limit<T>(fn: () => Promise<T>): Promise<T> {
+        await acquire()
+        try {
+            return await fn()
+        } finally {
+            // Release in `finally` so a rejected task never leaks its slot.
+            release()
+        }
+    }
+}
+
+function createLimiterPair(): LimiterPair {
+    return {
+        moves: createLimiter(ConcurrencyLimits.TASK_MOVES),
+        writes: createLimiter(ConcurrencyLimits.WRITES),
+    }
+}
+
+/**
+ * Limiters are keyed by account rather than by client instance because the HTTP
+ * transport builds a fresh `TodoistApi` for every request — instance-keyed
+ * limiters would let concurrent requests for one account fan out without bound.
+ */
+const limitersByAccount = new Map<string, LimiterPair>()
+
+/** Lets a tool find its account's limiters from the client it was handed. */
+const limitersByClient = new WeakMap<object, LimiterPair>()
+
+/**
+ * Catches clients built outside `createTodoistClient` (tests, direct SDK use) so
+ * every call site is bounded even when nothing registered it.
+ */
+let fallbackLimiters: LimiterPair | undefined
+
+function getFallbackLimiters(): LimiterPair {
+    fallbackLimiters ??= createLimiterPair()
+    return fallbackLimiters
+}
+
+/**
+ * Derives a stable per-account key. The raw token is never stored — only its
+ * digest — so limiter bookkeeping can't leak credentials.
+ */
+function accountKeyFromApiKey(apiKey: string): string {
+    return createHash('sha256').update(apiKey).digest('hex')
+}
+
+/**
+ * Associates a client with its account's limiters, sharing one pair across every
+ * client built for the same account.
+ */
+function registerClientLimiters(client: object, apiKey: string): void {
+    const key = accountKeyFromApiKey(apiKey)
+    let limiters = limitersByAccount.get(key)
+    if (!limiters) {
+        limiters = createLimiterPair()
+        limitersByAccount.set(key, limiters)
+    }
+    limitersByClient.set(client, limiters)
+}
+
+function getLimiters(client: object): LimiterPair {
+    return limitersByClient.get(client) ?? getFallbackLimiters()
+}
+
+function getMoveLimiter(client: object): Limiter {
+    return getLimiters(client).moves
+}
+
+function getWriteLimiter(client: object): Limiter {
+    return getLimiters(client).writes
+}
+
+/** Test-only: drops all registered limiters so cases start from a clean slate. */
+function resetLimitersForTesting(): void {
+    limitersByAccount.clear()
+    fallbackLimiters = undefined
+}
+
+export {
+    createLimiter,
+    getMoveLimiter,
+    getWriteLimiter,
+    type Limiter,
+    registerClientLimiters,
+    resetLimitersForTesting,
+}

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -13,6 +13,12 @@ type LimiterPair = {
     writes: Limiter
 }
 
+type QueuedTask = {
+    admit: () => void
+    abandon: (reason: Error) => void
+    timer?: NodeJS.Timeout
+}
+
 /**
  * A FIFO semaphore. Tasks beyond `maxConcurrent` queue and start as slots free up.
  *
@@ -20,13 +26,24 @@ type LimiterPair = {
  * `customFetch`: the SDK installs its request-timeout `AbortSignal` *before*
  * calling `customFetch`, so gating there would charge queue time against the
  * request timeout and fail long-queued requests that never actually ran.
+ *
+ * That same property is why queued tasks need their own deadline. A task's request
+ * timeout only starts once it reaches the front of the queue, so without one a task
+ * can wait indefinitely — long past the point its caller gave up — and then still
+ * issue its request. `queueTimeoutMs` bounds the wait instead, failing the task with
+ * a reason that says the request was never sent.
  */
-function createLimiter(maxConcurrent: number): Limiter {
-    if (maxConcurrent < 1) {
-        throw new Error(`maxConcurrent must be at least 1, received ${maxConcurrent}`)
+function createLimiter(
+    maxConcurrent: number,
+    { queueTimeoutMs = ConcurrencyLimits.QUEUE_WAIT_MS }: { queueTimeoutMs?: number } = {},
+): Limiter {
+    if (!Number.isInteger(maxConcurrent) || maxConcurrent < 1) {
+        throw new Error(
+            `maxConcurrent must be a positive integer, received ${String(maxConcurrent)}`,
+        )
     }
 
-    const queue: Array<() => void> = []
+    const queue: QueuedTask[] = []
     let active = 0
 
     async function acquire(): Promise<void> {
@@ -34,14 +51,39 @@ function createLimiter(maxConcurrent: number): Limiter {
             active++
             return
         }
+
         // A queued task inherits the releasing task's slot, so `active` stays put.
-        await new Promise<void>((resolve) => queue.push(resolve))
+        await new Promise<void>((resolve, reject) => {
+            const queued: QueuedTask = { admit: resolve, abandon: reject }
+            queue.push(queued)
+
+            if (queueTimeoutMs <= 0) {
+                return
+            }
+
+            queued.timer = setTimeout(() => {
+                // Drop it from the queue first: a slot handed to an abandoned task
+                // would never be released, shrinking the pool for good.
+                const position = queue.indexOf(queued)
+                if (position !== -1) {
+                    queue.splice(position, 1)
+                }
+                queued.abandon(
+                    new Error(
+                        `Timed out after ${queueTimeoutMs}ms waiting for an earlier request to finish; this request was not sent`,
+                    ),
+                )
+            }, queueTimeoutMs)
+            // Never keep the process alive purely to time out a queued task.
+            queued.timer.unref?.()
+        })
     }
 
     function release() {
         const next = queue.shift()
         if (next) {
-            next()
+            clearTimeout(next.timer)
+            next.admit()
             return
         }
         active--

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -71,6 +71,15 @@ export const ConcurrencyLimits = {
     TASK_MOVES: 1,
     /** In-flight non-move write requests per account. */
     WRITES: 4,
+    /**
+     * How long a request may wait for a slot before it is abandoned unsent.
+     *
+     * Matches the SDK's own 30s request timeout, which only starts once a request
+     * actually goes out: a task that has already waited that long would be
+     * answering a caller who has given up. Comfortably above the worst realistic
+     * queue (serialised moves to 100 distinct destinations is roughly 15s).
+     */
+    QUEUE_WAIT_MS: 30_000,
 } as const
 
 // Response Builder Configuration

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -57,6 +57,22 @@ export const BatchLimits = {
     TASKS_PER_OPERATION: 25,
 } as const
 
+// Concurrency Limits
+export const ConcurrencyLimits = {
+    /**
+     * In-flight task-move requests per account.
+     *
+     * Kept at 1 because the API locks the whole task tree for a move, and a tree
+     * spans a task's source as well as its destination — two moves of sibling
+     * subtasks contend even when they target different projects, and the loser
+     * fails. Batching same-destination moves into a single request means
+     * serialising costs little in practice.
+     */
+    TASK_MOVES: 1,
+    /** In-flight non-move write requests per account. */
+    WRITES: 4,
+} as const
+
 // Response Builder Configuration
 export const ResponseConfig = {
     /** Maximum characters per line in text responses */


### PR DESCRIPTION
## Context

[Janusz flagged on Comms](https://comms.todoist.com/69/ch/AK6drPS98yMaYmyWmztS2/t/CdffD1JCLJMYmWYSf3Fi2) that `todoist-mcp` submits large numbers of concurrent `POST /api/v1/tasks/<id>/move` requests — one case moved 88 tasks at once — and that by volume almost all failing moves platform-wide come from us. Backend locking is being fixed such that concurrent moves within the same task tree will fail with 503 + Retry-After, so unbounded fan-out stops being merely rude and starts being the failure.

`update-tasks` fired every task in a batch through `Promise.allSettled` with no limiter, and the 25-item cap is enforced *per call*, so an agent making four parallel calls reached 100 in-flight writes with nothing to stop it. There was no concurrency limiter anywhere in the repo.

Second of three PRs from that thread. Stacked on #546. No semantic change to what a call does — only to how many requests it has open at once.

## What changed

New `src/utils/concurrency.ts`: a FIFO semaphore with two lanes, applied in `update-tasks` around the move calls and the `updateTask` fan-out.

**Limiters are keyed by account, not by client instance.** `src/http-app.ts` calls `getMcpServer()` per request, so parallel `POST /mcp` calls get distinct `TodoistApi` instances — an instance-keyed `WeakMap` would have bounded nothing in the deployment that matters. Registration happens in `createTodoistClient`, keyed on a SHA-256 of the token so no credential is retained. Clients built outside that factory (tests, direct SDK use) fall back to a shared pair, so no call site is ever unbounded.

`ConcurrencyLimits.TASK_MOVES` is **1**. The lock covers the whole task tree, and a tree spans a task's source as well as its destination — two sibling subtasks moved to different projects still contend, and the loser fails. Grouping by destination (PR 3) doesn't help with that, and since that PR collapses the common case to a single request anyway, serialising costs little. Accepted worst case: 4 concurrent calls × 25 distinct destinations ≈ 100 serialised requests ≈ 15s, which is pathological rather than realistic. `WRITES` is 4.

**Why the tool layer and not `customFetch`:** gating inside the transport would catch every call site automatically, but the SDK installs its 30s timeout `AbortSignal` *before* invoking `customFetch`, so queue time would be charged against the request timeout and long-queued requests would fail without ever running. The reasoning is recorded in the module JSDoc so nobody moves it later.

## Testing

New `src/utils/concurrency.test.ts` covers the semaphore directly: the cap holds under load, FIFO order is preserved, a rejecting task releases its slot, and — the subtle one — a task arriving in the window where a slot is being handed off to a queued task cannot slip past the limit. Plus per-account sharing, account isolation, separate move/write lanes, and the unregistered-client fallback.

`update-tasks.test.ts` gains in-flight assertions driven by deferred promises: 4 tasks to 4 destinations peak at 1 concurrent move, 10 content-only updates peak at `ConcurrencyLimits.WRITES`.

`npm test` (1062 tests), `npm run type-check`, `npm run check` all pass.

## Follow-up, not in this PR

The write lane should also go on `manage-assignments`, `add-tasks`, `update-projects`, `update-sections`, `add-comments` and `reschedule-tasks`, all of which fan out unbounded today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)