### PR TITLE
fix: load all task list pages in MCP app

### DIFF
--- a/src/mcp-apps/task-list/app.tsx
+++ b/src/mcp-apps/task-list/app.tsx
@@ -168,10 +168,11 @@ export function App() {
                 fetchPage: (cursor) => fetchTaskPage(app, paginationRequest.args, cursor),
                 onPage: (page) => {
                     if (cancelled || paginationRequest.requestId !== requestId.current) {
-                        return
+                        return false
                     }
 
                     setTasks((previous) => [...(previous ?? []), ...page.tasks])
+                    return true
                 },
             }).catch((error: unknown) => {
                 if (!cancelled && paginationRequest.requestId === requestId.current) {
@@ -192,7 +193,11 @@ export function App() {
         async (taskId: string) => {
             if (!app || !tasks) return
 
-            const previousTasks = tasks
+            const completedTaskIndex = tasks.findIndex((task) => task.id === taskId)
+            const completedTask = tasks[completedTaskIndex]
+            if (!completedTask) return
+
+            const completionRequestId = requestId.current
 
             setTasks((previous) => previous?.filter((task) => task.id !== taskId) ?? [])
             setToolError(null)
@@ -209,7 +214,22 @@ export function App() {
                     )
                 }
             } catch (error) {
-                setTasks(previousTasks)
+                if (completionRequestId !== requestId.current) {
+                    return
+                }
+
+                setTasks((previous) => {
+                    if (!previous || previous.some((task) => task.id === taskId)) {
+                        return previous
+                    }
+
+                    const insertionIndex = Math.min(completedTaskIndex, previous.length)
+                    return [
+                        ...previous.slice(0, insertionIndex),
+                        completedTask,
+                        ...previous.slice(insertionIndex),
+                    ]
+                })
                 setToolError(error instanceof Error ? error.message : 'Failed to complete task.')
             }
         },

--- a/src/mcp-apps/task-list/app.tsx
+++ b/src/mcp-apps/task-list/app.tsx
@@ -1,10 +1,11 @@
-import { useApp, useHostStyles } from '@modelcontextprotocol/ext-apps/react'
-import { useCallback, useMemo, useState } from 'react'
+import { type App as McpApp, useApp, useHostStyles } from '@modelcontextprotocol/ext-apps/react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { z } from 'zod'
 import { ArgsSchema } from '../../tools/find-tasks-by-date.js'
 import { ToolNames } from '../../utils/tool-names.js'
 import { Empty } from './empty'
 import { Loading } from './loading'
+import { loadRemainingPages } from './pagination'
 import { TaskList } from './task-list'
 import type { Task } from './types'
 import styles from './task-list.module.css'
@@ -13,6 +14,7 @@ type FindTasksByDateArgs = z.input<z.ZodObject<typeof ArgsSchema>>
 
 type ToolOutput = {
     tasks: Task[]
+    nextCursor?: string
     appliedFilters?: FindTasksByDateArgs
 }
 
@@ -20,6 +22,12 @@ type ToolResult = {
     isError?: boolean
     structuredContent?: unknown
     content?: Array<{ type?: string; text?: string }>
+}
+
+type PaginationRequest = {
+    args: Omit<FindTasksByDateArgs, 'cursor'>
+    cursor: string
+    requestId: number
 }
 
 const TODOIST_APP_URL = 'https://app.todoist.com/app'
@@ -36,6 +44,27 @@ function getInvocationArgs(args: FindTasksByDateArgs | null | undefined) {
 function getToolResultMessage(result: ToolResult, fallback: string) {
     const message = result.content?.find((item) => item.type === 'text' && item.text)?.text?.trim()
     return message && message.length > 0 ? message : fallback
+}
+
+async function fetchTaskPage(
+    app: McpApp,
+    args: Omit<FindTasksByDateArgs, 'cursor'>,
+    cursor: string,
+): Promise<ToolOutput> {
+    const result = await app.callServerTool({
+        name: ToolNames.FIND_TASKS_BY_DATE,
+        arguments: { ...args, cursor },
+    })
+
+    if (result.isError) {
+        throw new Error(getToolResultMessage(result as ToolResult, 'Failed to load more tasks.'))
+    }
+
+    if (!result.structuredContent) {
+        throw new Error('Task page data was missing from the tool result.')
+    }
+
+    return result.structuredContent as ToolOutput
 }
 
 function OpenInTodoistIcon() {
@@ -72,11 +101,22 @@ export function App() {
     const [loading, setLoading] = useState(true)
     const [lastArgs, setLastArgs] = useState<Omit<FindTasksByDateArgs, 'cursor'> | null>(null)
     const [toolError, setToolError] = useState<string | null>(null)
+    const [paginationError, setPaginationError] = useState<string | null>(null)
+    const [paginationRequest, setPaginationRequest] = useState<PaginationRequest | null>(null)
+    const requestId = useRef(0)
 
     const handleToolOutput = useCallback((output: ToolOutput) => {
+        const args = getInvocationArgs(output.appliedFilters)
+
         setTasks(output.tasks)
-        setLastArgs(getInvocationArgs(output.appliedFilters))
+        setLastArgs(args)
         setToolError(null)
+        setPaginationError(null)
+        setPaginationRequest(
+            output.nextCursor && args
+                ? { args, cursor: output.nextCursor, requestId: requestId.current }
+                : null,
+        )
         setLoading(false)
     }, [])
 
@@ -85,9 +125,12 @@ export function App() {
         capabilities: {},
         onAppCreated: (app) => {
             app.ontoolinput = (params) => {
+                requestId.current += 1
                 setLoading(true)
                 setToolError(null)
+                setPaginationError(null)
                 setTasks(null)
+                setPaginationRequest(null)
                 setLastArgs(getInvocationArgs((params.arguments ?? {}) as FindTasksByDateArgs))
             }
 
@@ -111,6 +154,39 @@ export function App() {
     })
 
     useHostStyles(app, app?.getHostContext())
+
+    useEffect(
+        function loadTaskPages() {
+            if (!app || !paginationRequest) {
+                return
+            }
+
+            let cancelled = false
+
+            void loadRemainingPages({
+                initialCursor: paginationRequest.cursor,
+                fetchPage: (cursor) => fetchTaskPage(app, paginationRequest.args, cursor),
+                onPage: (page) => {
+                    if (cancelled || paginationRequest.requestId !== requestId.current) {
+                        return
+                    }
+
+                    setTasks((previous) => [...(previous ?? []), ...page.tasks])
+                },
+            }).catch((error: unknown) => {
+                if (!cancelled && paginationRequest.requestId === requestId.current) {
+                    setPaginationError(
+                        error instanceof Error ? error.message : 'Failed to load more tasks.',
+                    )
+                }
+            })
+
+            return () => {
+                cancelled = true
+            }
+        },
+        [app, paginationRequest],
+    )
 
     const handleComplete = useCallback(
         async (taskId: string) => {
@@ -177,6 +253,9 @@ export function App() {
         <div className={styles.widgetContainer}>
             <div className={styles.contentColumn}>
                 <h1 className={styles.widgetTitle}>{title}</h1>
+                {paginationError ? (
+                    <div className={styles.paginationError}>{paginationError}</div>
+                ) : null}
                 <TaskList tasks={tasks} onCompleteTask={handleComplete} />
             </div>
             <OpenInTodoistButton onClick={handleOpenTodoist} />

--- a/src/mcp-apps/task-list/pagination.test.ts
+++ b/src/mcp-apps/task-list/pagination.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { loadRemainingPages } from './pagination.js'
+
+describe('loadRemainingPages', () => {
+    it('fetches every following cursor in order', async () => {
+        const fetchPage = vi
+            .fn()
+            .mockResolvedValueOnce({ tasks: ['second'], nextCursor: 'third-page' })
+            .mockResolvedValueOnce({ tasks: ['third'] })
+        const onPage = vi.fn()
+
+        await loadRemainingPages({
+            initialCursor: 'second-page',
+            fetchPage,
+            onPage,
+        })
+
+        expect(fetchPage).toHaveBeenNthCalledWith(1, 'second-page')
+        expect(fetchPage).toHaveBeenNthCalledWith(2, 'third-page')
+        expect(onPage).toHaveBeenCalledWith({ tasks: ['second'], nextCursor: 'third-page' })
+        expect(onPage).toHaveBeenCalledWith({ tasks: ['third'] })
+    })
+
+    it('does not request another page when the initial result has no cursor', async () => {
+        const fetchPage = vi.fn()
+
+        await loadRemainingPages({
+            initialCursor: undefined,
+            fetchPage,
+            onPage: vi.fn(),
+        })
+
+        expect(fetchPage).not.toHaveBeenCalled()
+    })
+
+    it('stops a malformed pagination loop', async () => {
+        const fetchPage = vi.fn().mockResolvedValue({ nextCursor: 'same-cursor' })
+
+        await expect(
+            loadRemainingPages({
+                initialCursor: 'same-cursor',
+                fetchPage,
+                onPage: vi.fn(),
+            }),
+        ).rejects.toThrow('repeated cursor')
+
+        expect(fetchPage).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/mcp-apps/task-list/pagination.test.ts
+++ b/src/mcp-apps/task-list/pagination.test.ts
@@ -34,6 +34,18 @@ describe('loadRemainingPages', () => {
         expect(fetchPage).not.toHaveBeenCalled()
     })
 
+    it('stops when the page handler cancels pagination', async () => {
+        const fetchPage = vi.fn().mockResolvedValue({ nextCursor: 'third-page' })
+
+        await loadRemainingPages({
+            initialCursor: 'second-page',
+            fetchPage,
+            onPage: () => false,
+        })
+
+        expect(fetchPage).toHaveBeenCalledTimes(1)
+    })
+
     it('stops a malformed pagination loop', async () => {
         const fetchPage = vi.fn().mockResolvedValue({ nextCursor: 'same-cursor' })
 

--- a/src/mcp-apps/task-list/pagination.ts
+++ b/src/mcp-apps/task-list/pagination.ts
@@ -16,7 +16,7 @@ async function loadRemainingPages<PageResult extends Page>({
 }: {
     initialCursor: string | undefined
     fetchPage: (cursor: string) => Promise<PageResult>
-    onPage: (page: PageResult) => void
+    onPage: (page: PageResult) => boolean | void
 }): Promise<void> {
     let cursor = initialCursor
     const seenCursors = new Set<string>()
@@ -28,7 +28,9 @@ async function loadRemainingPages<PageResult extends Page>({
 
         seenCursors.add(cursor)
         const page = await fetchPage(cursor)
-        onPage(page)
+        if (onPage(page) === false) {
+            return
+        }
         cursor = page.nextCursor
     }
 }

--- a/src/mcp-apps/task-list/pagination.ts
+++ b/src/mcp-apps/task-list/pagination.ts
@@ -1,0 +1,36 @@
+type Page = {
+    nextCursor?: string
+}
+
+/**
+ * Fetch every page after an initial cursor-based tool result.
+ *
+ * The widget receives its first page from the host. Subsequent pages are fetched
+ * directly from the MCP server so a paginated result is not presented as a
+ * complete task list.
+ */
+async function loadRemainingPages<PageResult extends Page>({
+    initialCursor,
+    fetchPage,
+    onPage,
+}: {
+    initialCursor: string | undefined
+    fetchPage: (cursor: string) => Promise<PageResult>
+    onPage: (page: PageResult) => void
+}): Promise<void> {
+    let cursor = initialCursor
+    const seenCursors = new Set<string>()
+
+    while (cursor) {
+        if (seenCursors.has(cursor)) {
+            throw new Error('Task pagination returned a repeated cursor.')
+        }
+
+        seenCursors.add(cursor)
+        const page = await fetchPage(cursor)
+        onPage(page)
+        cursor = page.nextCursor
+    }
+}
+
+export { loadRemainingPages }

--- a/src/mcp-apps/task-list/task-list.module.css
+++ b/src/mcp-apps/task-list/task-list.module.css
@@ -80,3 +80,8 @@
     padding: 24px;
     background-color: #ffffff;
 }
+
+.paginationError {
+    font-size: 14px;
+    color: #b42318;
+}

--- a/src/tools/find-tasks-by-date.ts
+++ b/src/tools/find-tasks-by-date.ts
@@ -48,7 +48,7 @@ export const ArgsSchema = {
         .min(1)
         .max(ApiLimits.TASKS_MAX)
         .default(ApiLimits.TASKS_DEFAULT)
-        .describe('The maximum number of tasks to return.'),
+        .describe('The maximum number of tasks to return. Default is 10.'),
     cursor: z
         .string()
         .optional()


### PR DESCRIPTION
## 🗺️ Overview

- follow cursor-based task pages inside the MCP task-list widget
- append fetched pages while guarding against stale responses
- show a non-blocking error if a later page cannot load

Fixes #554

## 🎥 Demo

Here you can see the widget running locally in isolation connected to a demo account with more than 20 tasks in the today view. It now shows them all.

https://github.com/user-attachments/assets/b2882738-288d-492e-a1ef-e3a9b5486238

## 🧪 Test plan

### Prerequisites

1. Configure the local MCP server with a valid Todoist API token:

   ```bash
   cp .env.example .env
   # Set TODOIST_API_KEY in .env
   ```

2. Use an account with more than 10 active tasks that match `startDate: "today"` (due today or overdue). The account must be the one referenced by `TODOIST_API_KEY`.
3. Build the local server:

   ```bash
   npm run build
   ```

### Steps

1. Start the local MCP server:

   ```bash
   PORT=3001 npm run start:http
   ```

2. Start an MCP Apps-compatible host connected to `http://localhost:3001/mcp`. To use the reference `basic-host`:

   ```bash
   cd /private/tmp/ext-apps
   npm install
   cd examples/basic-host
   SERVERS="[\"http://localhost:3001/mcp\"]" npm start
   ```

3. Open `http://localhost:8080`, select `find-tasks-by-date`, and call it with:

   ```json
   { "startDate": "today" }
   ```

**Before this change:** the task-list widget renders only the initial cursor page (the default is 10 tasks).

**After this change:** the widget follows `nextCursor` and appends every remaining page.

### Reference-host note

`basic-host` runs in a browser, so connecting it directly to the local server requires a temporary local CORS bridge or proxy. That is test-harness configuration only and is deliberately not part of this PR.
