### PR TITLE
fix: derive the tool surface from a single registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,16 +34,19 @@ When you need to support clearing an optional field:
 
 ## Adding a New Tool
 
-When adding a new tool, it must be registered in **all** of these locations:
+`src/tool-registry.ts` is the single source of truth for the tool surface. `src/mcp-server.ts`, the `tools` export in `src/index.ts`, `scripts/run-tool.ts`, `scripts/validate-schemas.ts` and `src/token-footprint.test.ts` all derive from it, so adding a tool there wires it up everywhere.
 
-1. `src/utils/tool-names.ts` — add tool name constant
-2. `src/tools/<tool-name>.ts` — create tool definition
-3. `src/mcp-server.ts` — import, register with `registerTool()`, and add to LLM `instructions` string
-4. `src/index.ts` — import and add to both the `tools` object and the named exports
-5. `scripts/run-tool.ts` — import and add to the `tools` record
-6. `src/tools/tool-annotations.test.ts` — add annotation expectation entry
-7. `src/tools/<tool-name>.test.ts` — create test file
-8. `src/token-footprint.test.ts` — import the tool and append it to the `allTools` array so the token baseline keeps measuring the full surface. If the new tool's schema/description is large enough to push the combined fixed cost over `TOKEN_BUDGET`, raise the budget in the same PR and call it out in the description.
+1. `src/utils/tool-names.ts` — add the tool name constant
+2. `src/tools/<tool-name>.ts` — create the tool definition
+3. `src/tool-registry.ts` — add it to `registeredTools`, in the section it belongs to
+4. `src/index.ts` — add it to the `tools` object and the named exports (public API)
+5. `src/tools/<tool-name>.test.ts` — create the test file
+6. `src/tools/tool-annotations.test.ts` — add the annotation expectation entry
+7. `src/mcp-server.ts` — add to the `instructions` string **only** if the tool needs cross-tool routing guidance; per-tool detail belongs in the tool's own description
+
+`src/tool-registry.test.ts` enforces that steps 1, 3 and 4 agree with what the server actually registers, so a partial registration fails CI instead of silently degrading `lint:schemas` coverage or leaving the tool unreachable from `run-tool.ts`.
+
+If a new tool pushes the combined fixed cost over `TOKEN_BUDGET` in `src/token-footprint.test.ts`, raise the budget in the same PR and call it out in the description.
 
 ## Testing Requirements
 

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -39,10 +39,11 @@ src/
 ├─ main-http.ts               # Express entry: thin bootstrap — reads env, builds the app, listen()
 ├─ http-app.ts                # createHttpApp(): the Express app + middleware chain (Host/Origin guard scoped to /mcp). Pure/side-effect-free so it's testable
 ├─ index.ts                   # Public package exports — a curated subset of tools + helpers + types. NOT the full registry.
-├─ mcp-server.ts              # getMcpServer() factory. **Authoritative tool registry** — imports every tool, calls registerTool() for each, registers productivity-analysis prompt, contains the giant `instructions` string shown to the LLM
+├─ mcp-server.ts              # getMcpServer() factory. Iterates `registeredTools`, registers the productivity-analysis prompt, contains the giant `instructions` string shown to the LLM
+├─ tool-registry.ts           # **Authoritative tool registry** — the ordered list of every registered tool. mcp-server, index.ts, run-tool.ts, validate-schemas.ts and the token-footprint test all derive from it
 ├─ mcp-helpers.ts             # registerTool(), FEATURE_NAMES, output formatting, retry wrapping
 ├─ usage-tracking.ts          # Shared Todoist request headers + SDK customFetch wrapper for MCP usage attribution
-├─ todoist-tool.ts            # TodoistTool<Params, Output> contract (the tool interface)
+├─ todoist-tool.ts            # TodoistTool<Params, Output> contract (the tool interface) + AnyTodoistTool for mixed-shape collections
 ├─ tool-helpers.ts            # Shared transforms: mapTask, fetchAllPages, toWildcardQuery, compileWildcardQuery + matchesWildcardQuery (client-side name match), resolveInboxProjectId, isInboxProjectId, isPersonalProject, isWorkspaceProject. Re-exports filter-helpers.
 ├─ filter-helpers.ts          # appendToQuery, buildResponsibleUserQueryFilter, resolveResponsibleUser
 ├─ tool-execution-error.ts    # formatToolExecutionError (actionable API-error formatting, incl. known error_tag hints like MAX_ITEMS_LIMIT_REACHED) + formatBatchItemError (single-line per-item failure summaries — use in batch tools instead of error.message)
@@ -58,8 +59,8 @@ src/
 1. `main.ts` reads `TODOIST_API_KEY` (and optional `TODOIST_BASE_URL`) from env.
 2. Calls `getMcpServer()` in `mcp-server.ts`, which:
     - instantiates a shared tracked `TodoistApi` client via `usage-tracking.ts`,
-    - iterates every imported tool object and calls
-      `registerTool(server, tool, client, features)` from `mcp-helpers.ts`,
+    - iterates `registeredTools` from `tool-registry.ts` and calls
+      `registerTool({ tool, server, client, features })` from `mcp-helpers.ts`,
     - registers the `productivity-analysis` prompt,
     - returns the configured `McpServer`.
 3. `registerTool()` unwraps the `TodoistTool` contract, wires MCP's
@@ -118,7 +119,7 @@ Tool files are flat in `src/tools/` (kebab-case). Don't enumerate — grep. Curr
 - **Productivity/activity** — get-overview, get-productivity-stats, find-activity
 - **Generic** — delete-object, fetch, fetch-object, search, reorder-objects, view-attachment
 
-New tool? Full checklist in `AGENTS.md`. Short version: copy `add-tasks.ts`; import + register in `src/mcp-server.ts`; add tool name to `src/utils/tool-names.ts`; add to `src/index.ts` (exports) and `scripts/run-tool.ts` (direct-run registry); add annotation entry to `src/tools/tool-annotations.test.ts`; write `<tool-name>.test.ts` alongside it.
+New tool? Full checklist in `AGENTS.md`. Short version: copy `add-tasks.ts`; add the name to `src/utils/tool-names.ts`; add the tool to `src/tool-registry.ts` (everything else derives from it) and to `src/index.ts` (public exports); add an annotation entry to `src/tools/tool-annotations.test.ts`; write `<tool-name>.test.ts` alongside it. `src/tool-registry.test.ts` fails the build if those views disagree.
 
 ## `src/utils/` catalog — don't reimplement
 

--- a/scripts/run-tool.ts
+++ b/scripts/run-tool.ts
@@ -17,49 +17,7 @@
 import { readFileSync } from 'node:fs'
 import { TodoistApi } from '@doist/todoist-sdk'
 import { config } from 'dotenv'
-import { addComments } from '../src/tools/add-comments.js'
-import { addFilters } from '../src/tools/add-filters.js'
-import { addLabels } from '../src/tools/add-labels.js'
-import { addProjects } from '../src/tools/add-projects.js'
-import { addSections } from '../src/tools/add-sections.js'
-import { addTasks } from '../src/tools/add-tasks.js'
-import { analyzeProjectHealth } from '../src/tools/analyze-project-health.js'
-import { completeTasks } from '../src/tools/complete-tasks.js'
-import { deleteObject } from '../src/tools/delete-object.js'
-import { exportProjectTemplate } from '../src/tools/export-project-template.js'
-import { fetchObject } from '../src/tools/fetch-object.js'
-import { fetch } from '../src/tools/fetch.js'
-import { findActivity } from '../src/tools/find-activity.js'
-import { findComments } from '../src/tools/find-comments.js'
-import { findCompletedTasks } from '../src/tools/find-completed-tasks.js'
-import { findFilters } from '../src/tools/find-filters.js'
-import { findLabels } from '../src/tools/find-labels.js'
-import { findProjectCollaborators } from '../src/tools/find-project-collaborators.js'
-import { findProjects } from '../src/tools/find-projects.js'
-import { findSections } from '../src/tools/find-sections.js'
-import { findTasksByDate } from '../src/tools/find-tasks-by-date.js'
-import { findTasks } from '../src/tools/find-tasks.js'
-import { getOverview } from '../src/tools/get-overview.js'
-import { getProjectActivityStats } from '../src/tools/get-project-activity-stats.js'
-import { getProjectHealth } from '../src/tools/get-project-health.js'
-import { getWorkspaceInsights } from '../src/tools/get-workspace-insights.js'
-import { importProjectTemplate } from '../src/tools/import-project-template.js'
-import { listWorkspaces } from '../src/tools/list-workspaces.js'
-import { manageAssignments } from '../src/tools/manage-assignments.js'
-import { projectManagement } from '../src/tools/project-management.js'
-import { projectMove } from '../src/tools/project-move.js'
-import { reorderObjects } from '../src/tools/reorder-objects.js'
-import { rescheduleTasks } from '../src/tools/reschedule-tasks.js'
-import { search } from '../src/tools/search.js'
-import { uncompleteTasks } from '../src/tools/uncomplete-tasks.js'
-import { updateComments } from '../src/tools/update-comments.js'
-import { updateFilters } from '../src/tools/update-filters.js'
-import { updateLabels } from '../src/tools/update-labels.js'
-import { updateProjects } from '../src/tools/update-projects.js'
-import { updateSections } from '../src/tools/update-sections.js'
-import { updateTasks } from '../src/tools/update-tasks.js'
-import { userInfo } from '../src/tools/user-info.js'
-import { viewAttachment } from '../src/tools/view-attachment.js'
+import { registeredTools } from '../src/tool-registry.js'
 import { createTodoistClient, runWithUsageTrackingContext } from '../src/usage-tracking.js'
 
 config()
@@ -75,51 +33,9 @@ type ExecutableTool = {
     ) => Promise<{ textContent?: string; structuredContent?: unknown; contentItems?: unknown[] }>
 }
 
-const tools: Record<string, ExecutableTool> = {
-    'add-tasks': addTasks,
-    'add-projects': addProjects,
-    'add-filters': addFilters,
-    'add-sections': addSections,
-    'add-comments': addComments,
-    'add-labels': addLabels,
-    'complete-tasks': completeTasks,
-    'uncomplete-tasks': uncompleteTasks,
-    'delete-object': deleteObject,
-    fetch: fetch,
-    'fetch-object': fetchObject,
-    'find-activity': findActivity,
-    'find-comments': findComments,
-    'find-filters': findFilters,
-    'find-completed-tasks': findCompletedTasks,
-    'find-labels': findLabels,
-    'find-project-collaborators': findProjectCollaborators,
-    'find-projects': findProjects,
-    'find-sections': findSections,
-    'find-tasks': findTasks,
-    'find-tasks-by-date': findTasksByDate,
-    'get-overview': getOverview,
-    'get-project-health': getProjectHealth,
-    'get-project-activity-stats': getProjectActivityStats,
-    'analyze-project-health': analyzeProjectHealth,
-    'get-workspace-insights': getWorkspaceInsights,
-    'export-project-template': exportProjectTemplate,
-    'import-project-template': importProjectTemplate,
-    'list-workspaces': listWorkspaces,
-    'manage-assignments': manageAssignments,
-    'project-management': projectManagement,
-    'project-move': projectMove,
-    'reorder-objects': reorderObjects,
-    'reschedule-tasks': rescheduleTasks,
-    search: search,
-    'update-comments': updateComments,
-    'update-filters': updateFilters,
-    'update-labels': updateLabels,
-    'update-projects': updateProjects,
-    'update-sections': updateSections,
-    'update-tasks': updateTasks,
-    'user-info': userInfo,
-    'view-attachment': viewAttachment,
-}
+const tools: Record<string, ExecutableTool> = Object.fromEntries(
+    registeredTools.map((tool) => [tool.name, tool as ExecutableTool]),
+)
 
 function printUsage() {
     console.log(`

--- a/scripts/validate-schemas.ts
+++ b/scripts/validate-schemas.ts
@@ -158,11 +158,9 @@ function validateToolSchema(tool: {
  */
 async function validateAllSchemas(verbose: boolean = false): Promise<ValidationResult> {
     try {
-        const { registeredTools, tools } = await import(`${process.cwd()}/dist/index.js`)
+        const { registeredTools } = await import(`${process.cwd()}/dist/index.js`)
 
-        // `registeredTools` is the full MCP surface; `tools` is the older keyed
-        // export, kept as a fallback so a stale build still validates something.
-        const allTools = registeredTools ?? Object.values(tools)
+        const allTools = registeredTools
 
         const allIssues: ValidationIssue[] = []
         let totalParameters = 0

--- a/scripts/validate-schemas.ts
+++ b/scripts/validate-schemas.ts
@@ -158,14 +158,17 @@ function validateToolSchema(tool: {
  */
 async function validateAllSchemas(verbose: boolean = false): Promise<ValidationResult> {
     try {
-        const { tools } = await import(`${process.cwd()}/dist/index.js`)
+        const { registeredTools, tools } = await import(`${process.cwd()}/dist/index.js`)
+
+        // `registeredTools` is the full MCP surface; `tools` is the older keyed
+        // export, kept as a fallback so a stale build still validates something.
+        const allTools = registeredTools ?? Object.values(tools)
 
         const allIssues: ValidationIssue[] = []
         let totalParameters = 0
-        const toolNames = Object.keys(tools)
 
-        for (const toolName of toolNames) {
-            const tool = tools[toolName]
+        for (const tool of allTools) {
+            const toolName = tool.name
             const toolIssues = validateToolSchema(tool)
             allIssues.push(...toolIssues)
 
@@ -199,7 +202,7 @@ async function validateAllSchemas(verbose: boolean = false): Promise<ValidationR
         return {
             success: allIssues.length === 0,
             issues: allIssues,
-            toolsChecked: toolNames.length,
+            toolsChecked: allTools.length,
             parametersChecked: totalParameters,
         }
     } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import {
     requireValidTodoistToken,
     type RequireValidTodoistTokenOptions,
 } from './middleware/require-valid-todoist-token.js'
-import { registeredTools } from './tool-registry.js'
+import { registeredTools, toolRegistry } from './tool-registry.js'
 // Comment management tools
 import { addComments } from './tools/add-comments.js'
 // Filter management tools
@@ -64,71 +64,12 @@ import { userInfo } from './tools/user-info.js'
 import { viewAttachment } from './tools/view-attachment.js'
 import { validateTodoistToken } from './utils/validate-todoist-token.js'
 
-const tools = {
-    // Task management tools
-    addTasks,
-    completeTasks,
-    uncompleteTasks,
-    updateTasks,
-    findTasks,
-    findTasksByDate,
-    findCompletedTasks,
-    rescheduleTasks,
-    // Project management tools
-    addProjects,
-    updateProjects,
-    findProjects,
-    projectManagement,
-    projectMove,
-    // Section management tools
-    addSections,
-    updateSections,
-    findSections,
-    // Comment management tools
-    addComments,
-    updateComments,
-    findComments,
-    // Reminder management tools
-    addReminders,
-    findReminders,
-    updateReminders,
-    // Attachment tools
-    viewAttachment,
-    // Label management tools
-    addLabels,
-    updateLabels,
-    findLabels,
-    // Filter management tools
-    findFilters,
-    addFilters,
-    updateFilters,
-
-    // Activity and audit tools
-    findActivity,
-    getProductivityStats,
-    // Health and insights tools
-    getProjectHealth,
-    getProjectActivityStats,
-    analyzeProjectHealth,
-    getWorkspaceInsights,
-    // General tools
-    getOverview,
-    deleteObject,
-    fetchObject,
-    reorderObjects,
-    userInfo,
-    // Assignment and collaboration tools
-    findProjectCollaborators,
-    manageAssignments,
-    // Template tools
-    exportProjectTemplate,
-    importProjectTemplate,
-    // Workspace tools
-    listWorkspaces,
-    // OpenAI MCP tools
-    search,
-    fetch,
-}
+/**
+ * Every tool, keyed by its export name.
+ *
+ * Derived from the registry so it cannot drift from what the server registers.
+ */
+const tools = toolRegistry
 
 export {
     // Task management tools

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -3,7 +3,7 @@ import { registerAppTool } from '@modelcontextprotocol/ext-apps/server'
 import type { McpServer, ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { ContentBlock, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js'
 import type { z } from 'zod'
-import type { TodoistTool } from './todoist-tool.js'
+import type { AnyTodoistTool, ExecuteResult } from './todoist-tool.js'
 import { formatToolExecutionError } from './tool-execution-error.js'
 import { runWithUsageTrackingContext } from './usage-tracking.js'
 import { executeWithRetry } from './utils/retry.js'
@@ -234,13 +234,13 @@ function stripEmailsFromText(text: string): string {
 /**
  * Register a Todoist tool in an MCP server.
  */
-function registerTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape = z.ZodRawShape>({
+function registerTool({
     tool,
     server,
     client,
     features = [],
 }: {
-    tool: TodoistTool<Params, Output>
+    tool: AnyTodoistTool
     server: McpServer
     client: TodoistApi
     features?: Features
@@ -249,14 +249,25 @@ function registerTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape
         features.some((f) => f.name === 'strip_emails') &&
         TOOLS_WITH_USER_EMAILS.includes(tool.name as (typeof TOOLS_WITH_USER_EMAILS)[number])
 
-    // @ts-expect-error I give up
-    const cb: ToolCallback<Params> = async (args: z.infer<z.ZodObject<Params>>, _context) => {
+    // `AnyTodoistTool` declares `args` as `never` so that tools of every
+    // parameter shape can be held in one collection. Widening it back is safe
+    // here and only here: the SDK has already validated `args` against this
+    // tool's own `inputSchema` before invoking the callback.
+    const execute = tool.execute as (
+        args: Record<string, unknown>,
+        client: TodoistApi,
+    ) => ExecuteResult<z.ZodRawShape>
+
+    // `getToolOutput` assembles its result incrementally and so is typed as a
+    // plain record, which does not structurally match `CallToolResult` (that
+    // requires `content`). The values it produces are valid results; only the
+    // static shape is looser.
+    // @ts-expect-error see above
+    const cb: ToolCallback<z.ZodRawShape> = async (args, _context) => {
         try {
             let { textContent, structuredContent, contentItems } =
                 await runWithUsageTrackingContext(tool.name, () =>
-                    executeWithRetry(() =>
-                        tool.execute(args as z.infer<z.ZodObject<Params>>, client),
-                    ),
+                    executeWithRetry(() => execute(args, client)),
                 )
 
             // Strip emails from outputs for ChatGPT clients on collaborator-related tools
@@ -279,7 +290,7 @@ function registerTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape
     const toolConfig = {
         description: tool.description,
         inputSchema: tool.parameters,
-        ...(tool.outputSchema ? { outputSchema: tool.outputSchema as Output } : {}),
+        ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
         annotations: getMcpAnnotations(tool),
         ...(tool._meta ? { _meta: tool._meta } : {}),
     }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-import { registerTaskListApp, taskListResourceUri } from './mcp-apps/resources.js'
+import { registerTaskListApp } from './mcp-apps/resources.js'
 import {
     FEATURE_NAMES,
     type Feature,
@@ -9,53 +9,7 @@ import {
     registerTool,
 } from './mcp-helpers.js'
 import { productivityAnalysis } from './prompts/productivity-analysis.js'
-import { addComments } from './tools/add-comments.js'
-import { addFilters } from './tools/add-filters.js'
-import { addLabels } from './tools/add-labels.js'
-import { addProjects } from './tools/add-projects.js'
-import { addReminders } from './tools/add-reminders.js'
-import { addSections } from './tools/add-sections.js'
-import { addTasks } from './tools/add-tasks.js'
-import { analyzeProjectHealth } from './tools/analyze-project-health.js'
-import { completeTasks } from './tools/complete-tasks.js'
-import { deleteObject } from './tools/delete-object.js'
-import { exportProjectTemplate } from './tools/export-project-template.js'
-import { fetchObject } from './tools/fetch-object.js'
-import { fetch } from './tools/fetch.js'
-import { findActivity } from './tools/find-activity.js'
-import { findComments } from './tools/find-comments.js'
-import { findCompletedTasks } from './tools/find-completed-tasks.js'
-import { findFilters } from './tools/find-filters.js'
-import { findLabels } from './tools/find-labels.js'
-import { findProjectCollaborators } from './tools/find-project-collaborators.js'
-import { findProjects } from './tools/find-projects.js'
-import { findReminders } from './tools/find-reminders.js'
-import { findSections } from './tools/find-sections.js'
-import { findTasksByDate } from './tools/find-tasks-by-date.js'
-import { findTasks } from './tools/find-tasks.js'
-import { getOverview } from './tools/get-overview.js'
-import { getProductivityStats } from './tools/get-productivity-stats.js'
-import { getProjectActivityStats } from './tools/get-project-activity-stats.js'
-import { getProjectHealth } from './tools/get-project-health.js'
-import { getWorkspaceInsights } from './tools/get-workspace-insights.js'
-import { importProjectTemplate } from './tools/import-project-template.js'
-import { listWorkspaces } from './tools/list-workspaces.js'
-import { manageAssignments } from './tools/manage-assignments.js'
-import { projectManagement } from './tools/project-management.js'
-import { projectMove } from './tools/project-move.js'
-import { reorderObjects } from './tools/reorder-objects.js'
-import { rescheduleTasks } from './tools/reschedule-tasks.js'
-import { search } from './tools/search.js'
-import { uncompleteTasks } from './tools/uncomplete-tasks.js'
-import { updateComments } from './tools/update-comments.js'
-import { updateFilters } from './tools/update-filters.js'
-import { updateLabels } from './tools/update-labels.js'
-import { updateProjects } from './tools/update-projects.js'
-import { updateReminders } from './tools/update-reminders.js'
-import { updateSections } from './tools/update-sections.js'
-import { updateTasks } from './tools/update-tasks.js'
-import { userInfo } from './tools/user-info.js'
-import { viewAttachment } from './tools/view-attachment.js'
+import { registeredTools } from './tool-registry.js'
 import { TODOIST_MCP_VERSION, createTodoistClient } from './usage-tracking.js'
 
 export const instructions = `
@@ -195,98 +149,18 @@ function getMcpServer({
     /**
      * MCP Apps
      */
-    const findTasksByDateToolWithUi = {
-        ...findTasksByDate,
-        _meta: {
-            ui: {
-                resourceUri: taskListResourceUri,
-            },
-        },
-    }
-
     registerTaskListApp(server)
 
     /**
      * Tools
+     *
+     * The surface is defined by `registeredTools`; see `tool-registry.ts`.
      */
     const toolArgs = { server, client: todoist, features }
 
-    // Task management tools
-    registerTool({ tool: addTasks, ...toolArgs })
-    registerTool({ tool: completeTasks, ...toolArgs })
-    registerTool({ tool: uncompleteTasks, ...toolArgs })
-    registerTool({ tool: updateTasks, ...toolArgs })
-    registerTool({ tool: rescheduleTasks, ...toolArgs })
-    registerTool({ tool: findTasks, ...toolArgs })
-    registerTool({ tool: findTasksByDateToolWithUi, ...toolArgs })
-    registerTool({ tool: findCompletedTasks, ...toolArgs })
-
-    // Project management tools
-    registerTool({ tool: addProjects, ...toolArgs })
-    registerTool({ tool: updateProjects, ...toolArgs })
-    registerTool({ tool: findProjects, ...toolArgs })
-    registerTool({ tool: projectManagement, ...toolArgs })
-    registerTool({ tool: projectMove, ...toolArgs })
-
-    // Section management tools
-    registerTool({ tool: addSections, ...toolArgs })
-    registerTool({ tool: updateSections, ...toolArgs })
-    registerTool({ tool: findSections, ...toolArgs })
-
-    // Comment management tools
-    registerTool({ tool: addComments, ...toolArgs })
-    registerTool({ tool: findComments, ...toolArgs })
-    registerTool({ tool: updateComments, ...toolArgs })
-
-    // Reminder management tools
-    registerTool({ tool: addReminders, ...toolArgs })
-    registerTool({ tool: findReminders, ...toolArgs })
-    registerTool({ tool: updateReminders, ...toolArgs })
-
-    // Attachment tools
-    registerTool({ tool: viewAttachment, ...toolArgs })
-
-    // Label management tools
-    registerTool({ tool: addLabels, ...toolArgs })
-    registerTool({ tool: updateLabels, ...toolArgs })
-    registerTool({ tool: findLabels, ...toolArgs })
-
-    // Filter management tools
-    registerTool({ tool: findFilters, ...toolArgs })
-    registerTool({ tool: addFilters, ...toolArgs })
-    registerTool({ tool: updateFilters, ...toolArgs })
-
-    // Activity and audit tools
-    registerTool({ tool: findActivity, ...toolArgs })
-    registerTool({ tool: getProductivityStats, ...toolArgs })
-
-    // Health and insights tools
-    registerTool({ tool: getProjectHealth, ...toolArgs })
-    registerTool({ tool: getProjectActivityStats, ...toolArgs })
-    registerTool({ tool: analyzeProjectHealth, ...toolArgs })
-    registerTool({ tool: getWorkspaceInsights, ...toolArgs })
-
-    // General tools
-    registerTool({ tool: getOverview, ...toolArgs })
-    registerTool({ tool: deleteObject, ...toolArgs })
-    registerTool({ tool: fetchObject, ...toolArgs })
-    registerTool({ tool: reorderObjects, ...toolArgs })
-    registerTool({ tool: userInfo, ...toolArgs })
-
-    // Assignment and collaboration tools
-    registerTool({ tool: findProjectCollaborators, ...toolArgs })
-    registerTool({ tool: manageAssignments, ...toolArgs })
-
-    // Template tools
-    registerTool({ tool: exportProjectTemplate, ...toolArgs })
-    registerTool({ tool: importProjectTemplate, ...toolArgs })
-
-    // Workspace tools
-    registerTool({ tool: listWorkspaces, ...toolArgs })
-
-    // OpenAI MCP tools
-    registerTool({ tool: search, ...toolArgs })
-    registerTool({ tool: fetch, ...toolArgs })
+    for (const tool of registeredTools) {
+        registerTool({ tool, ...toolArgs })
+    }
 
     /**
      * Prompts

--- a/src/todoist-tool.ts
+++ b/src/todoist-tool.ts
@@ -71,4 +71,20 @@ type TodoistTool<
     execute: (args: z.infer<z.ZodObject<Params>>, client: TodoistApi) => ExecuteResult<Output>
 }
 
-export type { RequiredToolAnnotations, TodoistTool }
+/**
+ * A tool of any parameter and output shape.
+ *
+ * `TodoistTool` is generic over its schemas, and `execute` is contravariant in
+ * its argument, so no single instantiation of it accepts every tool. Declaring
+ * the argument as `never` does: `never` is assignable to any parameter type, so
+ * a tool taking concrete args satisfies this while a caller cannot invoke
+ * `execute` without narrowing back to the real tool type first.
+ *
+ * Use this for collections that hold tools of mixed shapes. Individual tools
+ * keep their precise types through their own `satisfies TodoistTool<...>`.
+ */
+type AnyTodoistTool = Omit<TodoistTool<z.ZodRawShape, z.ZodRawShape>, 'execute'> & {
+    execute: (args: never, client: TodoistApi) => ExecuteResult<z.ZodRawShape>
+}
+
+export type { AnyTodoistTool, ExecuteResult, RequiredToolAnnotations, TodoistTool }

--- a/src/token-footprint.test.ts
+++ b/src/token-footprint.test.ts
@@ -3,106 +3,15 @@ import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 
 import { instructions } from './mcp-server.js'
-import type { TodoistTool } from './todoist-tool.js'
-import { addComments } from './tools/add-comments.js'
-import { addFilters } from './tools/add-filters.js'
-import { addLabels } from './tools/add-labels.js'
-import { addProjects } from './tools/add-projects.js'
-import { addReminders } from './tools/add-reminders.js'
-import { addSections } from './tools/add-sections.js'
-import { addTasks } from './tools/add-tasks.js'
-import { analyzeProjectHealth } from './tools/analyze-project-health.js'
-import { completeTasks } from './tools/complete-tasks.js'
-import { deleteObject } from './tools/delete-object.js'
-import { exportProjectTemplate } from './tools/export-project-template.js'
-import { fetchObject } from './tools/fetch-object.js'
-import { fetch } from './tools/fetch.js'
-import { findActivity } from './tools/find-activity.js'
-import { findComments } from './tools/find-comments.js'
-import { findCompletedTasks } from './tools/find-completed-tasks.js'
-import { findFilters } from './tools/find-filters.js'
-import { findLabels } from './tools/find-labels.js'
-import { findProjectCollaborators } from './tools/find-project-collaborators.js'
-import { findProjects } from './tools/find-projects.js'
-import { findReminders } from './tools/find-reminders.js'
-import { findSections } from './tools/find-sections.js'
-import { findTasksByDate } from './tools/find-tasks-by-date.js'
-import { findTasks } from './tools/find-tasks.js'
-import { getOverview } from './tools/get-overview.js'
-import { getProductivityStats } from './tools/get-productivity-stats.js'
-import { getProjectActivityStats } from './tools/get-project-activity-stats.js'
-import { getProjectHealth } from './tools/get-project-health.js'
-import { getWorkspaceInsights } from './tools/get-workspace-insights.js'
-import { importProjectTemplate } from './tools/import-project-template.js'
-import { listWorkspaces } from './tools/list-workspaces.js'
-import { manageAssignments } from './tools/manage-assignments.js'
-import { projectManagement } from './tools/project-management.js'
-import { projectMove } from './tools/project-move.js'
-import { reorderObjects } from './tools/reorder-objects.js'
-import { rescheduleTasks } from './tools/reschedule-tasks.js'
-import { search } from './tools/search.js'
-import { uncompleteTasks } from './tools/uncomplete-tasks.js'
-import { updateComments } from './tools/update-comments.js'
-import { updateFilters } from './tools/update-filters.js'
-import { updateLabels } from './tools/update-labels.js'
-import { updateProjects } from './tools/update-projects.js'
-import { updateReminders } from './tools/update-reminders.js'
-import { updateSections } from './tools/update-sections.js'
-import { updateTasks } from './tools/update-tasks.js'
-import { userInfo } from './tools/user-info.js'
-import { viewAttachment } from './tools/view-attachment.js'
+import type { AnyTodoistTool } from './todoist-tool.js'
+import { registeredTools } from './tool-registry.js'
 
-// Mirror of getMcpServer()'s registration order, minus the runtime client.
-// Keep in sync when tools are added/removed.
-const allTools: TodoistTool<z.ZodRawShape, z.ZodRawShape>[] = [
-    addTasks,
-    completeTasks,
-    uncompleteTasks,
-    updateTasks,
-    rescheduleTasks,
-    findTasks,
-    findTasksByDate,
-    findCompletedTasks,
-    addProjects,
-    updateProjects,
-    findProjects,
-    projectManagement,
-    projectMove,
-    addSections,
-    updateSections,
-    findSections,
-    addComments,
-    findComments,
-    updateComments,
-    addReminders,
-    findReminders,
-    updateReminders,
-    viewAttachment,
-    addLabels,
-    updateLabels,
-    findLabels,
-    findFilters,
-    addFilters,
-    updateFilters,
-    findActivity,
-    getProductivityStats,
-    getProjectHealth,
-    getProjectActivityStats,
-    analyzeProjectHealth,
-    getWorkspaceInsights,
-    getOverview,
-    deleteObject,
-    fetchObject,
-    reorderObjects,
-    userInfo,
-    findProjectCollaborators,
-    manageAssignments,
-    listWorkspaces,
-    exportProjectTemplate,
-    importProjectTemplate,
-    search,
-    fetch,
-] as unknown as TodoistTool<z.ZodRawShape, z.ZodRawShape>[]
+// The SDK serializes tool schemas with these options; see `toJsonSchemaCompat`
+// in @modelcontextprotocol/sdk's server/mcp.js. Zod defaults `io` to 'output',
+// which measures a schema the wire never carries — for tools using `.pipe()`
+// that can be several times the real cost. Keep these in step with the SDK.
+const INPUT_SCHEMA_OPTIONS = { unrepresentable: 'any', io: 'input', target: 'draft-7' } as const
+const OUTPUT_SCHEMA_OPTIONS = { unrepresentable: 'any', io: 'output', target: 'draft-7' } as const
 
 function tokens(text: string): number {
     return encode(text).length
@@ -116,12 +25,12 @@ function formatToolTitle(name: string): string {
         .join(' ')
 }
 
-function buildToolListEntry(tool: TodoistTool<z.ZodRawShape, z.ZodRawShape>) {
+function buildToolListEntry(tool: AnyTodoistTool) {
     const entry: Record<string, unknown> = {
         name: tool.name,
         title: `Todoist: ${formatToolTitle(tool.name)}`,
         description: tool.description,
-        inputSchema: z.toJSONSchema(z.object(tool.parameters), { unrepresentable: 'any' }),
+        inputSchema: z.toJSONSchema(z.object(tool.parameters), INPUT_SCHEMA_OPTIONS),
         annotations: {
             title: `Todoist: ${formatToolTitle(tool.name)}`,
             openWorldHint: false,
@@ -129,7 +38,7 @@ function buildToolListEntry(tool: TodoistTool<z.ZodRawShape, z.ZodRawShape>) {
         },
     }
     if (tool.outputSchema) {
-        entry.outputSchema = z.toJSONSchema(z.object(tool.outputSchema), { unrepresentable: 'any' })
+        entry.outputSchema = z.toJSONSchema(z.object(tool.outputSchema), OUTPUT_SCHEMA_OPTIONS)
     }
     return entry
 }
@@ -143,7 +52,7 @@ type Row = {
 }
 
 function measure(): Row[] {
-    return allTools.map((tool) => {
+    return registeredTools.map((tool) => {
         const entry = buildToolListEntry(tool)
         const inputSchemaJson = JSON.stringify(entry.inputSchema)
         const outputSchemaJson = entry.outputSchema ? JSON.stringify(entry.outputSchema) : ''
@@ -175,7 +84,7 @@ describe('token footprint baseline', () => {
         const lines: string[] = []
         lines.push('')
         lines.push('=== MCP token footprint baseline ===')
-        lines.push(`tools registered:    ${allTools.length}`)
+        lines.push(`tools registered:    ${registeredTools.length}`)
         lines.push(`instructions string: ${instructionsTokens} tokens`)
         lines.push(`tools/list payload:  ${toolsListTotal} tokens`)
         lines.push(`combined fixed cost: ${combinedFixed} tokens`)

--- a/src/token-footprint.test.ts
+++ b/src/token-footprint.test.ts
@@ -25,6 +25,23 @@ function formatToolTitle(name: string): string {
         .join(' ')
 }
 
+/**
+ * Mirror of the `_meta` normalisation `registerAppTool` applies, which fills in
+ * whichever of the two widget resource-URI spellings the tool did not declare.
+ */
+function normalizeAppUiMeta(meta: Record<string, unknown>): Record<string, unknown> {
+    const ui = meta.ui as { resourceUri?: string } | undefined
+    const legacyUri = meta['ui/resourceUri']
+
+    if (ui?.resourceUri && !legacyUri) {
+        return { ...meta, 'ui/resourceUri': ui.resourceUri }
+    }
+    if (typeof legacyUri === 'string' && !ui?.resourceUri) {
+        return { ...meta, ui: { ...ui, resourceUri: legacyUri } }
+    }
+    return meta
+}
+
 function buildToolListEntry(tool: AnyTodoistTool) {
     const entry: Record<string, unknown> = {
         name: tool.name,
@@ -39,6 +56,13 @@ function buildToolListEntry(tool: AnyTodoistTool) {
     }
     if (tool.outputSchema) {
         entry.outputSchema = z.toJSONSchema(z.object(tool.outputSchema), OUTPUT_SCHEMA_OPTIONS)
+    }
+    if (tool._meta) {
+        // The SDK forwards `_meta` on every tools/list entry, so it is part of
+        // the fixed cost. Registration normalises the widget resource URI into
+        // both the `ui.resourceUri` and `ui/resourceUri` spellings; mirror that
+        // or the measurement undercounts the tools that carry one.
+        entry._meta = normalizeAppUiMeta(tool._meta)
     }
     return entry
 }

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { tools } from './index.js'
+import { registeredTools } from './tool-registry.js'
+import { ToolNames } from './utils/tool-names.js'
+
+/**
+ * `registeredTools` is the single source of truth for the tool surface, but a
+ * couple of places still keep their own view of it. These tests fail when those
+ * views drift, which is how six tools once went missing from the public `tools`
+ * export — silently reducing `npm run lint:schemas` coverage — while four others
+ * became uninvokable through `scripts/run-tool.ts`.
+ *
+ * `mcp-server.ts` needs no assertion here: it registers by iterating this array,
+ * so it cannot disagree with it. That every registered tool is also annotated is
+ * covered by `tools/tool-annotations.test.ts`.
+ */
+describe('tool registry', () => {
+    const registryNames = registeredTools.map((tool) => tool.name).sort()
+
+    it('has no duplicate entries', () => {
+        expect(registryNames).toEqual([...new Set(registryNames)])
+    })
+
+    it('matches the ToolNames enum', () => {
+        expect(registryNames).toEqual(Object.values(ToolNames).sort())
+    })
+
+    it('matches the public tools export', () => {
+        const exported = Object.values(tools)
+            .map((tool) => tool.name)
+            .sort()
+        expect(exported).toEqual(registryNames)
+    })
+
+    it('is fully reachable through scripts/run-tool.ts', () => {
+        // The script builds its lookup from the registry, so this guards the
+        // wiring rather than a second list.
+        const source = readFileSync(join(import.meta.dirname, '../scripts/run-tool.ts'), 'utf8')
+        expect(source).toContain("import { registeredTools } from '../src/tool-registry.js'")
+        expect(source).toMatch(/registeredTools\.map\(\(tool\) => \[tool\.name, /)
+    })
+})

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -2,8 +2,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-import { tools } from './index.js'
-import { registeredTools } from './tool-registry.js'
+import { registeredTools, toolRegistry } from './tool-registry.js'
 import { ToolNames } from './utils/tool-names.js'
 
 /**
@@ -28,18 +27,25 @@ describe('tool registry', () => {
         expect(registryNames).toEqual(Object.values(ToolNames).sort())
     })
 
-    it('matches the public tools export', () => {
-        const exported = Object.values(tools)
-            .map((tool) => tool.name)
-            .sort()
-        expect(exported).toEqual(registryNames)
+    it('is what the public tools export is built from', async () => {
+        const { tools } = await import('./index.js')
+        expect(tools).toBe(toolRegistry)
     })
 
-    it('is fully reachable through scripts/run-tool.ts', () => {
-        // The script builds its lookup from the registry, so this guards the
-        // wiring rather than a second list.
+    it('has a named package export for every tool', async () => {
+        // `tools` is derived, but the named re-exports that let consumers write
+        // `import { addTasks } from '@doist/todoist-mcp'` are still written out
+        // by hand, so they can fall behind the registry.
+        const packageExports = await import('./index.js')
+        const missing = Object.keys(toolRegistry).filter((key) => !(key in packageExports))
+        expect(missing).toEqual([])
+    })
+
+    it('is what scripts/run-tool.ts builds its lookup from', () => {
+        // run-tool.ts calls main() at module scope, so it cannot be imported
+        // here. It derives its lookup by iterating the registry and so cannot
+        // hold a divergent list; this only checks that wiring is still in place.
         const source = readFileSync(join(import.meta.dirname, '../scripts/run-tool.ts'), 'utf8')
-        expect(source).toContain("import { registeredTools } from '../src/tool-registry.js'")
-        expect(source).toMatch(/registeredTools\.map\(\(tool\) => \[tool\.name, /)
+        expect(source).toContain("from '../src/tool-registry.js'")
     })
 })

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -1,38 +1,23 @@
-import { FEATURE_NAMES, type Feature, type FeatureName, type Features } from './mcp-helpers.js'
-import { getMcpServer } from './mcp-server.js'
-import {
-    requireValidTodoistToken,
-    type RequireValidTodoistTokenOptions,
-} from './middleware/require-valid-todoist-token.js'
-import { registeredTools } from './tool-registry.js'
-// Comment management tools
+import { taskListResourceUri } from './mcp-apps/resources.js'
+import type { AnyTodoistTool } from './todoist-tool.js'
 import { addComments } from './tools/add-comments.js'
-// Filter management tools
 import { addFilters } from './tools/add-filters.js'
-// Label management tools
 import { addLabels } from './tools/add-labels.js'
-// Project management tools
 import { addProjects } from './tools/add-projects.js'
-// Reminder management tools
 import { addReminders } from './tools/add-reminders.js'
-// Section management tools
 import { addSections } from './tools/add-sections.js'
-// Task management tools
 import { addTasks } from './tools/add-tasks.js'
 import { analyzeProjectHealth } from './tools/analyze-project-health.js'
 import { completeTasks } from './tools/complete-tasks.js'
-// General tools
 import { deleteObject } from './tools/delete-object.js'
 import { exportProjectTemplate } from './tools/export-project-template.js'
 import { fetchObject } from './tools/fetch-object.js'
 import { fetch } from './tools/fetch.js'
-// Activity and audit tools
 import { findActivity } from './tools/find-activity.js'
 import { findComments } from './tools/find-comments.js'
 import { findCompletedTasks } from './tools/find-completed-tasks.js'
 import { findFilters } from './tools/find-filters.js'
 import { findLabels } from './tools/find-labels.js'
-// Assignment and collaboration tools
 import { findProjectCollaborators } from './tools/find-project-collaborators.js'
 import { findProjects } from './tools/find-projects.js'
 import { findReminders } from './tools/find-reminders.js'
@@ -62,42 +47,75 @@ import { updateSections } from './tools/update-sections.js'
 import { updateTasks } from './tools/update-tasks.js'
 import { userInfo } from './tools/user-info.js'
 import { viewAttachment } from './tools/view-attachment.js'
-import { validateTodoistToken } from './utils/validate-todoist-token.js'
 
-const tools = {
+/**
+ * `find-tasks-by-date` backed by the interactive task-list widget.
+ *
+ * The `_meta.ui` marker is what routes a tool through the MCP Apps registration
+ * path and tells a host which resource to render its results with.
+ */
+const findTasksByDateWithUi = {
+    ...findTasksByDate,
+    _meta: {
+        ui: {
+            resourceUri: taskListResourceUri,
+        },
+    },
+}
+
+/**
+ * Every tool the MCP server exposes, in registration order.
+ *
+ * This is the single source of truth for the tool surface. The MCP server, the
+ * package's public `tools` export, the schema validator and the token-footprint
+ * baseline all derive from this array, so a tool added here is picked up
+ * everywhere. `tool-registry.test.ts` fails the build if those views ever
+ * disagree.
+ *
+ * Note this holds the *registered* objects, which is not always the bare tool
+ * definition — `find-tasks-by-date` is wrapped to carry its widget metadata.
+ */
+const registeredTools: readonly AnyTodoistTool[] = [
     // Task management tools
     addTasks,
     completeTasks,
     uncompleteTasks,
     updateTasks,
-    findTasks,
-    findTasksByDate,
-    findCompletedTasks,
     rescheduleTasks,
+    findTasks,
+    findTasksByDateWithUi,
+    findCompletedTasks,
+
     // Project management tools
     addProjects,
     updateProjects,
     findProjects,
     projectManagement,
     projectMove,
+
     // Section management tools
     addSections,
     updateSections,
     findSections,
+
     // Comment management tools
     addComments,
-    updateComments,
     findComments,
+    updateComments,
+
     // Reminder management tools
     addReminders,
     findReminders,
     updateReminders,
+
     // Attachment tools
     viewAttachment,
+
     // Label management tools
     addLabels,
     updateLabels,
     findLabels,
+
     // Filter management tools
     findFilters,
     addFilters,
@@ -106,104 +124,34 @@ const tools = {
     // Activity and audit tools
     findActivity,
     getProductivityStats,
-    // Health and insights tools
-    getProjectHealth,
-    getProjectActivityStats,
-    analyzeProjectHealth,
-    getWorkspaceInsights,
-    // General tools
-    getOverview,
-    deleteObject,
-    fetchObject,
-    reorderObjects,
-    userInfo,
-    // Assignment and collaboration tools
-    findProjectCollaborators,
-    manageAssignments,
-    // Template tools
-    exportProjectTemplate,
-    importProjectTemplate,
-    // Workspace tools
-    listWorkspaces,
-    // OpenAI MCP tools
-    search,
-    fetch,
-}
 
-export {
-    // Task management tools
-    addTasks,
-    completeTasks,
-    findTasks,
-    findTasksByDate,
-    findCompletedTasks,
-    rescheduleTasks,
-    // Project management tools
-    addProjects,
-    findProjects,
-    analyzeProjectHealth,
-    projectManagement,
-    projectMove,
-    // Section management tools
-    addSections,
-    findSections,
-    // Comment management tools
-    addComments,
-    findComments,
-    // Reminder management tools
-    addReminders,
-    findReminders,
-    updateReminders,
-    // Label management tools
-    addLabels,
-    findLabels,
-    updateLabels,
-    // Filter management tools
-    addFilters,
-    findFilters,
-    // Activity and audit tools
-    findActivity,
-    getProductivityStats,
     // Health and insights tools
     getProjectHealth,
     getProjectActivityStats,
+    analyzeProjectHealth,
     getWorkspaceInsights,
+
+    // General tools
+    getOverview,
+    deleteObject,
+    fetchObject,
+    reorderObjects,
+    userInfo,
+
     // Assignment and collaboration tools
     findProjectCollaborators,
     manageAssignments,
+
     // Template tools
     exportProjectTemplate,
     importProjectTemplate,
+
     // Workspace tools
     listWorkspaces,
-    // Attachment tools
-    viewAttachment,
-    // General tools
-    deleteObject,
-    fetchObject,
-    getOverview,
-    reorderObjects,
-    userInfo,
-    uncompleteTasks,
-    updateComments,
-    updateFilters,
-    updateProjects,
-    updateSections,
-    updateTasks,
+
     // OpenAI MCP tools
     search,
     fetch,
-    // Server and types
-    getMcpServer,
-    tools,
-    registeredTools,
-    FEATURE_NAMES,
-    type Feature,
-    type FeatureName,
-    type Features,
-    // Token validation middleware
-    requireValidTodoistToken,
-    type RequireValidTodoistTokenOptions,
-    // Token validation utility
-    validateTodoistToken,
-}
+]
+
+export { findTasksByDateWithUi, registeredTools }

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -64,18 +64,17 @@ const findTasksByDateWithUi = {
 }
 
 /**
- * Every tool the MCP server exposes, in registration order.
+ * Every tool the MCP server exposes, keyed by its public export name and held
+ * in registration order.
  *
  * This is the single source of truth for the tool surface. The MCP server, the
  * package's public `tools` export, the schema validator and the token-footprint
- * baseline all derive from this array, so a tool added here is picked up
- * everywhere. `tool-registry.test.ts` fails the build if those views ever
- * disagree.
+ * baseline all derive from it, so a tool added here is picked up everywhere.
  *
  * Note this holds the *registered* objects, which is not always the bare tool
  * definition — `find-tasks-by-date` is wrapped to carry its widget metadata.
  */
-const registeredTools: readonly AnyTodoistTool[] = [
+const toolRegistry = {
     // Task management tools
     addTasks,
     completeTasks,
@@ -83,7 +82,7 @@ const registeredTools: readonly AnyTodoistTool[] = [
     updateTasks,
     rescheduleTasks,
     findTasks,
-    findTasksByDateWithUi,
+    findTasksByDate: findTasksByDateWithUi,
     findCompletedTasks,
 
     // Project management tools
@@ -152,6 +151,14 @@ const registeredTools: readonly AnyTodoistTool[] = [
     // OpenAI MCP tools
     search,
     fetch,
-]
+}
 
-export { findTasksByDateWithUi, registeredTools }
+/**
+ * The registered tools in registration order.
+ *
+ * `tools/list` preserves this ordering, which is insertion order on
+ * {@link toolRegistry}.
+ */
+const registeredTools: readonly AnyTodoistTool[] = Object.values(toolRegistry)
+
+export { registeredTools, toolRegistry }


### PR DESCRIPTION
First of four PRs from #558. No behaviour change — nothing a client receives is different. This one makes the tool surface derive from one place, so the later token work is measuring something trustworthy.

## The drift

`AGENTS.md` told contributors to register each new tool by hand in eight places. Measured against the 47 tools the server actually registers, three of those lists had silently drifted:

| List | State before |
|---|---|
| `src/utils/tool-names.ts` | complete — and the only one with a test asserting it |
| `src/index.ts` `tools` | missing 6: `project-management`, `project-move`, `add-reminders`, `find-reminders`, `update-reminders`, `fetch-object` |
| `scripts/run-tool.ts` | missing 4: `add-reminders`, `find-reminders`, `update-reminders`, `get-productivity-stats` |
| `src/token-footprint.test.ts` | mirrored the bare `findTasksByDate`, not the widget-wrapped object that is actually registered |

`scripts/validate-schemas.ts` iterates the `src/index.ts` export, so `npm run lint:schemas` — the Gemini-compatibility guardrail — had been checking 41 of 47 tools. It now reports `Checked 47 tools with 118 parameters`. The four missing from `run-tool.ts` could not be invoked at all.

The only list that stayed correct is the only one under test. A longer checklist was never going to fix this, so the duplicate lists are gone rather than corrected.

## What changed

`src/tool-registry.ts` is now the single source of truth. `mcp-server.ts` registers by iterating it, and the public `tools` export, `run-tool.ts`, `validate-schemas.ts` and the token-footprint baseline all derive from it. `src/tool-registry.test.ts` fails the build when the remaining views disagree — verified by removing a tool and watching it report 44 against 47.

The `AGENTS.md` checklist drops from eight registration points to one, and `CODEBASE.md` picks up the registry.

## Measurement fix

`token-footprint.test.ts` serialised input schemas with Zod's default `io: 'output'`, while the SDK emits `io: 'input'` with `target: 'draft-7'`. For tools using `.pipe()` that gap is large — `find-activity` measured 938 tokens against an actual 369, because on the output side the pipe resolves to two full ISO regexes.

Reported baseline moves from 40,508 to 39,437. Nothing on the wire changed; the old number was simply wrong. The budget constant stays at 41,000 in this PR and drops in the next one.

## registerTool is no longer generic

Everything `registerTool` does with a tool is dynamic. The generic existed only to type a callback that was already suppressed with `// @ts-expect-error I give up`, so dropping it removes that suppression on the argument path. The remaining one is narrowed to the real cause — `getToolOutput` builds its result incrementally and so is typed looser than `CallToolResult` — and explained in place.

`AnyTodoistTool` declares `execute`'s argument as `never`, which is what lets tools of every parameter shape sit in one collection without a cast: `never` is assignable to any parameter type, so storing a tool is safe while calling it still requires narrowing. The one widening happens inside `registerTool`, where the SDK has already validated the arguments against that tool's own `inputSchema`.

## Verification

- `npm test` — 72 files, 1132 tests
- `npm run type-check`, `npm run format:check` clean
- `npm run lint:schemas` — 47 tools, up from 41
- `getMcpServer()` still registers 47 tools, and `find-tasks-by-date` keeps its `outputSchema` and both `_meta` spellings of the widget resource URI

Downstream `todoist-ai-integrations` needs no change: it calls `getMcpServer({ todoistApiKey, baseUrl, features })`, whose signature is untouched. Its `Object.values(tools)` path in `src/shared/tool-call.ts` gains the six previously-missing tools, which is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
