### PR TITLE
fix: preserve nullable fields in MCP tool output

### DIFF
--- a/src/mcp-helpers.test.ts
+++ b/src/mcp-helpers.test.ts
@@ -2,7 +2,9 @@ import type { TodoistApi } from '@doist/todoist-sdk'
 import type { ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { registerTool, stripEmailsFromObject, stripEmailsFromText } from './mcp-helpers.js'
+import { getWorkspaceInsights } from './tools/get-workspace-insights.js'
 import { addTasks } from './tools/add-tasks.js'
+import { workspaceResolver } from './utils/workspace-resolver.js'
 
 type RegisterToolArgs = Parameters<typeof registerTool>[0]
 type ToolFixture = RegisterToolArgs['tool']
@@ -365,5 +367,42 @@ describe('registerTool content ordering', () => {
         expect(content).toHaveLength(1)
         const only = content[0] as { type: string; text: string }
         expect(only.text).toBe('No tasks.')
+    })
+
+    it('preserves a null workspace folder ID in both output representations', async () => {
+        vi.stubEnv('NODE_ENV', 'production')
+        vi.stubEnv('USE_STRUCTURED_CONTENT', '')
+        vi.resetModules()
+
+        const { registerTool: registerToolFresh } = await import('./mcp-helpers.js')
+        const { mock, server } = captureRegisterToolMock()
+        const getWorkspaceInsightsMock = vi.fn().mockResolvedValue({ projectInsights: [] })
+        const client = { getWorkspaceInsights: getWorkspaceInsightsMock } as unknown as TodoistApi
+        const resolveWorkspace = vi.spyOn(workspaceResolver, 'resolveWorkspace').mockResolvedValue({
+            workspaceId: 'ws-123',
+            workspaceName: 'Engineering',
+        })
+
+        registerToolFresh({ tool: getWorkspaceInsights, server, client })
+
+        const callback = mock.mock.calls[0]?.[2] as (
+            args: Record<string, unknown>,
+            context: unknown,
+        ) => Promise<{
+            content?: ContentBlock[]
+            structuredContent?: Record<string, unknown>
+        }>
+
+        const output = await callback({ workspaceIdOrName: 'Engineering' }, {})
+
+        expect(getWorkspaceInsightsMock).toHaveBeenCalledWith('ws-123', {
+            projectIds: undefined,
+        })
+        expect(output.structuredContent).toMatchObject({ folderId: null })
+
+        const legacyJson = output.content?.[0] as { type: string; text: string }
+        expect(legacyJson.type).toBe('text')
+        expect(JSON.parse(legacyJson.text)).toMatchObject({ folderId: null })
+        resolveWorkspace.mockRestore()
     })
 })

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -7,7 +7,6 @@ import type { AnyTodoistTool, ExecuteResult } from './todoist-tool.js'
 import { formatToolExecutionError } from './tool-execution-error.js'
 import { runWithUsageTrackingContext } from './usage-tracking.js'
 import { executeWithRetry } from './utils/retry.js'
-import { removeNullFields } from './utils/sanitize-data.js'
 import { ToolNames } from './utils/tool-names.js'
 
 /**
@@ -84,9 +83,6 @@ function getToolOutput<StructuredContent extends Record<string, unknown>>({
     structuredContent: StructuredContent | undefined
     contentItems?: ContentBlock[]
 }) {
-    // Remove null fields from structured content before returning
-    const sanitizedContent = removeNullFields(structuredContent)
-
     // Always include structuredContent when available since all tools have outputSchema
     const result: Record<string, unknown> = {}
 
@@ -104,7 +100,7 @@ function getToolOutput<StructuredContent extends Record<string, unknown>>({
     if (!USE_STRUCTURED_CONTENT && structuredContent) {
         contentArray.push({
             type: 'text' as const,
-            text: JSON.stringify(sanitizedContent),
+            text: JSON.stringify(structuredContent),
         })
     }
 
@@ -116,7 +112,7 @@ function getToolOutput<StructuredContent extends Record<string, unknown>>({
         result.content = contentArray
     }
 
-    if (structuredContent) result.structuredContent = sanitizedContent
+    if (structuredContent) result.structuredContent = structuredContent
 
     return result
 }


### PR DESCRIPTION
# Pull Request

Closes https://github.com/Doist/Issues/issues/20842

## Short description

Preserves nullable structured-output fields through MCP serialization so unscoped workspace insights responses retain `folderId: null`. Added a regression test covering both structured content and legacy JSON output.

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

- [x] Added tests for bugs / new features
- [ ] Updated docs (README, etc.)
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.