### PR TITLE
feat: advertise output schemas only for widget-backed tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,14 @@ When you need to support clearing an optional field:
 - Maintains backward compatibility through dual handling
 - Creates self-documenting APIs with explicit action strings
 
+### Output schemas are declared but not advertised
+
+Keep declaring `outputSchema` on every tool that returns `structuredContent` — it types the return, documents the shape, and is checked in tests.
+
+It is **not** sent to clients. Output schemas were over half the fixed cost of `tools/list`, and a client only needs one to validate structured output or render a widget from it, so `registerTool` advertises it only for tools carrying widget metadata (`_meta.ui`). Tools return `structuredContent` either way.
+
+The consequence for tool authors: the model never sees your output schema, so anything it needs to know about the result belongs in the tool's `description`. Because the SDK's own output validation only runs for advertised schemas, `registerTool` re-checks output against the declared schema when `NODE_ENV === 'test'` — a schema that drifts from what the tool returns fails CI instead of reaching a client.
+
 ## Adding a New Tool
 
 `src/tool-registry.ts` is the single source of truth for the tool surface. `src/mcp-server.ts`, the `tools` export in `src/index.ts`, `scripts/run-tool.ts`, `scripts/validate-schemas.ts` and `src/token-footprint.test.ts` all derive from it, so adding a tool there wires it up everywhere.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,9 @@ When you need to support clearing an optional field:
 
 Keep declaring `outputSchema` on every tool that returns `structuredContent` — it types the return, documents the shape, and is checked in tests.
 
-It is **not** sent to clients. Output schemas were over half the fixed cost of `tools/list`, and a client only needs one to validate structured output or render a widget from it, so `registerTool` advertises it only for tools carrying widget metadata (`_meta.ui`). Tools return `structuredContent` either way.
+It is **not** sent to clients by default. Output schemas were over half the fixed cost of `tools/list`, and a client only needs one to render a widget or to read a result's shape without calling the tool, so `registerTool` advertises it only for tools carrying widget metadata (`_meta.ui`). Tools return `structuredContent` either way.
+
+A consumer that does read schemas — code generation, where something has to know a result's field names in order to reference them — opts back in with the `output_schemas` feature: `getMcpServer({ ..., features: [{ name: FEATURE_NAMES.OUTPUT_SCHEMAS }] })`.
 
 The consequence for tool authors: the model never sees your output schema, so anything it needs to know about the result belongs in the tool's `description`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,17 @@ Keep declaring `outputSchema` on every tool that returns `structuredContent` —
 
 It is **not** sent to clients. Output schemas were over half the fixed cost of `tools/list`, and a client only needs one to validate structured output or render a widget from it, so `registerTool` advertises it only for tools carrying widget metadata (`_meta.ui`). Tools return `structuredContent` either way.
 
-The consequence for tool authors: the model never sees your output schema, so anything it needs to know about the result belongs in the tool's `description`. Because the SDK's own output validation only runs for advertised schemas, `registerTool` re-checks output against the declared schema when `NODE_ENV === 'test'` — a schema that drifts from what the tool returns fails CI instead of reaching a client.
+The consequence for tool authors: the model never sees your output schema, so anything it needs to know about the result belongs in the tool's `description`.
+
+Because the SDK's own output validation only runs for advertised schemas, `registerTool` re-checks output against the declared schema when `NODE_ENV === 'test'`. That only covers calls made through the MCP callback, and tool suites normally call `tool.execute()` directly — so where a tool's output can diverge from its schema at runtime rather than at compile time (an API returning a value outside a declared enum, say), assert it in the tool's own test:
+
+```typescript
+expect(() =>
+    assertStructuredContentMatchesSchema(findProjects, result.structuredContent),
+).not.toThrow()
+```
+
+Note that with the schema unadvertised, such a divergence no longer fails a client's tool call — it just means the declared shape is out of date.
 
 ## Adding a New Tool
 

--- a/src/mcp-helpers.test.ts
+++ b/src/mcp-helpers.test.ts
@@ -2,7 +2,12 @@ import type { TodoistApi } from '@doist/todoist-sdk'
 import type { ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
-import { registerTool, stripEmailsFromObject, stripEmailsFromText } from './mcp-helpers.js'
+import {
+    FEATURE_NAMES,
+    registerTool,
+    stripEmailsFromObject,
+    stripEmailsFromText,
+} from './mcp-helpers.js'
 import { addTasks } from './tools/add-tasks.js'
 
 type RegisterToolArgs = Parameters<typeof registerTool>[0]
@@ -160,6 +165,26 @@ describe('registerTool config', () => {
 
         expect(result.isError).toBe(true)
         expect(result.content?.[0]?.text).toContain('does not match its outputSchema')
+    })
+
+    it('includes outputSchema for any tool when the output_schemas feature is on', () => {
+        const { mock, server, client } = captureRegisterToolMock()
+        const outputSchema = {}
+
+        registerTool({
+            tool: buildToolFixture({
+                name: 'schema-tool',
+                description: 'Tool with output schema',
+                outputSchema,
+                execute: async () => ({ textContent: 'ok' }),
+            }),
+            server,
+            client,
+            features: [{ name: FEATURE_NAMES.OUTPUT_SCHEMAS }],
+        })
+
+        const config = mock.mock.calls[0]?.[1] as Record<string, unknown>
+        expect(config.outputSchema).toBe(outputSchema)
     })
 
     it('includes outputSchema for a widget-backed tool', () => {

--- a/src/mcp-helpers.test.ts
+++ b/src/mcp-helpers.test.ts
@@ -1,6 +1,7 @@
 import type { TodoistApi } from '@doist/todoist-sdk'
 import type { ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
 import { registerTool, stripEmailsFromObject, stripEmailsFromText } from './mcp-helpers.js'
 import { addTasks } from './tools/add-tasks.js'
 
@@ -16,15 +17,17 @@ function buildToolFixture(overrides: {
     name?: string
     description?: string
     outputSchema?: Record<string, unknown>
+    meta?: Record<string, unknown>
     execute: ToolFixture['execute']
 }): ToolFixture {
-    const { name = 'test-tool', description = 'Test tool', outputSchema, execute } = overrides
+    const { name = 'test-tool', description = 'Test tool', outputSchema, meta, execute } = overrides
 
     return {
         name,
         description,
         parameters: {},
         ...(outputSchema ? { outputSchema } : {}),
+        ...(meta ? { _meta: meta } : {}),
         annotations: {
             readOnlyHint: true,
             destructiveHint: false,
@@ -114,15 +117,61 @@ describe('registerTool config', () => {
         expect(Object.hasOwn(config, 'outputSchema')).toBe(false)
     })
 
-    it('includes outputSchema when the tool declares one', () => {
+    it('omits outputSchema for a tool with no UI contract, even when it declares one', () => {
         const { mock, server, client } = captureRegisterToolMock()
-        const outputSchema = {}
 
         registerTool({
             tool: buildToolFixture({
                 name: 'schema-tool',
                 description: 'Tool with output schema',
+                outputSchema: {},
+                execute: async () => ({ textContent: 'ok' }),
+            }),
+            server,
+            client,
+        })
+
+        const config = mock.mock.calls[0]?.[1] as Record<string, unknown>
+        expect(Object.hasOwn(config, 'outputSchema')).toBe(false)
+    })
+
+    it('still checks output against a declared schema that is no longer advertised', async () => {
+        // Most tools no longer advertise outputSchema, so the SDK's own output
+        // validation does not run for them. This check replaces it in CI, and
+        // is what stops a schema drifting away from what a tool returns.
+        const { mock, server, client } = captureRegisterToolMock()
+
+        registerTool({
+            tool: buildToolFixture({
+                name: 'mismatching-tool',
+                description: 'Tool whose output does not match its schema',
+                outputSchema: { count: z.number() },
+                execute: async () => ({ structuredContent: { count: 'not-a-number' } }),
+            }),
+            server,
+            client,
+        })
+
+        const cb = mock.mock.calls[0]?.[2] as (
+            args: unknown,
+            extra: unknown,
+        ) => Promise<{ isError?: boolean; content?: Array<{ text?: string }> }>
+        const result = await cb({}, {})
+
+        expect(result.isError).toBe(true)
+        expect(result.content?.[0]?.text).toContain('does not match its outputSchema')
+    })
+
+    it('includes outputSchema for a widget-backed tool', () => {
+        const { mock, server, client } = captureRegisterToolMock()
+        const outputSchema = {}
+
+        registerTool({
+            tool: buildToolFixture({
+                name: 'widget-tool',
+                description: 'Tool rendered by a widget',
                 outputSchema,
+                meta: { ui: { resourceUri: 'ui://todoist/task-list@abc123' } },
                 execute: async () => ({ textContent: 'ok' }),
             }),
             server,

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -349,6 +349,7 @@ function registerTool({
 }
 
 export {
+    assertStructuredContentMatchesSchema,
     FEATURE_NAMES,
     type Feature,
     type FeatureName,

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -2,7 +2,7 @@ import type { TodoistApi } from '@doist/todoist-sdk'
 import { registerAppTool } from '@modelcontextprotocol/ext-apps/server'
 import type { McpServer, ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { ContentBlock, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js'
-import type { z } from 'zod'
+import { z } from 'zod'
 import type { AnyTodoistTool, ExecuteResult } from './todoist-tool.js'
 import { formatToolExecutionError } from './tool-execution-error.js'
 import { runWithUsageTrackingContext } from './usage-tracking.js'
@@ -232,6 +232,34 @@ function stripEmailsFromText(text: string): string {
 }
 
 /**
+ * Check a tool's output against its declared schema, in tests only.
+ *
+ * The SDK validates `structuredContent` against a tool's `outputSchema`, but
+ * only for tools that advertise one — and most no longer do, to keep them out
+ * of the `tools/list` payload. Tool definitions still carry their schema, so
+ * this keeps that check where mismatches are worth catching: a schema that has
+ * drifted from what the tool actually returns fails CI rather than reaching a
+ * client. Production pays nothing.
+ *
+ * @throws if the output does not match the tool's declared `outputSchema`.
+ */
+function assertStructuredContentMatchesSchema(
+    tool: AnyTodoistTool,
+    structuredContent: Record<string, unknown> | undefined,
+) {
+    if (process.env.NODE_ENV !== 'test' || !tool.outputSchema || !structuredContent) {
+        return
+    }
+
+    const result = z.object(tool.outputSchema).safeParse(structuredContent)
+    if (!result.success) {
+        throw new Error(
+            `Tool ${tool.name} returned structuredContent that does not match its outputSchema: ${result.error.message}`,
+        )
+    }
+}
+
+/**
  * Register a Todoist tool in an MCP server.
  */
 function registerTool({
@@ -270,6 +298,8 @@ function registerTool({
                     executeWithRetry(() => execute(args, client)),
                 )
 
+            assertStructuredContentMatchesSchema(tool, structuredContent)
+
             // Strip emails from outputs for ChatGPT clients on collaborator-related tools
             if (shouldStripEmails) {
                 if (textContent) {
@@ -287,21 +317,28 @@ function registerTool({
         }
     }
 
+    // Output schemas are more than half the fixed cost of `tools/list`, and a
+    // client only needs one to validate `structuredContent` or to render a
+    // widget from it. Tools still return `structuredContent` either way, so
+    // advertising the schema is only worth its tokens for tools with a UI
+    // contract to honour.
+    const appUiMeta = hasAppUiMeta(tool._meta) ? tool._meta : undefined
+
     const toolConfig = {
         description: tool.description,
         inputSchema: tool.parameters,
-        ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
+        ...(appUiMeta && tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
         annotations: getMcpAnnotations(tool),
         ...(tool._meta ? { _meta: tool._meta } : {}),
     }
 
-    if (hasAppUiMeta(tool._meta)) {
+    if (appUiMeta) {
         registerAppTool(
             server,
             tool.name,
             {
                 ...toolConfig,
-                _meta: tool._meta,
+                _meta: appUiMeta,
             },
             cb,
         )
@@ -316,6 +353,7 @@ export {
     type Feature,
     type FeatureName,
     type Features,
+    hasAppUiMeta,
     registerTool,
     stripEmailsFromObject,
     stripEmailsFromText,

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -17,6 +17,8 @@ import { ToolNames } from './utils/tool-names.js'
  * - `'strip_emails'`: Strips email addresses from collaborator tool outputs
  *   (affects: find-project-collaborators, find-completed-tasks). Useful for
  *   clients like ChatGPT that should not have access to user emails.
+ * - `'output_schemas'`: Advertises every tool's output schema, rather than only
+ *   those needed to render a widget.
  */
 const FEATURE_NAMES = {
     /**
@@ -24,6 +26,20 @@ const FEATURE_NAMES = {
      * Affects: find-project-collaborators, find-completed-tasks
      */
     STRIP_EMAILS: 'strip_emails',
+
+    /**
+     * Advertises `outputSchema` on every tool that declares one.
+     *
+     * Output schemas are more than half the fixed cost of `tools/list`, so by
+     * default only widget-backed tools advertise one — a client needs the schema
+     * to render a widget, but not to read a result. Tools return
+     * `structuredContent` either way.
+     *
+     * Enable this for a consumer that reads the schema itself rather than just
+     * calling tools: code generation, for instance, where something has to know
+     * a result's field names in order to reference them.
+     */
+    OUTPUT_SCHEMAS: 'output_schemas',
 } as const
 
 /**
@@ -317,17 +333,20 @@ function registerTool({
         }
     }
 
-    // Output schemas are more than half the fixed cost of `tools/list`, and a
-    // client only needs one to validate `structuredContent` or to render a
-    // widget from it. Tools still return `structuredContent` either way, so
-    // advertising the schema is only worth its tokens for tools with a UI
-    // contract to honour.
     const appUiMeta = hasAppUiMeta(tool._meta) ? tool._meta : undefined
+
+    // Output schemas are more than half the fixed cost of `tools/list`, and a
+    // client only needs one to render a widget or to read the result shape
+    // without calling the tool. Tools return `structuredContent` either way, so
+    // by default only widget-backed tools pay for one; consumers that read
+    // schemas ask for them with the `output_schemas` feature.
+    const advertiseOutputSchema =
+        Boolean(appUiMeta) || features.some((f) => f.name === FEATURE_NAMES.OUTPUT_SCHEMAS)
 
     const toolConfig = {
         description: tool.description,
         inputSchema: tool.parameters,
-        ...(appUiMeta && tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
+        ...(advertiseOutputSchema && tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
         annotations: getMcpAnnotations(tool),
         ...(tool._meta ? { _meta: tool._meta } : {}),
     }

--- a/src/token-footprint.test.ts
+++ b/src/token-footprint.test.ts
@@ -2,9 +2,11 @@ import { encode } from 'gpt-tokenizer'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 
+import { hasAppUiMeta } from './mcp-helpers.js'
 import { instructions } from './mcp-server.js'
 import type { AnyTodoistTool } from './todoist-tool.js'
 import { registeredTools } from './tool-registry.js'
+import { ToolNames } from './utils/tool-names.js'
 
 // The SDK serializes tool schemas with these options; see `toJsonSchemaCompat`
 // in @modelcontextprotocol/sdk's server/mcp.js. Zod defaults `io` to 'output',
@@ -54,7 +56,9 @@ function buildToolListEntry(tool: AnyTodoistTool) {
             ...tool.annotations,
         },
     }
-    if (tool.outputSchema) {
+    // Gate on the same predicate registration uses, so this cannot drift from
+    // what the server actually advertises.
+    if (hasAppUiMeta(tool._meta) && tool.outputSchema) {
         entry.outputSchema = z.toJSONSchema(z.object(tool.outputSchema), OUTPUT_SCHEMA_OPTIONS)
     }
     if (tool._meta) {
@@ -92,10 +96,16 @@ function measure(): Row[] {
 }
 
 // Budget for the combined fixed token cost (tools/list payload + instructions).
-// Bump deliberately when adding tools or expanding descriptions. Override at
-// runtime with MCP_TOKEN_BUDGET=NNNN to experiment without editing the source.
-const DEFAULT_TOKEN_BUDGET = 41_000
+// Treat this as a ratchet rather than headroom: it should only ever move down,
+// and a rise needs justifying in the PR that causes it. Override at runtime
+// with MCP_TOKEN_BUDGET=NNNN to experiment without editing the source.
+const DEFAULT_TOKEN_BUDGET = 19_000
 const TOKEN_BUDGET = Number(process.env.MCP_TOKEN_BUDGET ?? DEFAULT_TOKEN_BUDGET)
+
+// No single tool should dominate the surface. The cap sits above the current
+// worst (find-tasks-by-date, which keeps its output schema for the widget) with
+// enough room that ordinary edits do not trip it.
+const PER_TOOL_TOKEN_CAP = 1_300
 
 describe('token footprint baseline', () => {
     it('reports per-tool and total token cost', () => {
@@ -129,5 +139,26 @@ describe('token footprint baseline', () => {
         // Soft budget cap: fails only on catastrophic growth, not normal drift.
         // Per-tool numbers above are the informative signal for reviewers.
         expect(combinedFixed).toBeLessThan(TOKEN_BUDGET)
+    })
+
+    it('advertises an output schema only for widget-backed tools', () => {
+        // Output schemas were over half the fixed cost. Only tools with a UI
+        // contract still pay for one; re-enabling them broadly would roughly
+        // double the surface, so fail loudly rather than drift back.
+        const withOutputSchema = measure()
+            .filter((row) => row.outputSchemaTokens > 0)
+            .map((row) => row.name)
+
+        expect(withOutputSchema).toEqual([ToolNames.FIND_TASKS_BY_DATE])
+    })
+
+    it('has no single tool dominating the payload', () => {
+        const worst = measure().sort((a, b) => b.totalTokens - a.totalTokens)[0]
+
+        expect(worst, 'expected at least one registered tool').toBeDefined()
+        expect(
+            worst?.totalTokens,
+            `${worst?.name} is ${worst?.totalTokens} tokens, over the ${PER_TOOL_TOKEN_CAP} per-tool cap`,
+        ).toBeLessThan(PER_TOOL_TOKEN_CAP)
     })
 })

--- a/src/tools/find-projects.test.ts
+++ b/src/tools/find-projects.test.ts
@@ -1,5 +1,6 @@
 import type { ColorKey, TodoistApi } from '@doist/todoist-sdk'
 import { type Mocked, vi } from 'vitest'
+import { assertStructuredContentMatchesSchema } from '../mcp-helpers.js'
 import { ColorOutputSchema } from '../utils/colors.js'
 import { ProjectSchema } from '../utils/output-schemas.js'
 import {
@@ -316,6 +317,13 @@ describe(`${FIND_PROJECTS} tool`, () => {
             // Should return all projects
             expect(result.structuredContent.projects).toHaveLength(2)
             expect(result.structuredContent.totalCount).toBe(2)
+
+            // Clients are no longer sent this tool's outputSchema, so nothing
+            // validates the result for them. Check it here instead: an
+            // unrecognised colour must still produce schema-valid output.
+            expect(() =>
+                assertStructuredContentMatchesSchema(findProjects, result.structuredContent),
+            ).not.toThrow()
         })
 
         it('should return matching projects when the matching project has an unrecognised color', async () => {

--- a/src/tools/tool-annotations.test.ts
+++ b/src/tools/tool-annotations.test.ts
@@ -5,6 +5,7 @@ import { ToolNames } from '../utils/tool-names.js'
 
 type RegisteredToolSpec = {
     annotations?: unknown
+    outputSchema?: unknown
     _meta?: Record<string, unknown>
 }
 
@@ -370,6 +371,17 @@ describe('Tool annotations', () => {
 
     it('should cover all tools', () => {
         expect(Object.values(ToolNames).sort()).toEqual(TOOL_EXPECTATIONS.map((t) => t.name).sort())
+    })
+
+    it('should advertise outputSchema only for widget-backed tools', () => {
+        // Every tool still returns structuredContent and still declares an
+        // outputSchema in its definition; only tools rendering a widget pay to
+        // advertise it, because output schemas dominated the tools/list payload.
+        const advertising = [...registered.entries()]
+            .filter(([, spec]) => Object.hasOwn(spec, 'outputSchema'))
+            .map(([name]) => name)
+
+        expect(advertising).toEqual([ToolNames.FIND_TASKS_BY_DATE])
     })
 
     describe.each(TOOL_EXPECTATIONS)('$name', (toolExpectation) => {


### PR DESCRIPTION
Second of four PRs from #558, and the one that does the work. Builds on #559.

## The problem

Output schemas were **21k of the server's 39,478-token fixed cost** — more than half of what every client pays before doing anything. They are also invisible to the model: a client uses `outputSchema` to validate `structuredContent` or to render a widget from it, and tools return `structuredContent` whether or not the schema is advertised.

So `registerTool` now only sends `outputSchema` for tools that carry widget metadata.

```
                     before     after
instructions          3,108     3,108
tools/list           36,370    15,640
combined fixed       39,478    18,748     -52.5%
```

No tool removed. No tool result changed. Nothing a client receives is different except the absence of a schema it was not using.

## Why this is safe for the ChatGPT app

`find-tasks-by-date` is the only widget-backed tool, and it keeps its output schema. I diffed its full `tools/list` entry against `main`: **4945 bytes on both sides, identical**.

The rest, verified in the SDK rather than assumed:

- `validateToolOutput` early-returns when a tool has no schema (`server/mcp.js:186-188`). Nothing in the SDK, the Protocol layer or `ext-apps` strips `structuredContent` when no schema is declared — `grep structuredContent` over `server/index.js` and `shared/protocol.js` returns nothing.
- `registerAppTool` only normalises `_meta` between the `ui.resourceUri` and `ui/resourceUri` spellings; it never touches `outputSchema`.
- Client-side validation only runs when a validator was cached, and one is only cached when `outputSchema` is present (`client/index.js:496-545`).
- The widget reads `params.structuredContent` directly (`task-list/app.tsx:63-67,138-139`), never the schema.
- OpenAI's [Apps SDK reference](https://developers.openai.com/apps-sdk/reference) treats `outputSchema` as prescriptive guidance, not a requirement, and documents `window.openai.toolOutput` as "Your `structuredContent`" with no schema precondition.

## Gated on `hasAppUiMeta`, not a list of names

The predicate already decides which registration path a tool takes, three lines further down, so the schema decision and the routing decision cannot disagree — and a future widget tool is covered without anyone remembering to update a list.

## Output schemas are still declared, and still checked

Tool definitions keep `outputSchema`. It types the return, documents the shape, and satisfies each tool's `satisfies TodoistTool<...>` clause.

The one thing genuinely lost is the SDK's runtime output validation, which only runs for advertised schemas. `registerTool` re-runs that check when `NODE_ENV === 'test'`, with a test proving it fires, and production pays nothing.

Be clear about how far that reaches, though: it only covers calls made through the MCP callback, and the tool suites call `tool.execute()` directly — 636 call sites across 48 files. So it is defence in depth on one path, not a guarantee across the suite. Where a tool's output can diverge from its schema at runtime rather than at compile time, `assertStructuredContentMatchesSchema` is exported for the tool's own test to call; `find-projects` uses it, and AGENTS.md documents when to reach for it.

I tried enforcing it everywhere with a vitest `setupFile` wrapping each tool's `execute`. It does not work — importing the tool modules in setup instantiates the real module graph before each test file's `vi.mock` applies, so mocked collaborators get bypassed and 104 tests fail. Snapshots were the other candidate, but they hold only text summaries, not `structuredContent`.

Two things keep the residual risk small. TypeScript still enforces the contract at each tool's definition through its `satisfies TodoistTool<..., typeof OutputSchema>` clause, so only runtime-vs-type divergence can escape. And with the schema unadvertised, that divergence no longer fails a client's tool call — it just means the declared shape is stale. In the one documented instance, issue #343, the SDK's validation was what *caused* the user-visible -32602 failure rather than what prevented it, so losing it there is an improvement.

Worth noting `validateToolOutput` only ever validated — it discards `parseResult.data` — so it was never reshaping payloads, and dropping it changes no bytes.

## Consumers that do read output schemas

Automations reads them. Its authoring model is shown each tool's output field names so it can write `{{steps.X.field}}` references for follow-up steps, and the schema carries the instruction "You MUST destructure the response according to this schema"; its test runner also shapes mocked tool results from them. It connects to `ai.todoist.net/mcp` with no version pin, so this would have reached it on deploy.

So this adds an `output_schemas` feature, using the existing `Features` mechanism, letting such a consumer opt back in. Default behaviour is unchanged.

Merge order, because the header is a no-op until the server understands it but Automations must not be left without schemas:

1. [Doist/automations#3832](https://github.com/Doist/automations/pull/3832) — starts sending `x-mcp-output-schemas: true`
2. **This PR** — releases the feature
3. [Doist/todoist-ai-integrations#183](https://github.com/Doist/todoist-ai-integrations/pull/183) — bumps the dependency and maps the header onto the feature

Nothing changes for any client until step 3 deploys.

## Guardrails

`TOKEN_BUDGET` drops 41,000 → 19,000 and is now documented as a ratchet rather than headroom. Two new assertions:

- exactly one tool may advertise an output schema, so re-enabling them broadly fails loudly rather than silently doubling the surface
- no single tool may exceed 1,300 tokens, which the combined budget would not notice

## Verification

- `npm test` — 72 files, 1138 tests
- `npm run type-check`, `npm run format:check`, `npm run lint:schemas` (47 tools) all clean
- `find-tasks-by-date` `tools/list` entry byte-identical to `main`

Still to do before this reaches users: render the widget end-to-end against the deployed ChatGPT app once this is released. Everything checkable from the code side is checked, but that last step needs the real host.

Downstream `todoist-ai-integrations` needs no change — `getMcpServer`'s signature is untouched. This is `feat:` rather than `feat!:` deliberately: the package's TypeScript API is unchanged, so a major bump would propagate downstream for no reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

