### PR TITLE
feat: add date filters for activity completion history

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -78,7 +78,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 - **uncomplete-tasks**: Reopen completed tasks using task IDs
 - **find-tasks**: Search by text, project/section/parent container, responsible user, labels, a raw Todoist \`filter\` string (e.g. "today", "p1", "##Work", "(today | overdue) & p1"), or a saved filter by ID or name (\`filterIdOrName\`). Requires at least one search parameter. \`filter\`/\`filterIdOrName\` cannot be combined with projectId/sectionId/parentId, and \`filter\` and \`filterIdOrName\` are mutually exclusive.
 - **find-tasks-by-date**: Get tasks by date range (startDate: YYYY-MM-DD or 'today' which includes overdue tasks) or specific day counts
-- **find-completed-tasks**: View completed tasks by completion date or original due date; if since/until are omitted, defaults to the last 7 days (returns all collaborators unless filtered)
+- **find-completed-tasks**: View completed tasks by completion date or original due date; if since/until are omitted, defaults to the last 7 days (returns all collaborators unless filtered). For a history of actual task-completion events, including recurring task occurrences, use find-activity instead.
 
 **Project & Organization:**
 - **add-projects/update-projects/find-projects**: Manage project lifecycle with names, descriptions (Markdown), favorites, view styles (list/board/calendar), and workspace assignment for new projects (by name or ID). find-projects returns active projects by default; pass archivedStatus ('archived' or 'all') to include archived projects. Every returned project includes an isArchived field
@@ -108,7 +108,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 - **update-filters**: Modify existing filters' name, query, color, or favorite status
 
 **Activity & Audit:**
-- **find-activity**: Retrieve recent activity logs to monitor and audit changes. Shows events from all users by default; use initiatorId to filter by specific user. Filter by object type (task/project/comment), event type (added/updated/deleted/completed/uncompleted/archived/unarchived/shared/left), and specific objects (objectId, projectId, taskId). Useful for tracking who did what and when. Note: Date-based filtering is not supported.
+- **find-activity**: Retrieve activity logs to monitor and audit changes. Shows events from all users by default; use initiatorId to filter by specific user. Filter by object type (task/project/comment), event type (added/updated/deleted/completed/uncompleted/archived/unarchived/shared/left), objects (objectId, projectId, taskId), and an inclusive dateFrom/exclusive dateTo range. For “what did I complete?” or “what got done?” questions, including recurring task occurrences, use objectType="task", eventType="completed", and the requested date range. Activity history retention depends on the user plan.
 - **get-productivity-stats**: Get comprehensive productivity statistics including daily/weekly completion breakdowns, goal streaks (current, last, max), karma score and trends, and historical karma data. No parameters required.
 
 **Project Health & Insights:**
@@ -148,6 +148,7 @@ You have access to comprehensive Todoist management tools for personal productiv
 - **User Lookup**: find-project-collaborators with just a searchTerm (no projectId) to resolve a name or email to a Todoist user ID across all shared-project collaborators you can access
 - **Task Search**: find-tasks with multiple filters → update-tasks or complete-tasks based on results
 - **Project Organization**: add-projects → add-sections → add-tasks with projectId and sectionId
+- **Completion History**: find-activity with objectType="task", eventType="completed", dateFrom, and dateTo to report what was actually completed in a period, including recurring task occurrences; use initiatorId for one collaborator
 - **Progress Reviews**: find-completed-tasks (defaults to last 7 days; optionally use explicit date ranges) → get-overview for project summaries
 - **Activity Auditing**: find-activity with event/object filters to track changes, monitor team activity, or investigate specific actions
 - **Productivity Analysis**: Use the productivity-analysis prompt for comprehensive analysis combining user-info, get-productivity-stats, and find-completed-tasks data into actionable insights

--- a/src/tools/find-activity.test.ts
+++ b/src/tools/find-activity.test.ts
@@ -1,5 +1,6 @@
 import type { ActivityEvent, TodoistApi } from '@doist/todoist-sdk'
 import { type Mocked, vi } from 'vitest'
+import { z } from 'zod'
 import { ToolNames } from '../utils/tool-names.js'
 import { findActivity } from './find-activity.js'
 
@@ -103,6 +104,19 @@ describe(`${FIND_ACTIVITY} tool`, () => {
     })
 
     describe('filtering', () => {
+        it.each(['dateFrom', 'dateTo'] as const)('should reject non-ISO values for %s', (field) => {
+            const result = z.object(findActivity.parameters).safeParse({ [field]: 'tomorrow' })
+
+            expect(result.success).toBe(false)
+        })
+
+        it('should normalize empty date filters to undefined', () => {
+            const parsed = z.object(findActivity.parameters).parse({ dateFrom: '', dateTo: '' })
+
+            expect(parsed.dateFrom).toBeUndefined()
+            expect(parsed.dateTo).toBeUndefined()
+        })
+
         it('should filter activity events by an inclusive/exclusive date range', async () => {
             const mockEvents: ActivityEvent[] = [
                 createMockActivityEvent({

--- a/src/tools/find-activity.test.ts
+++ b/src/tools/find-activity.test.ts
@@ -103,6 +103,41 @@ describe(`${FIND_ACTIVITY} tool`, () => {
     })
 
     describe('filtering', () => {
+        it('should filter activity events by an inclusive/exclusive date range', async () => {
+            const mockEvents: ActivityEvent[] = [
+                createMockActivityEvent({
+                    eventType: 'completed',
+                    eventDate: new Date('2026-08-02T12:00:00-04:00'),
+                }),
+            ]
+
+            mockTodoistApi.getActivityLogs.mockResolvedValue({
+                results: mockEvents,
+                nextCursor: null,
+            })
+
+            const result = await findActivity.execute(
+                {
+                    objectType: 'task',
+                    eventType: 'completed',
+                    dateFrom: '2026-08-02T00:00:00-04:00',
+                    dateTo: '2026-08-03T00:00:00-04:00',
+                    limit: 20,
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.getActivityLogs).toHaveBeenCalledWith({
+                objectEventTypes: 'task:completed',
+                dateFrom: '2026-08-02T00:00:00-04:00',
+                dateTo: '2026-08-03T00:00:00-04:00',
+                limit: 20,
+                cursor: null,
+            })
+            expect(result.textContent).toContain('from: 2026-08-02T00:00:00-04:00')
+            expect(result.textContent).toContain('until (exclusive): 2026-08-03T00:00:00-04:00')
+        })
+
         it.each([
             ['task', 'added'],
             ['project', 'updated'],

--- a/src/tools/find-activity.ts
+++ b/src/tools/find-activity.ts
@@ -38,6 +38,20 @@ const ArgsSchema = {
 
     initiatorId: z.string().optional().describe('Filter by the user ID who initiated the event.'),
 
+    dateFrom: z
+        .string()
+        .optional()
+        .describe(
+            'Inclusive start of the activity range, as an ISO 8601 date or date-time. For all events on one local calendar day, use that day\'s start, for example "2026-08-02T00:00:00-04:00".',
+        ),
+
+    dateTo: z
+        .string()
+        .optional()
+        .describe(
+            'Exclusive end of the activity range, as an ISO 8601 date or date-time. For all events on 2026-08-02, use "2026-08-03T00:00:00-04:00".',
+        ),
+
     limit: z
         .number()
         .int()
@@ -65,13 +79,23 @@ const OutputSchema = {
 const findActivity = {
     name: ToolNames.FIND_ACTIVITY,
     description:
-        'Retrieve recent activity logs to monitor and audit changes in Todoist. Shows events from all users by default (use initiatorId to filter by specific user). Track task completions, updates, deletions, project changes, and more with flexible filtering. Note: Date-based filtering is not supported by the Todoist API.',
+        'Retrieve activity logs to monitor and audit changes in Todoist. Shows events from all users by default (use initiatorId to filter by specific user). To answer what someone completed in a period, including recurring task occurrences, use objectType "task", eventType "completed", and dateFrom/dateTo. Track task completions, updates, deletions, project changes, and more with flexible filtering. Activity history availability and retention depend on the user plan.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
-        const { objectType, objectId, eventType, projectId, taskId, initiatorId, limit, cursor } =
-            args
+        const {
+            objectType,
+            objectId,
+            eventType,
+            projectId,
+            taskId,
+            initiatorId,
+            dateFrom,
+            dateTo,
+            limit,
+            cursor,
+        } = args
 
         // Build API arguments
         const apiArgs: Parameters<typeof client.getActivityLogs>[0] = {
@@ -87,6 +111,8 @@ const findActivity = {
         if (projectId) apiArgs.parentProjectId = projectId
         if (taskId) apiArgs.parentItemId = taskId
         if (initiatorId) apiArgs.initiatorId = initiatorId
+        if (dateFrom) apiArgs.dateFrom = dateFrom
+        if (dateTo) apiArgs.dateTo = dateTo
 
         // Fetch activity logs from API
         const { results, nextCursor } = await client.getActivityLogs(apiArgs)
@@ -146,6 +172,12 @@ function generateTextContent({
     }
     if (args.initiatorId) {
         filterHints.push(`initiator: ${args.initiatorId}`)
+    }
+    if (args.dateFrom) {
+        filterHints.push(`from: ${args.dateFrom}`)
+    }
+    if (args.dateTo) {
+        filterHints.push(`until (exclusive): ${args.dateTo}`)
     }
 
     // Generate helpful suggestions for empty results

--- a/src/tools/find-activity.ts
+++ b/src/tools/find-activity.ts
@@ -4,7 +4,14 @@ import { mapActivityEvent } from '../tool-helpers.js'
 import { ApiLimits } from '../utils/constants.js'
 import { ActivityEventSchema } from '../utils/output-schemas.js'
 import { summarizeList } from '../utils/response-builders.js'
+import { optionalString } from '../utils/schema-helpers.js'
 import { ToolNames } from '../utils/tool-names.js'
+
+const IsoDateOrDateTime = z.union([z.iso.date(), z.iso.datetime({ offset: true })])
+
+function optionalIsoDateOrDateTime(description: string) {
+    return optionalString(description).pipe(IsoDateOrDateTime.optional())
+}
 
 const ArgsSchema = {
     objectType: z
@@ -38,19 +45,13 @@ const ArgsSchema = {
 
     initiatorId: z.string().optional().describe('Filter by the user ID who initiated the event.'),
 
-    dateFrom: z
-        .string()
-        .optional()
-        .describe(
-            'Inclusive start of the activity range, as an ISO 8601 date or date-time. For all events on one local calendar day, use that day\'s start, for example "2026-08-02T00:00:00-04:00".',
-        ),
+    dateFrom: optionalIsoDateOrDateTime(
+        'Inclusive start of the activity range, as an ISO 8601 date or date-time. For all events on one local calendar day, use that day\'s start, for example "2026-08-02T00:00:00-04:00". Natural-language dates such as "tomorrow" are not supported.',
+    ),
 
-    dateTo: z
-        .string()
-        .optional()
-        .describe(
-            'Exclusive end of the activity range, as an ISO 8601 date or date-time. For all events on 2026-08-02, use "2026-08-03T00:00:00-04:00".',
-        ),
+    dateTo: optionalIsoDateOrDateTime(
+        'Exclusive end of the activity range, as an ISO 8601 date or date-time. For all events on 2026-08-02, use "2026-08-03T00:00:00-04:00". Natural-language dates such as "tomorrow" are not supported.',
+    ),
 
     limit: z
         .number()


### PR DESCRIPTION
## Summary
- expose inclusive `dateFrom` and exclusive `dateTo` filters on `find-activity`
- guide completion-history queries, including recurring task occurrences, to activity events
- add date-range forwarding coverage
