### PR TITLE
feat(move-planner): decide when a requested container change is a real move

### DIFF
--- a/src/utils/move-planner.test.ts
+++ b/src/utils/move-planner.test.ts
@@ -1,0 +1,200 @@
+import { destinationKey, isMoveRedundant, planMove } from './move-planner.js'
+import { createMockTask } from './test-helpers.js'
+
+const PROJECT = 'project-1'
+const SECTION = 'section-1'
+const PARENT = 'parent-1'
+
+describe('isMoveRedundant', () => {
+    describe('a project destination', () => {
+        it('is redundant when the task already sits at the project root', () => {
+            const task = createMockTask({ projectId: PROJECT, sectionId: null, parentId: null })
+            expect(isMoveRedundant(task, { projectId: PROJECT })).toBe(true)
+        })
+
+        it('is not redundant for a different project', () => {
+            const task = createMockTask({ projectId: 'other', sectionId: null, parentId: null })
+            expect(isMoveRedundant(task, { projectId: PROJECT })).toBe(false)
+        })
+
+        it('is not redundant when the task is in a section, since the move lifts it out', () => {
+            const task = createMockTask({ projectId: PROJECT, sectionId: SECTION, parentId: null })
+            expect(isMoveRedundant(task, { projectId: PROJECT })).toBe(false)
+        })
+
+        it('is not redundant when the task has a parent, since the move lifts it out', () => {
+            const task = createMockTask({ projectId: PROJECT, sectionId: null, parentId: PARENT })
+            expect(isMoveRedundant(task, { projectId: PROJECT })).toBe(false)
+        })
+    })
+
+    describe('a section destination', () => {
+        it('is redundant when the task already sits directly in that section', () => {
+            const task = createMockTask({ sectionId: SECTION, parentId: null })
+            expect(isMoveRedundant(task, { sectionId: SECTION })).toBe(true)
+        })
+
+        it('is not redundant for a different section', () => {
+            const task = createMockTask({ sectionId: 'other', parentId: null })
+            expect(isMoveRedundant(task, { sectionId: SECTION })).toBe(false)
+        })
+
+        it('is not redundant when the task has no section', () => {
+            const task = createMockTask({ sectionId: null, parentId: null })
+            expect(isMoveRedundant(task, { sectionId: SECTION })).toBe(false)
+        })
+
+        it('is not redundant when the task has a parent, since the move lifts it out', () => {
+            const task = createMockTask({ sectionId: SECTION, parentId: PARENT })
+            expect(isMoveRedundant(task, { sectionId: SECTION })).toBe(false)
+        })
+    })
+
+    describe('a parent destination', () => {
+        it('is redundant when the task is already that parent’s subtask', () => {
+            const task = createMockTask({ parentId: PARENT })
+            expect(isMoveRedundant(task, { parentId: PARENT })).toBe(true)
+        })
+
+        it('is not redundant for a different parent', () => {
+            const task = createMockTask({ parentId: 'other' })
+            expect(isMoveRedundant(task, { parentId: PARENT })).toBe(false)
+        })
+
+        it('is not redundant when the task has no parent', () => {
+            const task = createMockTask({ parentId: null })
+            expect(isMoveRedundant(task, { parentId: PARENT })).toBe(false)
+        })
+
+        it('ignores section and project, which a parent move determines anyway', () => {
+            const task = createMockTask({
+                projectId: 'elsewhere',
+                sectionId: SECTION,
+                parentId: PARENT,
+            })
+            expect(isMoveRedundant(task, { parentId: PARENT })).toBe(true)
+        })
+    })
+})
+
+describe('destinationKey', () => {
+    it('distinguishes the destination kinds', () => {
+        expect(destinationKey({ projectId: 'x' })).not.toBe(destinationKey({ sectionId: 'x' }))
+        expect(destinationKey({ sectionId: 'x' })).not.toBe(destinationKey({ parentId: 'x' }))
+    })
+
+    it('matches for the same destination', () => {
+        expect(destinationKey({ projectId: 'x' })).toBe(destinationKey({ projectId: 'x' }))
+    })
+
+    it('differs for different destinations of the same kind', () => {
+        expect(destinationKey({ projectId: 'x' })).not.toBe(destinationKey({ projectId: 'y' }))
+    })
+})
+
+describe('planMove', () => {
+    const atProjectRoot = createMockTask({
+        projectId: PROJECT,
+        sectionId: null,
+        parentId: null,
+    })
+
+    it('plans no move when no container was requested', () => {
+        expect(planMove({ taskId: 't', request: {}, current: atProjectRoot })).toEqual({
+            redundantMoveSkipped: false,
+        })
+    })
+
+    it('plans the requested move when the task is somewhere else', () => {
+        expect(
+            planMove({ taskId: 't', request: { projectId: 'elsewhere' }, current: atProjectRoot }),
+        ).toEqual({ move: { projectId: 'elsewhere' }, redundantMoveSkipped: false })
+    })
+
+    it('plans no move when the task is already in the requested project', () => {
+        expect(
+            planMove({ taskId: 't', request: { projectId: PROJECT }, current: atProjectRoot }),
+        ).toEqual({ redundantMoveSkipped: true })
+    })
+
+    it('moves anyway when the current state is unknown', () => {
+        expect(
+            planMove({ taskId: 't', request: { projectId: PROJECT }, current: undefined }),
+        ).toEqual({ move: { projectId: PROJECT }, redundantMoveSkipped: false })
+    })
+
+    it('resolves an echoed project alongside a real section change to the section move', () => {
+        expect(
+            planMove({
+                taskId: 't',
+                request: { projectId: PROJECT, sectionId: SECTION },
+                current: atProjectRoot,
+            }),
+        ).toEqual({ move: { sectionId: SECTION }, redundantMoveSkipped: true })
+    })
+
+    it('plans no move when a full echo names the project and section the task is in', () => {
+        const inSection = createMockTask({ projectId: PROJECT, sectionId: SECTION, parentId: null })
+        expect(
+            planMove({
+                taskId: 't',
+                request: { projectId: PROJECT, sectionId: SECTION },
+                current: inSection,
+            }),
+        ).toEqual({ redundantMoveSkipped: true })
+    })
+
+    it('plans no move when a full echo names the section and parent the task is under', () => {
+        const subtask = createMockTask({
+            projectId: PROJECT,
+            sectionId: SECTION,
+            parentId: PARENT,
+        })
+        expect(
+            planMove({
+                taskId: 't',
+                request: { projectId: PROJECT, sectionId: SECTION, parentId: PARENT },
+                current: subtask,
+            }),
+        ).toEqual({ redundantMoveSkipped: true })
+    })
+
+    it('moves a task out of its section when only the project is named', () => {
+        const inSection = createMockTask({ projectId: PROJECT, sectionId: SECTION, parentId: null })
+        expect(
+            planMove({ taskId: 't', request: { projectId: PROJECT }, current: inSection }),
+        ).toEqual({ move: { projectId: PROJECT }, redundantMoveSkipped: false })
+    })
+
+    it('takes the real destination when an echoed project accompanies a new parent', () => {
+        expect(
+            planMove({
+                taskId: 't',
+                request: { projectId: PROJECT, parentId: PARENT },
+                current: atProjectRoot,
+            }),
+        ).toEqual({ move: { parentId: PARENT }, redundantMoveSkipped: true })
+    })
+
+    it('rejects a request with more than one real destination', () => {
+        expect(() =>
+            planMove({
+                taskId: 'task-9',
+                request: { projectId: 'elsewhere', parentId: PARENT },
+                current: atProjectRoot,
+            }),
+        ).toThrow(
+            'Task task-9: Only one of projectId, sectionId, or parentId can be specified at a time',
+        )
+    })
+
+    it('rejects an ambiguous request when the current state is unknown', () => {
+        expect(() =>
+            planMove({
+                taskId: 'task-9',
+                request: { projectId: PROJECT, sectionId: SECTION },
+                current: undefined,
+            }),
+        ).toThrow('Only one of projectId, sectionId, or parentId can be specified at a time')
+    })
+})

--- a/src/utils/move-planner.ts
+++ b/src/utils/move-planner.ts
@@ -1,0 +1,154 @@
+import type { MoveTaskArgs, Task } from '@doist/todoist-sdk'
+
+/** The container fields a caller can send to relocate a task. */
+type MoveRequest = {
+    projectId?: string | undefined
+    sectionId?: string | undefined
+    parentId?: string | undefined
+}
+
+type MovePlan = {
+    /** The move to perform, or undefined when the task is already where it was asked to go. */
+    move?: MoveTaskArgs
+    /** True when a requested destination was dropped as already-satisfied. */
+    redundantMoveSkipped: boolean
+}
+
+/**
+ * Whether moving `current` to `destination` would leave the task exactly where it
+ * already is, making the request a pointless write.
+ *
+ * Matching the destination field alone is not enough. Moving a task to a project
+ * also lifts it out of its section and out from under its parent, and moving it
+ * to a section lifts it out from under its parent — so a task that matches on
+ * `projectId` but sits in a section is *not* already in the requested end state.
+ *
+ * The extra conditions therefore make this predicate conservative on purpose: it
+ * only reports "redundant" when the task already looks the way the move would
+ * leave it under those detaching semantics. If the API turned out not to detach,
+ * the cost is a move we could have skipped, never a move we wrongly skipped.
+ */
+function isMoveRedundant(current: Task, destination: MoveTaskArgs): boolean {
+    if (destination.projectId !== undefined) {
+        return (
+            current.projectId === destination.projectId && !current.sectionId && !current.parentId
+        )
+    }
+
+    if (destination.sectionId !== undefined) {
+        return current.sectionId === destination.sectionId && !current.parentId
+    }
+
+    return current.parentId === destination.parentId
+}
+
+/**
+ * Whether the task's own container field already names `destination`, ignoring
+ * what a move would do to its other containers.
+ *
+ * This is the right question only when a caller names several containers at once:
+ * a task described as being in both a project and a section it is already in has
+ * nothing to move, and the section says the project was descriptive rather than a
+ * request to leave the section. On its own, a container is a statement about the
+ * task's whole position, which is what `isMoveRedundant` checks.
+ */
+function matchesCurrentContainer(current: Task, destination: MoveTaskArgs): boolean {
+    if (destination.projectId !== undefined) {
+        return current.projectId === destination.projectId
+    }
+    if (destination.sectionId !== undefined) {
+        return current.sectionId === destination.sectionId
+    }
+    return current.parentId === destination.parentId
+}
+
+/**
+ * Identifies a move destination, so tasks heading to the same place can be
+ * collapsed into one request.
+ */
+function destinationKey(move: MoveTaskArgs): string {
+    if (move.projectId !== undefined) {
+        return `project:${move.projectId}`
+    }
+    if (move.sectionId !== undefined) {
+        return `section:${move.sectionId}`
+    }
+    return `parent:${move.parentId}`
+}
+
+function toDestinations(request: MoveRequest): MoveTaskArgs[] {
+    const destinations: MoveTaskArgs[] = []
+    if (request.projectId) {
+        destinations.push({ projectId: request.projectId })
+    }
+    if (request.sectionId) {
+        destinations.push({ sectionId: request.sectionId })
+    }
+    if (request.parentId) {
+        destinations.push({ parentId: request.parentId })
+    }
+    return destinations
+}
+
+/**
+ * Works out what move, if any, a requested update actually needs.
+ *
+ * Callers commonly echo a task's whole current shape back when they only meant to
+ * edit a field, which would otherwise be read as a relocation. Dropping the
+ * containers the task already satisfies means those calls perform no move at all —
+ * and a request that names several containers, all but one of them unchanged,
+ * resolves to the single real move instead of being rejected as ambiguous.
+ *
+ * A single container is judged on the whole position it describes, so asking for a
+ * task's current project still moves it when that would lift it out of a section.
+ * Several containers are judged field by field, so a task described as already
+ * being in its project *and* its section is left alone rather than pulled out of
+ * that section.
+ *
+ * @param taskId - Used only to describe the task in error messages.
+ * @param request - The container fields as supplied by the caller.
+ * @param current - The task's current state, or undefined when it could not be
+ *   read. Unknown state means every requested move is performed, matching the
+ *   behaviour of not checking at all.
+ * @throws If more than one genuine destination remains, since the API accepts
+ *   exactly one.
+ */
+function planMove({
+    taskId,
+    request,
+    current,
+}: {
+    taskId: string
+    request: MoveRequest
+    current: Task | undefined
+}): MovePlan {
+    const requested = toDestinations(request)
+    if (requested.length === 0) {
+        return { redundantMoveSkipped: false }
+    }
+
+    let effective = requested
+    let redundantMoveSkipped = false
+    if (current) {
+        const isSatisfied =
+            requested.length === 1
+                ? (destination: MoveTaskArgs) => isMoveRedundant(current, destination)
+                : (destination: MoveTaskArgs) => matchesCurrentContainer(current, destination)
+        effective = requested.filter((destination) => !isSatisfied(destination))
+        redundantMoveSkipped = effective.length < requested.length
+    }
+
+    if (effective.length === 0) {
+        return { redundantMoveSkipped }
+    }
+
+    if (effective.length > 1) {
+        throw new Error(
+            `Task ${taskId}: Only one of projectId, sectionId, or parentId can be specified at a time. The Todoist API requires exactly one destination for move operations.`,
+        )
+    }
+
+    return { move: effective[0], redundantMoveSkipped }
+}
+
+export { destinationKey, isMoveRedundant, type MovePlan, type MoveRequest, planMove }


### PR DESCRIPTION
## Context

Split out of #548 to keep that PR reviewable. This is the decision logic on its own — pure functions, no API involved, no callers yet. The wiring into `update-tasks` is #548, which is stacked on this branch.

[Janusz reported on Comms](https://comms.todoist.com/69/ch/AK6drPS98yMaYmyWmztS2/t/CdffD1JCLJMYmWYSf3Fi2) that by volume almost all failing task moves the API sees come from `todoist-mcp`. The cause is that `update-tasks` only checks whether a container field is *present*, so a caller echoing back a task's existing `projectId` alongside a field edit gets a real move write. Telling those apart needs the task's current state plus a rule about what a move actually does to a task's position — and that rule doesn't belong tangled up in the tool's request handling.

## What this adds

- **`isMoveRedundant(current, destination)`** — whether moving the task would leave it exactly where it already is. Matching the destination field alone isn't sufficient: moving a task to a project also lifts it out of its section and out from under its parent, and moving it to a section lifts it out from under its parent. So a task whose `projectId` matches but which sits in a section is *not* already in the requested end state.
- **`planMove({ taskId, request, current })`** — reduces the containers a caller sent to the single move actually needed, or none. Throws the existing "only one of projectId, sectionId, or parentId" error if more than one *genuine* destination remains.
- **`destinationKey(move)`** — identifies a destination so tasks heading to the same place can be collapsed into one request later.

## The rule worth reviewing

`planMove` is deliberately asymmetric:

- **One container** → judged on the whole position it describes. Asking for a task's current project still moves it, because that would lift it out of its section, which is a real change the caller may well want.
- **Several containers** → judged field by field. A task described as already being in its project *and* its section is left alone rather than pulled out of that section.

My first version applied the single-container rule uniformly, which would have silently detached tasks from their sections whenever a caller echoed a whole task object. The asymmetry is what prevents that.

It also turns a pure-loss case into a working one: `{ projectId: <current>, sectionId: <current> }` previously failed outright as "only one of…", so a full echo was a guaranteed failed call. Some of the error volume Janusz is seeing is likely exactly this.

## Residual uncertainty

The detaching behaviour these rules assume is not verifiable from this repo — the SDK just forwards `project_id`. The predicate is therefore conservative: it only reports "redundant" when the task already looks the way the move would leave it under the detaching reading. If the API turned out *not* to detach, we merely under-skip; we never wrongly skip. That reasoning is in the JSDoc so it doesn't get "simplified" later. A definitive answer from the API side would let us relax the extra conditions and skip more.

## Testing

`move-planner.test.ts` covers the redundancy matrix — three destination kinds × section/parent present or absent — plus the multi-container reduction, the full-echo cases, the ≥2-real-destinations throw, and unknown current state always moving. 26 tests.

`npm test` (1050), `npm run type-check`, `npm run check` all pass.

## Note for review

Nothing imports these functions on this branch, so they are unused until #548 lands. That is the cost of splitting; the alternative was one ~1400-line PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)