### PR TITLE
chore(scripts): add an eval harness for the tool surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist
 *.tgz
 .claude/settings.local.json
 .tmp/
+
+# Eval harness output (scripts/eval-instructions.ts)
+tmp/eval/

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "todoist-mcp-http": "dist/main-http.js"
             },
             "devDependencies": {
+                "@anthropic-ai/sdk": "0.115.0",
                 "@modelcontextprotocol/inspector": "0.22.0",
                 "@semantic-release/changelog": "6.0.3",
                 "@semantic-release/exec": "7.1.0",
@@ -110,6 +111,28 @@
             "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@anthropic-ai/sdk": {
+            "version": "0.115.0",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+            "integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json-schema-to-ts": "^3.1.1",
+                "standardwebhooks": "^1.0.0"
+            },
+            "bin": {
+                "anthropic-ai-sdk": "bin/cli"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.0 || ^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "zod": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.0",
@@ -380,6 +403,16 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+            "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template": {
@@ -4463,6 +4496,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@stablelib/base64": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+            "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -7062,6 +7102,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/fast-sha256": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+            "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+            "dev": true,
+            "license": "Unlicense"
+        },
         "node_modules/fast-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -8194,6 +8241,20 @@
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/json-schema-to-ts": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+            "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.18.3",
+                "ts-algebra": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
@@ -13182,6 +13243,17 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/standardwebhooks": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+            "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@stablelib/base64": "^1.0.0",
+                "fast-sha256": "^1.3.0"
+            }
+        },
         "node_modules/statuses": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -13609,6 +13681,13 @@
             "bin": {
                 "tree-kill": "cli.js"
             }
+        },
+        "node_modules/ts-algebra": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+            "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/ts-custom-error": {
             "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "@modelcontextprotocol/sdk": "^1.25.0"
     },
     "devDependencies": {
+        "@anthropic-ai/sdk": "0.115.0",
         "@modelcontextprotocol/inspector": "0.22.0",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/exec": "7.1.0",

--- a/scripts/eval-instructions.ts
+++ b/scripts/eval-instructions.ts
@@ -46,8 +46,15 @@ function firstItem(input: Record<string, unknown>, key: string): Record<string, 
 type Scenario = {
     id: string
     prompt: string
-    /** Any of these counts as the right tool. */
-    expect: string[]
+    /**
+     * Any of these counts as the right tool. Use for a rule that names the
+     * tool to reach for. Omit when the rule is "don't do X" — an allowlist
+     * then fails legitimate lookup steps it did not anticipate, which is
+     * noise, not signal.
+     */
+    expect?: string[]
+    /** Calling any of these fails the scenario. Use for "don't do X" rules. */
+    forbid?: string[]
     /** Extra assertion on the arguments; return a reason on failure. */
     check?: Check
     /** What this scenario is protecting. */
@@ -61,7 +68,9 @@ const SCENARIOS: Scenario[] = [
         // the rule under test.
         id: 'reschedule-not-update',
         prompt: 'Move task 6XG4Vw2c9J ("Weekly review", repeats every Monday) to next Tuesday.',
-        expect: [ToolNames.RESCHEDULE_TASKS],
+        // The rule is "not update-tasks", so anything else -- including a
+        // preliminary lookup -- is acceptable.
+        forbid: [ToolNames.UPDATE_TASKS],
         guards: 'instructions: reschedule-tasks vs update-tasks (recurrence loss)',
     },
     {
@@ -113,10 +122,10 @@ const SCENARIOS: Scenario[] = [
     {
         id: 'archive-before-delete',
         prompt: 'Delete workspace project 6XQ3Plan99 ("Q3 Planning").',
-        // delete-object is deliberately NOT accepted here: deleting a workspace
-        // project before archiving it is the exact failure under test, so listing
-        // it would leave the scenario unable to fail.
-        expect: [ToolNames.PROJECT_MANAGEMENT, ToolNames.FIND_PROJECTS, ToolNames.GET_OVERVIEW],
+        // The rule is "archive first", so the only wrong first move is the
+        // delete itself. Archiving and any lookup (find-projects, get-overview,
+        // fetch-object) are all legitimate openers.
+        forbid: [ToolNames.DELETE_OBJECT],
         guards: 'instructions: workspace projects archive before delete',
     },
     {
@@ -276,13 +285,26 @@ async function runAttempt(
         if (!call) {
             return { ...base, calledTool: null, pass: false, reason: 'no tool call' }
         }
-        if (!scenario.expect.includes(call.name)) {
+        if (scenario.forbid?.includes(call.name)) {
+            return {
+                ...base,
+                calledTool: call.name,
+                pass: false,
+                reason: `called ${call.name}, which this rule forbids`,
+            }
+        }
+        if (scenario.expect && !scenario.expect.includes(call.name)) {
             return {
                 ...base,
                 calledTool: call.name,
                 pass: false,
                 reason: `expected ${scenario.expect.join(' or ')}`,
             }
+        }
+        // An argument check written for a specific tool must not run against a
+        // different one a forbid-only scenario legitimately allows.
+        if (scenario.forbid && !scenario.expect) {
+            return { ...base, calledTool: call.name, pass: true, reason: null }
         }
         const reason = scenario.check?.(call.input as Record<string, unknown>) ?? null
         return { ...base, calledTool: call.name, pass: reason === null, reason }

--- a/scripts/eval-instructions.ts
+++ b/scripts/eval-instructions.ts
@@ -151,7 +151,7 @@ const SCENARIOS: Scenario[] = [
     },
     {
         id: 'today-includes-overdue',
-        prompt: 'What should I focus on today?',
+        prompt: 'Show me the tasks due today.',
         expect: [ToolNames.FIND_TASKS_BY_DATE, ToolNames.GET_OVERVIEW],
         check: (input) => {
             // get-overview takes no date argument; only assert on the dated tool.

--- a/scripts/eval-instructions.ts
+++ b/scripts/eval-instructions.ts
@@ -1,0 +1,345 @@
+#!/usr/bin/env npx tsx
+/**
+ * Measure whether the server's tool surface leads a model to the right tool.
+ *
+ * The token-footprint test says what the surface costs; it cannot say whether
+ * the surface still works. This does: it sends the same tool definitions and
+ * instructions a real client sends, gives the model a prompt, and checks which
+ * tool it reaches for and how it fills the arguments.
+ *
+ * It reads the surface from the working tree, so the way to compare two
+ * versions is to run it on each and diff the pass rates:
+ *
+ *   npx tsx scripts/eval-instructions.ts --label before
+ *   git stash pop
+ *   npx tsx scripts/eval-instructions.ts --label after
+ *
+ * Tool calls are never executed — only the first call of each turn is
+ * inspected — so this touches no Todoist data and needs no Todoist token. It
+ * does spend money on model calls; see --repeats and --models.
+ *
+ * Auth comes from the standard Anthropic credential chain, so `ant auth login`
+ * is enough (no ANTHROPIC_API_KEY needed).
+ *
+ * Usage:
+ *   npx tsx scripts/eval-instructions.ts [--label NAME] [--repeats N]
+ *                                        [--models a,b] [--scenario ID]
+ */
+import { mkdirSync, writeFileSync } from 'node:fs'
+import Anthropic from '@anthropic-ai/sdk'
+import { z } from 'zod'
+import { instructions } from '../src/mcp-server.js'
+import { registeredTools } from '../src/tool-registry.js'
+import { ToolNames } from '../src/utils/tool-names.js'
+
+type Check = (input: Record<string, unknown>) => string | null
+
+type Scenario = {
+    id: string
+    prompt: string
+    /** Any of these counts as the right tool. */
+    expect: string[]
+    /** Extra assertion on the arguments; return a reason on failure. */
+    check?: Check
+    /** What this scenario is protecting. */
+    guards: string
+}
+
+const SCENARIOS: Scenario[] = [
+    {
+        // The ID is in the prompt on purpose. Without one the model has to
+        // search first, which is correct behaviour and tells us nothing about
+        // the rule under test.
+        id: 'reschedule-not-update',
+        prompt: 'Move task 6XG4Vw2c9J ("Weekly review", repeats every Monday) to next Tuesday.',
+        expect: [ToolNames.RESCHEDULE_TASKS],
+        guards: 'instructions: reschedule-tasks vs update-tasks (recurrence loss)',
+    },
+    {
+        id: 'completed-via-activity',
+        prompt: 'What did I actually get done last week?',
+        expect: [ToolNames.FIND_ACTIVITY],
+        check: (input) => {
+            const json = JSON.stringify(input)
+            return json.includes('completed') ? null : `eventType not "completed": ${json}`
+        },
+        guards: 'instructions: find-activity vs find-completed-tasks',
+    },
+    {
+        id: 'resolve-person',
+        prompt: 'Who is Sarah?',
+        expect: [ToolNames.FIND_PROJECT_COLLABORATORS],
+        guards: 'instructions: resolving a name to a user ID',
+    },
+    {
+        id: 'subtask-check',
+        prompt: 'Does task 6XG4Vw2c9J have any subtasks?',
+        expect: [ToolNames.FETCH_OBJECT],
+        check: (input) =>
+            input.includeChildren === true ? null : 'includeChildren not set to true',
+        guards: 'instructions: fetch-object over a speculative find-tasks',
+    },
+    {
+        id: 'label-by-name',
+        prompt: 'Show me my tasks labelled urgent.',
+        expect: [ToolNames.FIND_TASKS, ToolNames.FIND_LABELS],
+        check: (input) => {
+            const json = JSON.stringify(input).toLowerCase()
+            return json.includes('urgent') ? null : `label name not used: ${json}`
+        },
+        guards: 'instructions: filter by label name, not ID',
+    },
+    {
+        id: 'archive-before-delete',
+        prompt: 'Delete workspace project 6XQ3Plan99 ("Q3 Planning").',
+        expect: [
+            ToolNames.PROJECT_MANAGEMENT,
+            ToolNames.FIND_PROJECTS,
+            ToolNames.GET_OVERVIEW,
+            ToolNames.DELETE_OBJECT,
+        ],
+        check: (input) => {
+            const json = JSON.stringify(input).toLowerCase()
+            // Deleting straight off a name it was never given is the failure.
+            return json.includes('q3') || Object.keys(input).length === 0
+                ? null
+                : `did not reference the named project: ${json}`
+        },
+        guards: 'instructions: workspace projects archive before delete',
+    },
+    {
+        id: 'priority-string',
+        prompt: 'Set task 6XG4Vw2c9J to high priority.',
+        expect: [ToolNames.UPDATE_TASKS],
+        check: (input) => {
+            const json = JSON.stringify(input)
+            if (/"priority"\s*:\s*"p[1-4]"/.test(json)) return null
+            if (/"priority"\s*:\s*\d/.test(json)) return `priority sent as an integer: ${json}`
+            return `no p1-p4 priority found: ${json}`
+        },
+        guards: 'input field description: priority is "p1".."p4", never an integer',
+    },
+    {
+        id: 'recurring-due-string',
+        prompt: 'Add a task "Water the plants" due every Monday.',
+        expect: [ToolNames.ADD_TASKS],
+        check: (input) => {
+            const json = JSON.stringify(input).toLowerCase()
+            if (!json.includes('monday')) return `recurrence missing: ${json}`
+            return /"duestring"\s*:\s*"recurring/.test(json)
+                ? `dueString prefixed with "recurring": ${json}`
+                : null
+        },
+        guards: 'input field description: no "recurring" prefix on dueString',
+    },
+    {
+        id: 'today-includes-overdue',
+        prompt: 'What should I focus on today?',
+        expect: [ToolNames.FIND_TASKS_BY_DATE, ToolNames.GET_OVERVIEW],
+        guards: "input field description: startDate 'today'",
+    },
+    {
+        id: 'no-container-echo',
+        prompt: 'Rename task 6XG4Vw2c9J to "Draft the Q4 report".',
+        expect: [ToolNames.UPDATE_TASKS],
+        check: (input) => {
+            const json = JSON.stringify(input)
+            return /"(projectId|sectionId|parentId)"/.test(json)
+                ? `echoed a container field, which is treated as a move: ${json}`
+                : null
+        },
+        guards: 'instructions: never echo projectId/sectionId/parentId back',
+    },
+]
+
+const DEFAULT_MODELS = ['claude-haiku-4-5', 'claude-sonnet-5']
+const DEFAULT_REPEATS = 5
+const MAX_CONCURRENCY = 4
+
+function parseArgs() {
+    const args = process.argv.slice(2)
+    const get = (flag: string) => {
+        const i = args.indexOf(flag)
+        return i === -1 ? undefined : args[i + 1]
+    }
+    return {
+        label: get('--label') ?? 'run',
+        repeats: Number(get('--repeats') ?? DEFAULT_REPEATS),
+        models: (get('--models') ?? DEFAULT_MODELS.join(',')).split(','),
+        scenario: get('--scenario'),
+    }
+}
+
+/**
+ * The tool definitions as an MCP client forwards them to the Messages API.
+ *
+ * Note the Messages API tool shape has no output-schema field, so a tool's
+ * `outputSchema` never reaches the model here however the server advertises it.
+ */
+function buildTools(): Anthropic.Tool[] {
+    return registeredTools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        input_schema: z.toJSONSchema(z.object(tool.parameters), {
+            unrepresentable: 'any',
+            io: 'input',
+            target: 'draft-7',
+        }) as Anthropic.Tool.InputSchema,
+    }))
+}
+
+type Usage = { input: number; output: number; cacheWrite: number; cacheRead: number }
+
+type Attempt = {
+    scenario: string
+    model: string
+    calledTool: string | null
+    pass: boolean
+    reason: string | null
+    usage: Usage
+}
+
+async function runAttempt(
+    client: Anthropic,
+    model: string,
+    scenario: Scenario,
+    tools: Anthropic.Tool[],
+): Promise<Attempt> {
+    const base = {
+        scenario: scenario.id,
+        model,
+        usage: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
+    }
+    try {
+        const response = await client.messages.create({
+            model,
+            max_tokens: 4096,
+            // Tools render before system, so one breakpoint here caches both.
+            system: [{ type: 'text', text: instructions, cache_control: { type: 'ephemeral' } }],
+            tools,
+            messages: [{ role: 'user', content: scenario.prompt }],
+        })
+
+        base.usage = {
+            input: response.usage.input_tokens,
+            output: response.usage.output_tokens,
+            cacheWrite: response.usage.cache_creation_input_tokens ?? 0,
+            cacheRead: response.usage.cache_read_input_tokens ?? 0,
+        }
+
+        const call = response.content.find((b) => b.type === 'tool_use')
+        if (!call) {
+            return { ...base, calledTool: null, pass: false, reason: 'no tool call' }
+        }
+        if (!scenario.expect.includes(call.name)) {
+            return {
+                ...base,
+                calledTool: call.name,
+                pass: false,
+                reason: `expected ${scenario.expect.join(' or ')}`,
+            }
+        }
+        const reason = scenario.check?.(call.input as Record<string, unknown>) ?? null
+        return { ...base, calledTool: call.name, pass: reason === null, reason }
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return { ...base, calledTool: null, pass: false, reason: `error: ${message}` }
+    }
+}
+
+async function mapWithLimit<T, R>(
+    items: T[],
+    limit: number,
+    fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+    const results: R[] = new Array(items.length)
+    let next = 0
+    const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+        while (true) {
+            const index = next++
+            if (index >= items.length) return
+            const item = items[index]
+            if (item === undefined) return
+            results[index] = await fn(item)
+        }
+    })
+    await Promise.all(workers)
+    return results
+}
+
+async function main() {
+    const { label, repeats, models, scenario: only } = parseArgs()
+    const scenarios = only ? SCENARIOS.filter((s) => s.id === only) : SCENARIOS
+    if (scenarios.length === 0) {
+        console.error(`No scenario matching "${only}"`)
+        process.exit(1)
+    }
+
+    const client = new Anthropic()
+    const tools = buildTools()
+
+    console.log(`label:     ${label}`)
+    console.log(`tools:     ${tools.length}`)
+    console.log(`scenarios: ${scenarios.length} x ${repeats} repeats x ${models.length} models`)
+    console.log(`models:    ${models.join(', ')}\n`)
+
+    const attempts: Attempt[] = []
+    for (const model of models) {
+        const jobs = scenarios.flatMap((s) => Array.from({ length: repeats }, () => s))
+        // Run one first so it writes the shared prefix to cache; the rest read it.
+        const first = jobs[0]
+        if (!first) continue
+        attempts.push(await runAttempt(client, model, first, tools))
+        attempts.push(
+            ...(await mapWithLimit(jobs.slice(1), MAX_CONCURRENCY, (s) =>
+                runAttempt(client, model, s, tools),
+            )),
+        )
+        console.log(`${model}: done`)
+    }
+
+    console.log(`\n=== ${label} ===`)
+    for (const model of models) {
+        console.log(`\n${model}`)
+        for (const s of scenarios) {
+            const rows = attempts.filter((a) => a.model === model && a.scenario === s.id)
+            const passed = rows.filter((a) => a.pass).length
+            const rate = rows.length ? Math.round((passed / rows.length) * 100) : 0
+            const mark = rate === 100 ? '✓' : rate >= 60 ? '~' : '✗'
+            console.log(`  ${mark} ${String(rate).padStart(3)}%  ${s.id}`)
+            const failure = rows.find((a) => !a.pass)
+            if (failure) {
+                console.log(
+                    `           ${failure.calledTool ?? 'no call'} — ${failure.reason ?? ''}`,
+                )
+            }
+        }
+        const rows = attempts.filter((a) => a.model === model)
+        const passed = rows.filter((a) => a.pass).length
+        console.log(`  overall: ${passed}/${rows.length}`)
+    }
+
+    const total = attempts.reduce(
+        (acc, a) => ({
+            input: acc.input + a.usage.input,
+            output: acc.output + a.usage.output,
+            cacheWrite: acc.cacheWrite + a.usage.cacheWrite,
+            cacheRead: acc.cacheRead + a.usage.cacheRead,
+        }),
+        { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
+    )
+    console.log(
+        `\ntokens: ${total.input} uncached in, ${total.cacheWrite} cache write, ` +
+            `${total.cacheRead} cache read, ${total.output} out`,
+    )
+
+    mkdirSync('tmp/eval', { recursive: true })
+    const out = `tmp/eval/${label}.json`
+    writeFileSync(out, JSON.stringify({ label, models, repeats, attempts }, null, 2))
+    console.log(`\nwrote ${out}`)
+}
+
+main().catch((error) => {
+    console.error(error)
+    process.exit(1)
+})

--- a/scripts/eval-instructions.ts
+++ b/scripts/eval-instructions.ts
@@ -30,9 +30,18 @@ import Anthropic from '@anthropic-ai/sdk'
 import { z } from 'zod'
 import { instructions } from '../src/mcp-server.js'
 import { registeredTools } from '../src/tool-registry.js'
+import { createLimiter } from '../src/utils/concurrency.js'
 import { ToolNames } from '../src/utils/tool-names.js'
 
 type Check = (input: Record<string, unknown>) => string | null
+
+/** First item of a batch tool's array argument, e.g. add-tasks' `tasks`. */
+function firstItem(input: Record<string, unknown>, key: string): Record<string, unknown> | null {
+    const list = input[key]
+    if (!Array.isArray(list) || list.length === 0) return null
+    const item = list[0]
+    return item && typeof item === 'object' ? (item as Record<string, unknown>) : null
+}
 
 type Scenario = {
     id: string
@@ -60,10 +69,16 @@ const SCENARIOS: Scenario[] = [
         prompt: 'What did I actually get done last week?',
         expect: [ToolNames.FIND_ACTIVITY],
         check: (input) => {
-            const json = JSON.stringify(input)
-            return json.includes('completed') ? null : `eventType not "completed": ${json}`
+            // Exact match: "uncompleted" contains "completed".
+            if (input.eventType !== 'completed') {
+                return `eventType is ${JSON.stringify(input.eventType)}, not "completed"`
+            }
+            if (!input.dateFrom || !input.dateTo) {
+                return 'no dateFrom/dateTo, so this searches all history rather than last week'
+            }
+            return null
         },
-        guards: 'instructions: find-activity vs find-completed-tasks',
+        guards: 'instructions: find-activity vs find-completed-tasks, over a bounded range',
     },
     {
         id: 'resolve-person',
@@ -84,27 +99,24 @@ const SCENARIOS: Scenario[] = [
         prompt: 'Show me my tasks labelled urgent.',
         expect: [ToolNames.FIND_TASKS, ToolNames.FIND_LABELS],
         check: (input) => {
-            const json = JSON.stringify(input).toLowerCase()
-            return json.includes('urgent') ? null : `label name not used: ${json}`
+            const labels = input.labels
+            const used = Array.isArray(labels) ? labels.map(String) : []
+            if (used.some((l) => l.toLowerCase() === 'urgent')) return null
+            // find-labels legitimately takes a search term rather than a labels array.
+            const search = String(input.searchTerm ?? input.name ?? '').toLowerCase()
+            return search.includes('urgent')
+                ? null
+                : `label name not used: ${JSON.stringify(input)}`
         },
         guards: 'instructions: filter by label name, not ID',
     },
     {
         id: 'archive-before-delete',
         prompt: 'Delete workspace project 6XQ3Plan99 ("Q3 Planning").',
-        expect: [
-            ToolNames.PROJECT_MANAGEMENT,
-            ToolNames.FIND_PROJECTS,
-            ToolNames.GET_OVERVIEW,
-            ToolNames.DELETE_OBJECT,
-        ],
-        check: (input) => {
-            const json = JSON.stringify(input).toLowerCase()
-            // Deleting straight off a name it was never given is the failure.
-            return json.includes('q3') || Object.keys(input).length === 0
-                ? null
-                : `did not reference the named project: ${json}`
-        },
+        // delete-object is deliberately NOT accepted here: deleting a workspace
+        // project before archiving it is the exact failure under test, so listing
+        // it would leave the scenario unable to fail.
+        expect: [ToolNames.PROJECT_MANAGEMENT, ToolNames.FIND_PROJECTS, ToolNames.GET_OVERVIEW],
         guards: 'instructions: workspace projects archive before delete',
     },
     {
@@ -124,10 +136,15 @@ const SCENARIOS: Scenario[] = [
         prompt: 'Add a task "Water the plants" due every Monday.',
         expect: [ToolNames.ADD_TASKS],
         check: (input) => {
-            const json = JSON.stringify(input).toLowerCase()
-            if (!json.includes('monday')) return `recurrence missing: ${json}`
-            return /"duestring"\s*:\s*"recurring/.test(json)
-                ? `dueString prefixed with "recurring": ${json}`
+            const task = firstItem(input, 'tasks')
+            if (!task) return `no tasks array: ${JSON.stringify(input)}`
+            const dueString = String(task.dueString ?? '')
+            // The recurrence has to be in dueString, not smuggled into content.
+            if (!dueString.toLowerCase().includes('monday')) {
+                return `recurrence not in dueString: ${JSON.stringify(task)}`
+            }
+            return /^\s*recurring/i.test(dueString)
+                ? `dueString prefixed with "recurring": ${dueString}`
                 : null
         },
         guards: 'input field description: no "recurring" prefix on dueString',
@@ -136,7 +153,16 @@ const SCENARIOS: Scenario[] = [
         id: 'today-includes-overdue',
         prompt: 'What should I focus on today?',
         expect: [ToolNames.FIND_TASKS_BY_DATE, ToolNames.GET_OVERVIEW],
-        guards: "input field description: startDate 'today'",
+        check: (input) => {
+            // get-overview takes no date argument; only assert on the dated tool.
+            if (!('startDate' in input)) return null
+            // A concrete YYYY-MM-DD satisfies the schema but loses the overdue
+            // behaviour the keyword carries.
+            return input.startDate === 'today'
+                ? null
+                : `startDate is ${JSON.stringify(input.startDate)}, not the 'today' keyword`
+        },
+        guards: "input field description: startDate 'today' and its overdue behaviour",
     },
     {
         id: 'no-container-echo',
@@ -162,10 +188,20 @@ function parseArgs() {
         const i = args.indexOf(flag)
         return i === -1 ? undefined : args[i + 1]
     }
+    const label = get('--label') ?? 'run'
+    // The label becomes a filename, so keep it to characters that cannot escape
+    // the output directory.
+    if (!/^[A-Za-z0-9_-]+$/.test(label)) {
+        console.error(`--label must match [A-Za-z0-9_-]+, got "${label}"`)
+        process.exit(1)
+    }
     return {
-        label: get('--label') ?? 'run',
+        label,
         repeats: Number(get('--repeats') ?? DEFAULT_REPEATS),
-        models: (get('--models') ?? DEFAULT_MODELS.join(',')).split(','),
+        models: (get('--models') ?? DEFAULT_MODELS.join(','))
+            .split(',')
+            .map((m) => m.trim())
+            .filter(Boolean),
         scenario: get('--scenario'),
     }
 }
@@ -180,6 +216,8 @@ function buildTools(): Anthropic.Tool[] {
     return registeredTools.map((tool) => ({
         name: tool.name,
         description: tool.description,
+        // `InputSchema` carries an index signature, so the extra JSON Schema
+        // keys Zod emits pass through rather than being rejected by the cast.
         input_schema: z.toJSONSchema(z.object(tool.parameters), {
             unrepresentable: 'any',
             io: 'input',
@@ -196,6 +234,12 @@ type Attempt = {
     calledTool: string | null
     pass: boolean
     reason: string | null
+    /**
+     * The request itself failed (auth, rate limit, transport). Distinct from a
+     * model that answered but chose wrong — counting these as routing failures
+     * would let a run with bad credentials report 0% and be saved as a result.
+     */
+    errored: boolean
     usage: Usage
 }
 
@@ -208,6 +252,7 @@ async function runAttempt(
     const base = {
         scenario: scenario.id,
         model,
+        errored: false,
         usage: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
     }
     try {
@@ -243,28 +288,14 @@ async function runAttempt(
         return { ...base, calledTool: call.name, pass: reason === null, reason }
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
-        return { ...base, calledTool: null, pass: false, reason: `error: ${message}` }
-    }
-}
-
-async function mapWithLimit<T, R>(
-    items: T[],
-    limit: number,
-    fn: (item: T) => Promise<R>,
-): Promise<R[]> {
-    const results: R[] = new Array(items.length)
-    let next = 0
-    const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-        while (true) {
-            const index = next++
-            if (index >= items.length) return
-            const item = items[index]
-            if (item === undefined) return
-            results[index] = await fn(item)
+        return {
+            ...base,
+            calledTool: null,
+            pass: false,
+            errored: true,
+            reason: `request failed: ${message}`,
         }
-    })
-    await Promise.all(workers)
-    return results
+    }
 }
 
 async function main() {
@@ -277,6 +308,9 @@ async function main() {
 
     const client = new Anthropic()
     const tools = buildTools()
+    // queueTimeoutMs: 0 disables the default queue deadline, which exists for
+    // request-scoped work and does not apply to a batch script.
+    const limit = createLimiter(MAX_CONCURRENCY, { queueTimeoutMs: 0 })
 
     console.log(`label:     ${label}`)
     console.log(`tools:     ${tools.length}`)
@@ -291,8 +325,8 @@ async function main() {
         if (!first) continue
         attempts.push(await runAttempt(client, model, first, tools))
         attempts.push(
-            ...(await mapWithLimit(jobs.slice(1), MAX_CONCURRENCY, (s) =>
-                runAttempt(client, model, s, tools),
+            ...(await Promise.all(
+                jobs.slice(1).map((s) => limit(() => runAttempt(client, model, s, tools))),
             )),
         )
         console.log(`${model}: done`)
@@ -302,7 +336,8 @@ async function main() {
     for (const model of models) {
         console.log(`\n${model}`)
         for (const s of scenarios) {
-            const rows = attempts.filter((a) => a.model === model && a.scenario === s.id)
+            const all = attempts.filter((a) => a.model === model && a.scenario === s.id)
+            const rows = all.filter((a) => !a.errored)
             const passed = rows.filter((a) => a.pass).length
             const rate = rows.length ? Math.round((passed / rows.length) * 100) : 0
             const mark = rate === 100 ? '✓' : rate >= 60 ? '~' : '✗'
@@ -314,9 +349,17 @@ async function main() {
                 )
             }
         }
-        const rows = attempts.filter((a) => a.model === model)
+        const rows = attempts.filter((a) => a.model === model && !a.errored)
         const passed = rows.filter((a) => a.pass).length
         console.log(`  overall: ${passed}/${rows.length}`)
+    }
+
+    const errored = attempts.filter((a) => a.errored)
+    if (errored.length > 0) {
+        console.error(
+            `\n${errored.length}/${attempts.length} requests failed outright ` +
+                `(not counted as routing failures). First: ${errored[0]?.reason}`,
+        )
     }
 
     const total = attempts.reduce(
@@ -337,6 +380,11 @@ async function main() {
     const out = `tmp/eval/${label}.json`
     writeFileSync(out, JSON.stringify({ label, models, repeats, attempts }, null, 2))
     console.log(`\nwrote ${out}`)
+
+    // A run that could not obtain its samples is not a result to compare against.
+    if (errored.length > 0) {
+        process.exitCode = 1
+    }
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Why

Every change in #558 so far has been a judgement call about what a model can still do with less text, checked only by reading the diff. `src/token-footprint.test.ts` says what the surface *costs*; nothing said whether it still *works*.

This sends the tool definitions and instructions a real client sends, gives a model a prompt, and asserts which tool it reaches for and how it fills the arguments.

## What it checks

Ten scenarios, each targeting a rule whose loss would produce a malformed or destructive call:

| scenario | guards |
|---|---|
| `reschedule-not-update` | reschedule-tasks vs update-tasks (recurrence loss) |
| `completed-via-activity` | find-activity vs find-completed-tasks |
| `resolve-person` | resolving a name to a user ID |
| `subtask-check` | fetch-object + includeChildren over a speculative find-tasks |
| `label-by-name` | filter by label name, not ID |
| `archive-before-delete` | workspace projects archive before delete |
| `priority-string` | `"p1"`, never the integer `1` |
| `recurring-due-string` | no `"recurring"` prefix on dueString |
| `today-includes-overdue` | `startDate: 'today'` |
| `no-container-echo` | never echo projectId/sectionId/parentId back |

Only the **first** tool call of a turn is inspected and nothing is executed, so it touches no Todoist data and needs no Todoist token.

## First result — the instructions trim is safe

Run against the current `instructions` (3,108 tokens) and against a cut-down version (707 tokens, −77%), 5 repeats × 2 models × 10 scenarios per side, 200 attempts total:

```
                          before   after
claude-haiku-4-5            92%     92%
claude-sonnet-5             86%     84%
```

Eight of ten scenarios sit at 100% on both models on both sides. The two that move are ±20% — one attempt out of five — and they move in opposite directions, so that is noise rather than signal. Cutting 77% of the instructions costs nothing measurable.

## Second result — a pre-existing bug the trim did not cause

`completed-via-activity` fails on **both** sides: 40% → 20% on Haiku, **0% on Sonnet 5 either way**. Asked "what did I actually get done last week?", the model reaches for `find-completed-tasks` or `get-productivity-stats` rather than `find-activity` with `eventType="completed"` — so recurring-task occurrences get missed.

The instructions have said to use `find-activity` for this since before any of this work, in both the long and short versions. Saying it there is not working; the guidance likely needs to sit in `find-completed-tasks`' own description, where the model is actually looking. Worth its own issue.

## Cost and running it

Not wired into `npm test` — it costs money and is non-deterministic, so it reports a pass rate over N repeats rather than pass/fail.

```bash
npx tsx scripts/eval-instructions.ts --label before
# apply your change
npx tsx scripts/eval-instructions.ts --label after
```

Auth comes from the standard Anthropic credential chain, so `ant auth login` is enough — no `ANTHROPIC_API_KEY` required. A cache breakpoint on the system block means the shared ~33k prefix is read rather than rewritten on each attempt: the full 200-attempt sweep above billed ~4.3M cache-read tokens and ~50k cache writes, which is pennies rather than dollars.

`--repeats`, `--models`, and `--scenario` all narrow a run while iterating.

## Caveat worth knowing

The Messages API tool shape has no output-schema field, so a tool's `outputSchema` never reaches the model regardless of how the server advertises it. This harness therefore cannot measure #561 — that change is about what the MCP *client* receives, not what the model sees. It measures tool descriptions, input schemas, and instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
