### PR TITLE
test(request-profile): assert how many requests a batch makes

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -143,6 +143,7 @@ New tool? Full checklist in `AGENTS.md`. Short version: copy `add-tasks.ts`; imp
 - `sanitize-data.ts` — HTML sanitization (dompurify) for comment content
 - `validate-todoist-token.ts` — token validation for HTTP middleware
 - `test-helpers.ts` — `createMockTask`, `createMockProject`, `createMockSection`, `TEST_IDS`, `TODAY`
+- `request-profile.ts` — test-only. `createProfilingClient` returns a mock client plus a profile of the requests a tool made (count and peak concurrency per method); `expectRequestProfile` asserts the whole profile, so an unexpected request fails the test. Use it for any batch tool: it is what catches a read that scales with batch size, or writes fanning out concurrently
 
 ## Todoist SDK + auth
 
@@ -157,6 +158,7 @@ New tool? Full checklist in `AGENTS.md`. Short version: copy `add-tasks.ts`; imp
 - **Runner:** `vitest` with globals. `npm test` / `npm run test:watch` / `npm run test:coverage`.
 - **Location:** co-located at `src/tools/<tool>.test.ts`; utility tests alongside (`src/utils/retry.test.ts`, etc.).
 - **Mocks:** `vi.fn()` against `TodoistApi` methods. Use factories from `src/utils/test-helpers.ts` — do NOT hand-build mock entities.
+- **Batch tools:** assert the request profile, not just the result. `createProfilingClient` / `expectRequestProfile` (`src/utils/request-profile.ts`) pin how many requests a batch of N makes and how many run at once. Checking only the return value leaves request volume unverified, which is how a per-task lookup inside a batch survived here unnoticed.
 - **Coverage:** 333+ tests currently. All must pass before commit.
 
 ## Build & release

--- a/src/tools/add-tasks.test.ts
+++ b/src/tools/add-tasks.test.ts
@@ -2,6 +2,7 @@ import type { Task, TodoistApi } from '@doist/todoist-sdk'
 import { type Mocked, vi } from 'vitest'
 import { assignmentValidator } from '../utils/assignment-validator.js'
 import { convertPriorityToNumber } from '../utils/priorities.js'
+import { createProfilingClient, expectRequestProfile } from '../utils/request-profile.js'
 import {
     createMockProject,
     createMockSection,
@@ -1167,6 +1168,57 @@ describe(`${ADD_TASKS} tool`, () => {
     describe('batch limits', () => {
         it('should export MAX_TASKS_PER_OPERATION constant', () => {
             expect(MAX_TASKS_PER_OPERATION).toBe(25)
+        })
+    })
+
+    describe('request profile', () => {
+        const batch = (count: number, projectId?: string) =>
+            Array.from({ length: count }, (_, index) => ({
+                content: `task-${index}`,
+                ...(projectId ? { projectId } : {}),
+            }))
+
+        function profiling() {
+            return createProfilingClient({
+                getProject: (id: string) => createMockProject({ id }),
+                addTask: (args: { content: string }) => createMockTask({ content: args.content }),
+            })
+        }
+
+        it('checks a shared destination project once, not once per task', async () => {
+            const { client, profile } = profiling()
+
+            await addTasks.execute({ tasks: batch(25, 'project-1') }, client)
+
+            // The archived-project check used to run per task, so a batch bound for one
+            // project made 25 identical reads.
+            expectRequestProfile(profile, {
+                getProject: { count: 1, peak: 1 },
+                addTask: { count: 25, peak: 1 },
+            })
+        })
+
+        it('checks each distinct project once', async () => {
+            const { client, profile } = profiling()
+
+            await addTasks.execute(
+                {
+                    tasks: [...batch(3, 'project-1'), ...batch(3, 'project-2')],
+                },
+                client,
+            )
+
+            expect(profile.count('getProject')).toBe(2)
+        })
+
+        it('reads nothing when no project is named', async () => {
+            const { client, profile } = profiling()
+
+            await addTasks.execute({ tasks: batch(5) }, client)
+
+            // Sequential rather than concurrent: they share a destination, and creating
+            // siblings in order is what preserves the order the caller asked for.
+            expectRequestProfile(profile, { addTask: { count: 5, peak: 1 } })
         })
     })
 })

--- a/src/tools/add-tasks.ts
+++ b/src/tools/add-tasks.ts
@@ -2,7 +2,7 @@ import type { AddTaskArgs, Task, TodoistApi } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
 import { formatBatchItemError } from '../tool-execution-error.js'
-import { isInboxProjectId, mapTask } from '../tool-helpers.js'
+import { isInboxProjectId, mapTask, type Project } from '../tool-helpers.js'
 import { assignmentValidator } from '../utils/assignment-validator.js'
 import { BatchLimits } from '../utils/constants.js'
 import { DurationParseError, parseDuration } from '../utils/duration-parser.js'
@@ -101,6 +101,9 @@ const addTasks = {
 
         // Resolve each section's project at most once across the whole batch
         const sectionProjectCache = new Map<string, string>()
+        // Same for the archived check: a batch bound for one project asked the same
+        // question once per task, which is 25 identical reads at the batch cap.
+        const projectCache = new Map<string, Promise<Project>>()
 
         // Process groups in parallel; within each group, process sequentially
         type IndexedResult = { index: number; result: PromiseSettledResult<Task> }
@@ -109,7 +112,10 @@ const addTasks = {
                 const results: IndexedResult[] = []
                 for (const { task, index } of group) {
                     try {
-                        const created = await processTask(task, client, sectionProjectCache)
+                        const created = await processTask(task, client, {
+                            sectionProjectCache,
+                            projectCache,
+                        })
                         results.push({ index, result: { status: 'fulfilled', value: created } })
                     } catch (error) {
                         results.push({
@@ -181,8 +187,12 @@ function destinationKey(task: z.infer<typeof TaskSchema>): string {
 async function processTask(
     task: z.infer<typeof TaskSchema>,
     client: TodoistApi,
-    sectionProjectCache: Map<string, string>,
+    caches: {
+        sectionProjectCache: Map<string, string>
+        projectCache: Map<string, Promise<Project>>
+    },
 ): Promise<Task> {
+    const { sectionProjectCache, projectCache } = caches
     const {
         duration: durationStr,
         projectId,
@@ -201,7 +211,14 @@ async function processTask(
 
     // Validate project is not archived
     if (resolvedProjectId) {
-        const project = await client.getProject(resolvedProjectId)
+        // Cached as the promise, not the result, so tasks racing for the same project
+        // share one request rather than each starting their own.
+        let pending = projectCache.get(resolvedProjectId)
+        if (!pending) {
+            pending = client.getProject(resolvedProjectId)
+            projectCache.set(resolvedProjectId, pending)
+        }
+        const project = await pending
         if (project.isArchived) {
             throw new Error(
                 `Task "${task.content}": Cannot create task in archived project "${project.name}"`,

--- a/src/tools/reschedule-tasks.test.ts
+++ b/src/tools/reschedule-tasks.test.ts
@@ -1,5 +1,6 @@
 import type { TodoistApi } from '@doist/todoist-sdk'
 import { type Mocked, vi } from 'vitest'
+import { createProfilingClient } from '../utils/request-profile.js'
 import { createMockTask } from '../utils/test-helpers.js'
 import { ToolNames } from '../utils/tool-names.js'
 import { buildRescheduleDate, rescheduleTasks } from './reschedule-tasks.js'
@@ -358,5 +359,48 @@ describe('buildRescheduleDate', () => {
             isRecurring: true,
         })
         expect(result).toBe('2026-03-20T14:00:00')
+    })
+})
+
+describe('request profile', () => {
+    /** Reschedule needs an existing due date, so every task gets one. */
+    const withDueDate = (id: string) =>
+        createMockTask({
+            id,
+            due: {
+                date: '2026-08-01',
+                isRecurring: false,
+                lang: 'en',
+                string: 'Aug 1',
+                timezone: null,
+            },
+        })
+
+    it('batches the writes but reads each task separately', async () => {
+        const { client, profile } = createProfilingClient({
+            getTask: withDueDate,
+            sync: () => ({ syncToken: 'x', items: [] }),
+        })
+
+        await rescheduleTasks.execute(
+            {
+                tasks: Array.from({ length: 10 }, (_, index) => ({
+                    id: `task-${index}`,
+                    date: '2026-09-01',
+                })),
+            },
+            client,
+        )
+
+        // The writes are already collapsed into a single sync request.
+        expect(profile.count('sync')).toBe(1)
+
+        // The reads are not, and this records the current cost rather than endorsing it:
+        // two reads per task, all in flight at once. `getTasks({ ids })` would make this
+        // one request. Left as is here because switching reads is a change in its own
+        // right, and it needs the comma-separated `ids` workaround; this assertion is
+        // what will fail — deliberately — when that lands.
+        expect(profile.count('getTask')).toBe(20)
+        expect(profile.peak('getTask')).toBe(10)
     })
 })

--- a/src/tools/update-tasks.test.ts
+++ b/src/tools/update-tasks.test.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { resetLimitersForTesting } from '../utils/concurrency.js'
 import { ConcurrencyLimits } from '../utils/constants.js'
 import { convertPriorityToNumber } from '../utils/priorities.js'
+import { createProfilingClient, expectRequestProfile } from '../utils/request-profile.js'
 import { createMockTask, createMockUser, TEST_IDS } from '../utils/test-helpers.js'
 import { ToolNames } from '../utils/tool-names.js'
 import { updateTasks } from './update-tasks.js'
@@ -2158,6 +2159,101 @@ describe(`${UPDATE_TASKS} tool`, () => {
 
             expect(mockTodoistApi.updateTask).toHaveBeenCalledTimes(10)
             expect(tracker.state.max).toBe(ConcurrencyLimits.WRITES)
+        })
+    })
+
+    describe('request profile', () => {
+        const manyTasks = (count: number, extra: (index: number) => object = () => ({})) =>
+            Array.from({ length: count }, (_, index) => ({ id: `task-${index}`, ...extra(index) }))
+
+        function profiling() {
+            return createProfilingClient({
+                getUser: () => createMockUser(),
+                getTasks: () => ({ results: [], nextCursor: null }),
+                updateTask: (id: string) => createMockTask({ id }),
+                moveTask: (id: string) => createMockTask({ id }),
+                moveTasks: (ids: string[]) => ids.map((id) => createMockTask({ id })),
+            })
+        }
+
+        it('costs one request per task for a field-only batch', async () => {
+            const { client, profile } = profiling()
+
+            await updateTasks.execute({ tasks: manyTasks(25, () => ({ content: 'x' })) }, client)
+
+            // No move params, so no state to read and no user to resolve.
+            expectRequestProfile(profile, {
+                updateTask: { count: 25, peak: ConcurrencyLimits.WRITES },
+            })
+        })
+
+        it('costs two requests to move a whole batch to one destination', async () => {
+            const { client, profile } = profiling()
+
+            await updateTasks.execute(
+                { tasks: manyTasks(25, () => ({ projectId: 'destination' })) },
+                client,
+            )
+
+            // The point of the batching: 25 tasks, one read and one write — not 25 moves.
+            expectRequestProfile(profile, {
+                getTasks: { count: 1, peak: 1 },
+                moveTasks: { count: 1, peak: 1 },
+            })
+            expect(profile.total).toBe(2)
+        })
+
+        it('resolves the inbox once however many tasks target it', async () => {
+            const { client, profile } = profiling()
+
+            await updateTasks.execute(
+                { tasks: manyTasks(25, () => ({ projectId: 'inbox' })) },
+                client,
+            )
+
+            // One getUser, not one per task. This is the assertion whose absence let the
+            // per-task lookup live here unnoticed.
+            expect(profile.count('getUser')).toBe(1)
+        })
+
+        it('never has two moves in flight, however many destinations', async () => {
+            const { client, profile } = profiling()
+
+            await updateTasks.execute(
+                { tasks: manyTasks(10, (index) => ({ projectId: `destination-${index}` })) },
+                client,
+            )
+
+            expect(profile.count('moveTask')).toBe(10)
+            expect(profile.peak('moveTask')).toBe(ConcurrencyLimits.TASK_MOVES)
+        })
+
+        it('makes no write requests at all when every move is redundant', async () => {
+            const { client, profile } = createProfilingClient({
+                getUser: () => createMockUser(),
+                getTasks: () => ({
+                    results: manyTasks(25).map(({ id }) =>
+                        createMockTask({
+                            id,
+                            projectId: 'destination',
+                            sectionId: null,
+                            parentId: null,
+                        }),
+                    ),
+                    nextCursor: null,
+                }),
+                updateTask: (id: string) => createMockTask({ id }),
+                moveTask: (id: string) => createMockTask({ id }),
+                moveTasks: (ids: string[]) => ids.map((id) => createMockTask({ id })),
+            })
+
+            await updateTasks.execute(
+                { tasks: manyTasks(25, () => ({ projectId: 'destination' })) },
+                client,
+            )
+
+            // One read establishes there is nothing to do, and nothing is written.
+            expectRequestProfile(profile, { getTasks: { count: 1, peak: 1 } })
         })
     })
 })

--- a/src/utils/request-profile.test.ts
+++ b/src/utils/request-profile.test.ts
@@ -1,0 +1,148 @@
+import type { TodoistApi } from '@doist/todoist-sdk'
+import { createProfilingClient, expectRequestProfile } from './request-profile.js'
+import { createMockTask } from './test-helpers.js'
+
+describe('createProfilingClient', () => {
+    it('counts requests per method', async () => {
+        const { client, profile } = createProfilingClient({
+            updateTask: (id: string) => createMockTask({ id }),
+            moveTask: (id: string) => createMockTask({ id }),
+        })
+
+        await client.updateTask('a', {})
+        await client.updateTask('b', {})
+        await client.moveTask('a', { projectId: 'p' })
+
+        expect(profile.count('updateTask')).toBe(2)
+        expect(profile.count('moveTask')).toBe(1)
+        expect(profile.count('getTasks')).toBe(0)
+        expect(profile.total).toBe(3)
+    })
+
+    it('reports peak concurrency, not just the total', async () => {
+        const { client, profile } = createProfilingClient({
+            updateTask: (id: string) => createMockTask({ id }),
+        })
+
+        await Promise.all(['a', 'b', 'c'].map((id) => client.updateTask(id, {})))
+        expect(profile.peak('updateTask')).toBe(3)
+
+        profile.reset()
+        for (const id of ['a', 'b', 'c']) {
+            await client.updateTask(id, {})
+        }
+        // Same three requests, issued one at a time.
+        expect(profile.count('updateTask')).toBe(3)
+        expect(profile.peak('updateTask')).toBe(1)
+    })
+
+    it('records the order requests started in', async () => {
+        const { client, profile } = createProfilingClient({
+            getUser: () => ({ inboxProjectId: 'inbox-1' }),
+            moveTask: (id: string) => createMockTask({ id }),
+        })
+
+        await client.getUser()
+        await client.moveTask('a', { projectId: 'inbox-1' })
+
+        expect(profile.sequence).toEqual(['getUser', 'moveTask'])
+    })
+
+    it('exposes the arguments each request was made with', async () => {
+        const { client, profile } = createProfilingClient({
+            moveTasks: (ids: string[]) => ids.map((id) => createMockTask({ id })),
+        })
+
+        await client.moveTasks(['a', 'b'], { projectId: 'p' })
+
+        expect(profile.argsFor('moveTasks')).toEqual([[['a', 'b'], { projectId: 'p' }]])
+    })
+
+    it('returns whatever the handler returns', async () => {
+        const { client } = createProfilingClient({
+            updateTask: (id: string) => createMockTask({ id, content: 'from handler' }),
+        })
+
+        await expect(client.updateTask('a', {})).resolves.toMatchObject({
+            id: 'a',
+            content: 'from handler',
+        })
+    })
+
+    it('propagates a throwing handler and still records the request', async () => {
+        const { client, profile } = createProfilingClient({
+            moveTask: () => {
+                throw new Error('nope')
+            },
+        })
+
+        await expect(client.moveTask('a', { projectId: 'p' })).rejects.toThrow('nope')
+        expect(profile.count('moveTask')).toBe(1)
+        // A failed request must not leave the in-flight count stuck, or every later
+        // peak would be inflated.
+        expect(profile.peak('moveTask')).toBe(1)
+    })
+})
+
+describe('expectRequestProfile', () => {
+    async function twoUpdatesOneMove() {
+        const { client, profile } = createProfilingClient({
+            updateTask: (id: string) => createMockTask({ id }),
+            moveTask: (id: string) => createMockTask({ id }),
+        })
+        await Promise.all([client.updateTask('a', {}), client.updateTask('b', {})])
+        await client.moveTask('a', { projectId: 'p' })
+        return profile
+    }
+
+    it('passes when counts and peaks match', async () => {
+        expectRequestProfile(await twoUpdatesOneMove(), {
+            updateTask: { count: 2, peak: 2 },
+            moveTask: { count: 1, peak: 1 },
+        })
+    })
+
+    it('defaults peak to whatever happened when only a count is given', async () => {
+        expectRequestProfile(await twoUpdatesOneMove(), {
+            updateTask: { count: 2 },
+            moveTask: { count: 1 },
+        })
+    })
+
+    it('fails when a request was made that the profile does not mention', async () => {
+        const profile = await twoUpdatesOneMove()
+        // The point of the helper: a newly introduced request breaks the test instead of
+        // going unnoticed.
+        expect(() => expectRequestProfile(profile, { updateTask: { count: 2 } })).toThrow()
+    })
+
+    it('fails when a count is wrong', async () => {
+        const profile = await twoUpdatesOneMove()
+        expect(() =>
+            expectRequestProfile(profile, {
+                updateTask: { count: 1 },
+                moveTask: { count: 1 },
+            }),
+        ).toThrow()
+    })
+
+    it('fails when more ran concurrently than expected', async () => {
+        const profile = await twoUpdatesOneMove()
+        expect(() =>
+            expectRequestProfile(profile, {
+                updateTask: { count: 2, peak: 1 },
+                moveTask: { count: 1, peak: 1 },
+            }),
+        ).toThrow()
+    })
+})
+
+describe('the client is usable as a TodoistApi', () => {
+    it('satisfies the parameter a tool expects', () => {
+        const { client } = createProfilingClient({
+            updateTask: (id: string) => createMockTask({ id }),
+        })
+        const asApi: TodoistApi = client
+        expect(typeof asApi.updateTask).toBe('function')
+    })
+})

--- a/src/utils/request-profile.ts
+++ b/src/utils/request-profile.ts
@@ -1,0 +1,155 @@
+import type { TodoistApi } from '@doist/todoist-sdk'
+import { vi } from 'vitest'
+
+/**
+ * Test-only. Records the API requests a tool makes, so a batch's request behaviour can
+ * be asserted rather than inferred.
+ *
+ * Existing tool tests check what a call *returns*. That leaves the shape of the traffic
+ * unverified, which is how this server ended up issuing one `getUser` per task in a
+ * batch and firing every move in a batch at once: both looked correct per task, and no
+ * test could tell. A backend engineer's dashboard noticed instead of CI.
+ *
+ * Two properties are worth pinning for any batch tool:
+ *
+ * - **how many requests** a batch of N items makes. Anything that scales with N when it
+ *   needn't is the fan-out this exists to catch.
+ * - **how many run at once**, since concurrent writes to the same account contend
+ *   server-side.
+ */
+
+type Handlers = {
+    [K in keyof TodoistApi]?: TodoistApi[K] extends (...args: infer A) => unknown
+        ? (...args: A) => unknown
+        : never
+}
+
+type MethodProfile = {
+    /** Requests made to this method. */
+    count: number
+    /** The most that were ever in flight at once. */
+    peak: number
+}
+
+type RequestProfile = {
+    /** Per-method counts and peak concurrency, for methods that were called. */
+    byMethod: Record<string, MethodProfile>
+    /** Total requests across every method. */
+    total: number
+    /** Method names in the order their requests started, e.g. `['getTasks', 'moveTasks']`. */
+    sequence: string[]
+    count(method: keyof TodoistApi): number
+    peak(method: keyof TodoistApi): number
+    /** Requests recorded for a method, in call order, with their arguments. */
+    argsFor(method: keyof TodoistApi): unknown[][]
+    reset(): void
+}
+
+/**
+ * Builds a mock client whose requests are recorded, alongside the profile to assert on.
+ *
+ * Handlers return a value (or throw) and the wrapper makes it async, deliberately
+ * resolving a macrotask later: a handler that resolves immediately would let each
+ * caller finish before the next begins, and every peak would read as 1 no matter how
+ * the tool behaves.
+ *
+ * @example
+ * const { client, profile } = createProfilingClient({
+ *     updateTask: (id: string) => createMockTask({ id }),
+ * })
+ * await updateTasks.execute({ tasks: manyTasks }, client)
+ * expect(profile.count('updateTask')).toBe(25)
+ * expect(profile.peak('updateTask')).toBe(4)
+ */
+export function createProfilingClient(handlers: Handlers): {
+    client: TodoistApi
+    profile: RequestProfile
+} {
+    const records = new Map<string, { count: number; peak: number; inFlight: number }>()
+    const sequence: string[] = []
+    const argsByMethod = new Map<string, unknown[][]>()
+
+    const record = (method: string) => {
+        const entry = records.get(method) ?? { count: 0, peak: 0, inFlight: 0 }
+        entry.count++
+        entry.inFlight++
+        entry.peak = Math.max(entry.peak, entry.inFlight)
+        records.set(method, entry)
+        sequence.push(method)
+    }
+
+    const client = {} as Record<string, unknown>
+    for (const [method, handler] of Object.entries(handlers)) {
+        client[method] = vi.fn(async (...args: unknown[]) => {
+            record(method)
+            argsByMethod.set(method, [...(argsByMethod.get(method) ?? []), args])
+            try {
+                // Yield so concurrent callers all reach the handler before any returns,
+                // which is what makes `peak` meaningful.
+                await new Promise((resolve) => setImmediate(resolve))
+                return (handler as (...handlerArgs: unknown[]) => unknown)(...args)
+            } finally {
+                const entry = records.get(method)
+                if (entry) {
+                    entry.inFlight--
+                }
+            }
+        })
+    }
+
+    const profile: RequestProfile = {
+        get byMethod() {
+            return Object.fromEntries(
+                [...records].map(([method, { count, peak }]) => [method, { count, peak }]),
+            )
+        },
+        get total() {
+            return [...records.values()].reduce((sum, { count }) => sum + count, 0)
+        },
+        get sequence() {
+            return [...sequence]
+        },
+        count: (method) => records.get(String(method))?.count ?? 0,
+        peak: (method) => records.get(String(method))?.peak ?? 0,
+        argsFor: (method) => argsByMethod.get(String(method)) ?? [],
+        reset: () => {
+            records.clear()
+            argsByMethod.clear()
+            sequence.length = 0
+        },
+    }
+
+    return { client: client as unknown as TodoistApi, profile }
+}
+
+/**
+ * Asserts the exact request profile of an operation: every method called, how many
+ * times, and how many ran concurrently. Methods absent from `expected` must not have
+ * been called at all, so a newly introduced request fails the test rather than slipping
+ * in unnoticed.
+ *
+ * @example
+ * expectRequestProfile(profile, {
+ *     getTasks: { count: 1, peak: 1 },
+ *     moveTasks: { count: 1, peak: 1 },
+ * })
+ */
+export function expectRequestProfile(
+    profile: RequestProfile,
+    expected: Partial<Record<keyof TodoistApi, { count: number; peak?: number }>>,
+): void {
+    const actual = profile.byMethod
+    const expectedMethods = Object.keys(expected)
+
+    // Compared as whole objects so a failure reports the entire profile, which is far
+    // more use than "expected 1, got 2" on a single method.
+    expect(Object.keys(actual).toSorted()).toEqual(expectedMethods.toSorted())
+
+    const normalized = Object.fromEntries(
+        Object.entries(expected).map(([method, spec]) => [
+            method,
+            { count: spec?.count ?? 0, peak: spec?.peak ?? actual[method]?.peak ?? 0 },
+        ]),
+    )
+    expect(actual).toEqual(normalized)
+}


### PR DESCRIPTION
## Context

Stacked on #548. Retarget to `main` once that merges.

Reviewing the test suite after this work raised a fair question: were the tests added in #548 things we should have had already? Mostly no — they cover behaviour that didn't exist before. But one dimension was genuinely missing, and it is the one that let the original problem live here unnoticed.

Before #548, `update-tasks` had 48 tests with **8 request-count assertions between them**, and the only `getUser` count assertion was incidental — it checked that a retry made two attempts. So a 25-task inbox batch issuing **25 `getUser` calls**, and 25 concurrent moves, passed the suite happily for as long as that code existed. The tests verified what a call *returned*; nothing verified the shape of the traffic. That is precisely the dimension [Janusz's report](https://comms.todoist.com/69/ch/AK6drPS98yMaYmyWmztS2/t/CdffD1JCLJMYmWYSf3Fi2) lives in, and it was a backend dashboard that noticed rather than CI.

It isn't only that file. `add-tasks` had 4 count assertions across 34 tests, `update-projects` 3 across 18, `reschedule-tasks` 2 across 12.

## The helper

`src/utils/request-profile.ts`, test-only:

```ts
const { client, profile } = createProfilingClient({
    getTasks: () => ({ results: [], nextCursor: null }),
    moveTasks: (ids: string[]) => ids.map((id) => createMockTask({ id })),
})

await updateTasks.execute({ tasks: twentyFiveTasks }, client)

expectRequestProfile(profile, {
    getTasks: { count: 1, peak: 1 },
    moveTasks: { count: 1, peak: 1 },
})
```

- **`createProfilingClient(handlers)`** — a mock client whose requests are recorded. Handlers return a value (or throw); the profile exposes per-method `count` and `peak` concurrency, the `sequence` requests started in, and `argsFor(method)`.
- **`expectRequestProfile(profile, expected)`** — asserts the *whole* profile. A method absent from `expected` must not have been called, so a newly introduced request fails the test rather than slipping in unnoticed. Failures print the entire profile, which is far more use than "expected 1, got 2" on one method.

One implementation detail worth knowing: handlers resolve a macrotask later, deliberately. A handler that resolved immediately would let each caller finish before the next began, so every `peak` would read as 1 no matter how the tool actually behaved.

## It found two read amplifications immediately

**`add-tasks` checked the archived-project status once per task** (`add-tasks.ts:204`) — 25 identical reads for a batch bound for one project. Fixed here by caching the lookup for the duration of the batch, next to the section cache that already existed in the same function. The *promise* is cached rather than the result, so tasks racing for the same project share one request instead of each starting their own.

**`reschedule-tasks` makes two reads per task, all in flight at once**, while its writes are already collapsed into a single sync request — 10 tasks cost 20 concurrent `getTask` calls. Not fixed here: switching it to a batched read is a change in its own right and needs the comma-separated `ids` workaround from #548. The cost is now asserted with a comment saying so, so the test fails deliberately when that lands rather than the improvement going unnoticed.

## Coverage added

`update-tasks` — a field-only batch costs one request per task and nothing else; 25 tasks moving to one destination cost two requests in total; the inbox resolves once however many tasks target it; moves never overlap regardless of destination count; a batch of entirely redundant moves writes nothing at all.

`add-tasks` — a shared destination project is checked once, distinct projects once each, and no project means no reads. (That last test caught my own wrong assumption: same-destination tasks are created sequentially to preserve sibling order, so peak is 1, not N.)

`reschedule-tasks` — the characterisation described above.

Plus 12 tests for the helper itself, including that `expectRequestProfile` fails on an unexpected request, a wrong count, and excess concurrency — the failure modes it exists to produce.

## Notes

- `CODEBASE.md` gains the helper in the utils catalogue and a line under Testing conventions, since the point is for the next batch tool to use it rather than rediscover the gap.
- `manage-assignments.ts` has no test file of its own (only `assignment-integration.test.ts`) and is another unbounded fan-out site — `Promise.all` over up to 50 tasks plus a `getTask` prefetch each. Out of scope here, but it is the next obvious candidate.

`npm test` (1096), `npm run type-check`, `npm run check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)