### PR TITLE
docs: document the eval harness, and add npm run eval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,25 @@ npm run eval -- --label after
 
 Each run prints a pass rate per scenario per model and writes `tmp/eval/<label>.json`; diff the two. Narrow while iterating with `--scenario <id>`, `--repeats N`, `--models a,b`.
 
-Only the first tool call of a turn is inspected and nothing is executed, so it touches no Todoist data and needs no `TODOIST_API_KEY`. It does call real models, so it is deliberately **not** part of `npm test` — it costs money and is non-deterministic. Auth comes from the standard Anthropic credential chain, so `ant auth login` is enough; no `ANTHROPIC_API_KEY` required.
+Only the first tool call of a turn is inspected and nothing is executed, so it touches no Todoist data and needs no `TODOIST_API_KEY`. It does call real models, so it is deliberately **not** part of `npm test` — it costs money and is non-deterministic.
+
+### Authenticating
+
+The harness uses the Anthropic SDK's standard credential chain, so either of these works:
+
+- **`ANTHROPIC_API_KEY`** in your environment — a key from the [Anthropic Console](https://platform.claude.com). Create it in a workspace you can put a spend limit on.
+- **An OAuth profile**, which avoids managing a key at all. `ant` is Anthropic's CLI ([anthropics/anthropic-cli](https://github.com/anthropics/anthropic-cli)); `ant auth login` opens a browser and stores a profile under `~/.config/anthropic/` that the SDK picks up automatically.
+
+    ```bash
+    brew install anthropics/tap/ant                        # macOS
+    go install github.com/anthropics/anthropic-cli/cmd/ant@latest   # or from source (Go 1.22+)
+    # Linux/WSL: grab the tarball for your arch from the releases page above
+    ant auth login
+    ```
+
+    On a machine with no browser, `ant auth login --no-browser` prints a URL and takes the code back in the terminal.
+
+Note the two do not compose: a set `ANTHROPIC_API_KEY` **silently overrides** any OAuth profile, so requests go to whichever org that key belongs to. `ant auth status` shows which credential source won.
 
 Two things this has already caught that review and reading did not:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,3 +99,31 @@ npx tsx scripts/run-tool.ts get-overview '{}'
 ```
 
 Requires `TODOIST_API_KEY` in `.env` (and optionally `TODOIST_BASE_URL`).
+
+## Measuring a change to the tool surface
+
+`src/token-footprint.test.ts` tells you what the surface costs. It cannot tell you whether a model can still use it. When you change **tool descriptions, input field descriptions, or the `instructions` block**, measure the behaviour rather than reasoning about it:
+
+```bash
+npm run eval -- --label before
+# apply your change
+npm run eval -- --label after
+```
+
+Each run prints a pass rate per scenario per model and writes `tmp/eval/<label>.json`; diff the two. Narrow while iterating with `--scenario <id>`, `--repeats N`, `--models a,b`.
+
+Only the first tool call of a turn is inspected and nothing is executed, so it touches no Todoist data and needs no `TODOIST_API_KEY`. It does call real models, so it is deliberately **not** part of `npm test` — it costs money and is non-deterministic. Auth comes from the standard Anthropic credential chain, so `ant auth login` is enough; no `ANTHROPIC_API_KEY` required.
+
+Two things this has already caught that review and reading did not:
+
+- Trimming the instructions block turned out to **fix** a destructive bug, not merely be safe: asked to delete a workspace project, Haiku 4.5 called `delete-object` directly under the longer instructions and archived first under the shorter ones (0/10 vs 10/10).
+- A wording change made while addressing review feedback appeared to regress a scenario by 30 points. It was an artefact of the scenario prompt, not the change — but nothing else would have surfaced the question.
+
+### Adding a scenario
+
+Scenarios live at the top of `scripts/eval-instructions.ts`. Two shapes, and picking the wrong one produces noise that looks like signal:
+
+- **`expect`** — an allowlist, for a rule that names the tool to reach for.
+- **`forbid`** — for a rule of the form "don't do X". Prefer this whenever the rule is prohibitive. An allowlist then has to enumerate every legitimate opener, and it will miss some: a model looking a project up with `fetch-object` before deleting it is behaving correctly, and an allowlist that forgot `fetch-object` scores it as a failure.
+
+Make sure a scenario can actually fail. One early scenario listed the destructive tool in its own `expect` and checked an argument condition that was true by construction — it scored 100% while measuring nothing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,11 @@ Each run prints a pass rate per scenario per model and writes `tmp/eval/<label>.
 
 Only the first tool call of a turn is inspected and nothing is executed, so it touches no Todoist data and needs no `TODOIST_API_KEY`. It does call real models, so it is deliberately **not** part of `npm test` — it costs money and is non-deterministic.
 
+Two things this has already caught that review and reading did not:
+
+- Trimming the instructions block turned out to **fix** a destructive bug, not merely be safe: asked to delete a workspace project, Haiku 4.5 called `delete-object` directly under the longer instructions and archived first under the shorter ones (0/10 vs 10/10).
+- A wording change made while addressing review feedback appeared to regress a scenario by 30 points. It was an artefact of the scenario prompt, not the change — but nothing else would have surfaced the question.
+
 ### Authenticating
 
 The harness uses the Anthropic SDK's standard credential chain, so either of these works:
@@ -131,11 +136,6 @@ The harness uses the Anthropic SDK's standard credential chain, so either of the
     On a machine with no browser, `ant auth login --no-browser` prints a URL and takes the code back in the terminal.
 
 Note the two do not compose: a set `ANTHROPIC_API_KEY` **silently overrides** any OAuth profile, so requests go to whichever org that key belongs to. `ant auth status` shows which credential source won.
-
-Two things this has already caught that review and reading did not:
-
-- Trimming the instructions block turned out to **fix** a destructive bug, not merely be safe: asked to delete a workspace project, Haiku 4.5 called `delete-object` directly under the longer instructions and archived first under the shorter ones (0/10 vs 10/10).
-- A wording change made while addressing review feedback appeared to regress a scenario by 30 points. It was an artefact of the scenario prompt, not the change — but nothing else would have surfaced the question.
 
 ### Adding a scenario
 

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -20,7 +20,7 @@ TypeScript · ESM-only · Node >=24 · npm >=11 · `zod` v4 for schemas · MCP S
 ```
 /
 ├─ src/                   # All source. See tree below.
-├─ scripts/               # run-tool.ts (direct tool invocation), validate-schemas.ts, test-executable.cjs, bump-plugin-version.mjs (semantic-release plugin manifest sync)
+├─ scripts/               # run-tool.ts (direct tool invocation), eval-instructions.ts (does a model still pick the right tool — see AGENTS.md), validate-schemas.ts, test-executable.cjs, bump-plugin-version.mjs (semantic-release plugin manifest sync)
 ├─ .claude-plugin/        # Claude Code plugin manifest (plugin.json) + marketplace entry (marketplace.json)
 ├─ .mcp.json              # MCP server declaration consumed by the Claude Code plugin (HTTP transport → ai.todoist.net/mcp)
 ├─ dist/                  # Build output (Vite). Never edit.
@@ -166,6 +166,7 @@ New tool? Full checklist in `AGENTS.md`. Short version: copy `add-tasks.ts`; add
 - **Dev:** `npm run dev` (stdio + inspector, auto-rebuild) or `npm run dev:http`.
 - **Type-check:** `npm run type-check` (runs `tsc --noEmit`).
 - **Format/lint:** `npm run format:check` / `npm run format:fix` — uses **oxlint + oxfmt**, not eslint/prettier.
+- **Behaviour eval:** `npm run eval` — sends the real tool surface to a model and checks which tool it picks (`scripts/eval-instructions.ts`). Not part of `npm test`: it calls paid models and reports a pass rate rather than pass/fail. Run it either side of a change to tool descriptions or `instructions`; see AGENTS.md.
 - **Schema lint:** `npm run lint:schemas` — validates every tool's Zod schema via `scripts/validate-schemas.ts`. Runs automatically on `src/tools/*.ts` via lint-staged.
 - **Release:** `semantic-release` on merge to `main` (GitHub Actions). Commits must follow Conventional Commits — enforced by `check-semantic-pull-request.yml`. The pipeline runs `scripts/bump-plugin-version.mjs` (via `@semantic-release/exec`) to keep `.claude-plugin/plugin.json` in lockstep with `package.json`; both files are committed back together.
 - **Husky:** `prepare` script installs Husky. Actual commit-time behavior is in `.husky/pre-commit`, which runs `lint-staged` then `npm run type-check`.
@@ -186,7 +187,7 @@ Needs `TODOIST_API_KEY` in `.env`.
 - Priority: **`"p1"`–`"p4"` strings only**, never integers
 - Clearing optional fields: special strings `"remove"` / `"unassign"`, never `null` (Gemini compatibility — see `CLAUDE.md`)
 - Tool parameters: Zod **raw shape** (`{ foo: z.string() }`), not `z.object({...})`
-- Every new tool: register in `src/mcp-server.ts`, add to `src/utils/tool-names.ts`, `src/index.ts`, and `scripts/run-tool.ts`; add annotation entry to `src/tools/tool-annotations.test.ts`; write a `<tool>.test.ts` — full checklist in `AGENTS.md`
+- Every new tool: add the name to `src/utils/tool-names.ts` and the tool to `src/tool-registry.ts` (everything else derives from it) and `src/index.ts`; add an annotation entry to `src/tools/tool-annotations.test.ts`; write a `<tool>.test.ts` — full checklist in `AGENTS.md`, and `src/tool-registry.test.ts` fails the build if those views disagree
 
 ## Start here if new
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "setup": "cp .env.example .env && npm install && npm run build",
         "tool": "tsx scripts/run-tool.ts",
         "tool:list": "tsx scripts/run-tool.ts --list",
+        "eval": "tsx scripts/eval-instructions.ts",
         "test:executable": "npm run build && node scripts/test-executable.cjs",
         "type-check": "npx tsc --noEmit",
         "format:check": "oxlint src scripts && oxfmt --check",

--- a/scripts/eval-instructions.ts
+++ b/scripts/eval-instructions.ts
@@ -18,8 +18,12 @@
  * inspected — so this touches no Todoist data and needs no Todoist token. It
  * does spend money on model calls; see --repeats and --models.
  *
- * Auth comes from the standard Anthropic credential chain, so `ant auth login`
- * is enough (no ANTHROPIC_API_KEY needed).
+ * Auth uses the Anthropic SDK's standard credential chain: either
+ * ANTHROPIC_API_KEY (a key from the Anthropic Console at platform.claude.com),
+ * or an OAuth profile created with `ant auth login` — `ant` being Anthropic's
+ * CLI, from https://github.com/anthropics/anthropic-cli. A set
+ * ANTHROPIC_API_KEY silently overrides a profile; `ant auth status` shows which
+ * one is in use. See AGENTS.md for install steps.
  *
  * Usage:
  *   npx tsx scripts/eval-instructions.ts [--label NAME] [--repeats N]


### PR DESCRIPTION
The harness landed in #562 with its usage documented only in the file's own header comment. Nothing in `AGENTS.md`, `CODEBASE.md` or `package.json` mentioned it, so you had to already know it existed to find it — which defeats the point of building it.

## What this adds

**`npm run eval`**, alongside the existing `npm run tool`:

```bash
npm run eval -- --label before
# apply your change
npm run eval -- --label after
```

**AGENTS.md** gains a section covering when to reach for it — any change to tool descriptions, input field descriptions, or the `instructions` block — plus what it does and does not touch (no Todoist data, no `TODOIST_API_KEY`, deliberately outside `npm test` because it calls paid models), and how to add a scenario.

Two things from the section worth calling out, because both were learned the hard way in #562's review:

- **Use `forbid`, not `expect`, for "don't do X" rules.** An allowlist has to enumerate every legitimate opener and will miss some — a model looking a project up with `fetch-object` before deleting it is behaving correctly, and an allowlist that forgot it scores a failure.
- **Make sure a scenario can fail.** One early scenario listed the destructive tool in its own `expect` and checked a condition that was true by construction. It reported 100% while measuring nothing.

The section also records the two findings that justify the harness existing: the instructions trim turning out to *fix* a destructive bug rather than merely being safe (0/10 vs 10/10 on Haiku), and a wording change that appeared to regress a scenario by 30 points and turned out to be a prompt artefact.

**CODEBASE.md** lists it under `scripts/` and in the tooling section next to `lint:schemas`.

## Drive-by fix

`CODEBASE.md`'s new-tool checklist still said to register in `src/mcp-server.ts` and `scripts/run-tool.ts`. #559 replaced that with the single registry, so it contradicted `AGENTS.md`. Updated to match, including the note that `src/tool-registry.test.ts` fails the build if those views disagree.

## Verification

`npm run eval -- --scenario resolve-person --repeats 1` runs green through the new script entry. `npm test` (1133), `type-check` and `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)